### PR TITLE
Prettify the progress bar output

### DIFF
--- a/pb.go
+++ b/pb.go
@@ -152,7 +152,7 @@ func newCpBar() barSend {
 		bar.NotPrint = true
 		bar.ShowSpeed = true
 		bar.Callback = func(s string) {
-			console.Bar(s + "\r")
+			console.Bar("\r" + s)
 		}
 		cursorCh := cursorAnimate()
 		// Feels like wget


### PR DESCRIPTION
*) "➩" character  is deleted because progress bar dependency doesn't know how to count it (len("➩") = 3 though it takes only one column in the terminal)
*) One more change in bar.Callback to avoid overlapping between progress bar output and error messages