### PR TITLE
Fix test cases where cp and mirror would fail

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -44,6 +44,10 @@ var server *httptest.Server
 var app *cli.App
 
 func (s *CmdTestSuite) SetUpSuite(c *C) {
+	objectAPI := objectAPIHandler(objectAPIHandler{lock: &sync.Mutex{}, bucket: "bucket", object: make(map[string][]byte)})
+	server = httptest.NewServer(objectAPI)
+	console.IsTesting = true
+
 	// do not set it elsewhere, leads to data races since this is a global flag
 	globalQuietFlag = true
 
@@ -86,9 +90,6 @@ func (s *CmdTestSuite) SetUpSuite(c *C) {
 	c.Assert(perr, Not(IsNil))
 
 	app = registerApp()
-	objectAPI := objectAPIHandler(objectAPIHandler{lock: &sync.Mutex{}, bucket: "bucket", object: make(map[string][]byte)})
-	server = httptest.NewServer(objectAPI)
-	console.IsTesting = true
 }
 
 func (s *CmdTestSuite) TearDownSuite(c *C) {

--- a/cp_mirror_test.go
+++ b/cp_mirror_test.go
@@ -55,25 +55,18 @@ func (s *CmdTestSuite) TestCopyURLType(c *C) {
 
 // TODO fix both copy and mirror
 func (s *CmdTestSuite) TestCopyContext(c *C) {
-	err := app.Run([]string{os.Args[0], "cp", server.URL + "/bucket...", server.URL + "/bucket"})
+	err := app.Run([]string{os.Args[0], "cp", server.URL + "/invalid...", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
-	c.Assert(console.IsExited, Equals, true)
-
-	err = app.Run([]string{os.Args[0], "cp", server.URL + "/invalid...", server.URL + "/bucket"})
-	c.Assert(err, IsNil)
-	c.Assert(console.IsExited, Equals, true)
+	c.Assert(console.IsError, Equals, true)
 	// reset back
-	console.IsExited = false
+	console.IsError = false
 }
 
 func (s *CmdTestSuite) TestMirrorContext(c *C) {
-	err := app.Run([]string{os.Args[0], "mirror", server.URL + "/bucket...", server.URL + "/bucket"})
+	err := app.Run([]string{os.Args[0], "mirror", server.URL + "/invalid...", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
-	c.Assert(console.IsExited, Equals, true)
+	c.Assert(console.IsError, Equals, true)
 
-	err = app.Run([]string{os.Args[0], "mirror", server.URL + "/invalid...", server.URL + "/bucket"})
-	c.Assert(err, IsNil)
-	c.Assert(console.IsExited, Equals, true)
 	// reset back
-	console.IsExited = false
+	console.IsError = false
 }

--- a/ls_test.go
+++ b/ls_test.go
@@ -67,7 +67,7 @@ func (s *CmdTestSuite) TestLSCmd(c *C) {
 func (s *CmdTestSuite) TestLSContext(c *C) {
 	err := app.Run([]string{os.Args[0], "ls", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
-	c.Assert(console.IsExited, Equals, false)
+	c.Assert(console.IsError, Equals, false)
 
 	err = app.Run([]string{os.Args[0], "ls", server.URL + "/invalid"})
 	c.Assert(err, IsNil)

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -35,8 +35,11 @@ var NoDebugPrint = true
 // IsTesting this flag indicates if IsExited should be set or not, false by default
 var IsTesting = false
 
-// IsExited sets this boolean value if Fatal is called instead of os.Exit(1)
+// IsExited sets this boolean value if Fatal is called when IsTestng is enabled
 var IsExited = false
+
+// IsError sets this boolean value if Error is called when IsTesting is enabled
+var IsError = false
 
 // Theme holds console color scheme
 type Theme struct {
@@ -139,7 +142,7 @@ var (
 	Error = func(data ...interface{}) {
 		if IsTesting {
 			defer func() {
-				IsExited = true
+				IsError = true
 			}()
 		}
 		print(themesDB[currThemeName].Error, data...)
@@ -150,7 +153,7 @@ var (
 	Errorf = func(f string, data ...interface{}) {
 		if IsTesting {
 			defer func() {
-				IsExited = true
+				IsError = true
 			}()
 		}
 		printf(themesDB[currThemeName].Error, f, data...)
@@ -161,7 +164,7 @@ var (
 	Errorln = func(data ...interface{}) {
 		if IsTesting {
 			defer func() {
-				IsExited = true
+				IsError = true
 			}()
 		}
 		println(themesDB[currThemeName].Error, data...)


### PR DESCRIPTION
- globalQuietFlag and globalJSONFlag should be checked in conjunction
  for terminal features to be disabled. Otherwise ioctl fails for
  calculating the term size.

- Avoid unnecessary scoping for probe, it has two different error sets now