### PR TITLE
Avoid possible corrupted data when saving with quick

### DIFF
--- a/pkg/quick/quick.go
+++ b/pkg/quick/quick.go
@@ -115,7 +115,9 @@ func (d config) Save(filename string) (err error) {
 		return iodine.New(err, nil)
 	}
 
-	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	tmpfile := filename + ".tmp"
+
+	file, err := os.OpenFile(tmpfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return iodine.New(err, nil)
 	}
@@ -125,6 +127,10 @@ func (d config) Save(filename string) (err error) {
 		jsonData = []byte(strings.Replace(string(jsonData), "\n", "\r\n", -1))
 	}
 	_, err = file.Write(jsonData)
+	if err != nil {
+		return iodine.New(err, nil)
+	}
+	err = os.Rename(tmpfile, filename)
 	if err != nil {
 		return iodine.New(err, nil)
 	}


### PR DESCRIPTION
The user could kill mc when saving data to a quick config data (such as large session file) which could lead to a possible corrupted data. os.Rename is atomic, so I save data in a tmp file before renaming the latter to the original file name