### PR TITLE
yield CPU to progress bar builder

### DIFF
--- a/cmd-cp.go
+++ b/cmd-cp.go
@@ -130,6 +130,9 @@ func doCopyCmd(sourceURLs []string, targetURL string, bar barSend) <-chan error 
 				errCh <- cpURLs.Error
 				continue
 			}
+
+			runtime.Gosched() // Yield more CPU time to progress-bar builder.
+
 			cpQueue <- true // Wait for existing pool to drain.
 			wg.Add(1)
 			if !globalQuietFlag {


### PR DESCRIPTION
Can't seem to notice much difference visibly.. but it is a good change. As scheduler improves, this will help.

How ever, GOMAXPROCS certainly helps with the performance with or without runtime.Gosched()
$ GOMAXPROCS=16 mc cp /usr... /tmp/