### PR TITLE
Protect progress bar printing by the mutex

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -86,7 +86,9 @@ var (
 	}()
 
 	// Bar print progress bar
-	Bar = themesDB[currThemeName].Info.Print
+	Bar = func(data ...interface{}) {
+		print(themesDB[currThemeName].Bar, data...)
+	}
 
 	// Print prints a message
 	Print = func(data ...interface{}) {


### PR DESCRIPTION
Use print() instead of color.Print function to protect progress bar by a mutex