### PR TITLE
Session cmd fixes

### DIFF
--- a/cmd-session.go
+++ b/cmd-session.go
@@ -244,5 +244,7 @@ func runSessionCmd(ctx *cli.Context) {
 				Error:   iodine.ToError(err),
 			})
 		}
+	default:
+		cli.ShowCommandHelpAndExit(ctx, "session", 1) // last argument is exit code
 	}
 }


### PR DESCRIPTION
`mc session foo` doesn't print an error, fix that