### PR TITLE
Fix copy cmd when the host has only one CPU core

### DIFF
--- a/cmd-copy.go
+++ b/cmd-copy.go
@@ -110,7 +110,7 @@ func runCopyCmd(ctx *cli.Context) {
 		}
 	}(sourceURLs, targetURL)
 
-	var cpQueue = make(chan bool, runtime.NumCPU()-1)
+	var cpQueue = make(chan bool, intMax(runtime.NumCPU()-1, 1))
 	var wg sync.WaitGroup
 
 	for cpURLs := range prepareCopyURLs(sourceURLs, targetURL) {


### PR DESCRIPTION
Some VPS providers offer a single core VM, that's how I detected the error :)