### PR TITLE
Probe error should be marshalled as json.RawMessage to avoid re-encod…

### DIFF
--- a/error.go
+++ b/error.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"reflect"
 
@@ -36,7 +37,8 @@ func fatalIf(err *probe.Error) {
 			EmbeddedError: err.ToError(),
 		}
 		if globalDebugFlag {
-			errorMessage.ProbeError = err.JSON()
+			rawProbe := json.RawMessage(err.JSON())
+			errorMessage.ProbeError = &rawProbe
 		}
 		console.Println(errorMessage)
 		os.Exit(1)
@@ -59,7 +61,8 @@ func errorIf(err *probe.Error) {
 			EmbeddedError: err.ToError(),
 		}
 		if globalDebugFlag {
-			errorMessage.ProbeError = err.JSON()
+			rawProbe := json.RawMessage(err.JSON())
+			errorMessage.ProbeError = &rawProbe
 		}
 		console.Println(errorMessage)
 		return

--- a/print-structs.go
+++ b/print-structs.go
@@ -29,10 +29,10 @@ import (
 
 // ErrorMessage json container for error messages
 type ErrorMessage struct {
-	Type          string `json:"type"`
-	TypedError    string `json:"typed-error"`
-	EmbeddedError error  `json:"embedded-error"`
-	ProbeError    string `json:"probe-error"`
+	Type          string           `json:"type"`
+	TypedError    string           `json:"typed-error"`
+	EmbeddedError error            `json:"embedded-error"`
+	ProbeError    *json.RawMessage `json:"probe-error,omitempty"`
 }
 
 func (e ErrorMessage) String() string {


### PR DESCRIPTION
…ing of an already marshalled string