### PR TITLE
ls modifications - always print files first and folders at the end for multiple arguments

### DIFF
--- a/cat_test.go
+++ b/cat_test.go
@@ -27,7 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestCatCmd(c *C) {
+func (s *TestSuite) TestCat(c *C) {
 	/// filesystem
 	root, err := ioutil.TempDir(os.TempDir(), "cmd-")
 	c.Assert(err, IsNil)
@@ -55,7 +55,7 @@ func (s *CmdTestSuite) TestCatCmd(c *C) {
 	c.Assert(catURL(objectPath), Not(IsNil))
 }
 
-func (s *CmdTestSuite) TestCatContext(c *C) {
+func (s *TestSuite) TestCatContext(c *C) {
 	err := app.Run([]string{os.Args[0], "cat", server.URL + "/bucket/object1"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsExited, Equals, false)

--- a/common_methods_test.go
+++ b/common_methods_test.go
@@ -26,7 +26,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestCommonMethods(c *C) {
+func (s *TestSuite) TestCommonMethods(c *C) {
 	/// filesystem
 	root, err := ioutil.TempDir(os.TempDir(), "cmd-")
 	c.Assert(err, IsNil)

--- a/config_test.go
+++ b/config_test.go
@@ -23,7 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestConfigAliasContext(c *C) {
+func (s *TestSuite) TestConfigAliasContext(c *C) {
 	console.IsExited = false
 
 	err := app.Run([]string{os.Args[0], "config", "alias", "add", "test", "htt://test.io"})
@@ -41,7 +41,7 @@ func (s *CmdTestSuite) TestConfigAliasContext(c *C) {
 	console.IsExited = false
 }
 
-func (s *CmdTestSuite) TestConfigHostContext(c *C) {
+func (s *TestSuite) TestConfigHostContext(c *C) {
 	console.IsExited = false
 
 	err := app.Run([]string{os.Args[0], "config", "host", "add", "*test.io", "invalid", "invalid"})

--- a/cp_mirror_test.go
+++ b/cp_mirror_test.go
@@ -23,7 +23,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestCopyURLType(c *C) {
+func (s *TestSuite) TestCopyURLType(c *C) {
 	sourceURLs := []string{server.URL + "/bucket/object1"}
 	targetURL := server.URL + "/bucket/test"
 	c.Assert(guessCopyURLType(sourceURLs, targetURL), Equals, copyURLsTypeA)
@@ -53,8 +53,7 @@ func (s *CmdTestSuite) TestCopyURLType(c *C) {
 	c.Assert(guessCopyURLType(sourceURLs, targetURL), Equals, copyURLsTypeInvalid)
 }
 
-// TODO fix both copy and mirror
-func (s *CmdTestSuite) TestCopyContext(c *C) {
+func (s *TestSuite) TestCopyContext(c *C) {
 	err := app.Run([]string{os.Args[0], "cp", server.URL + "/invalid...", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsError, Equals, true)
@@ -63,7 +62,7 @@ func (s *CmdTestSuite) TestCopyContext(c *C) {
 	console.IsError = false
 }
 
-func (s *CmdTestSuite) TestMirrorContext(c *C) {
+func (s *TestSuite) TestMirrorContext(c *C) {
 	err := app.Run([]string{os.Args[0], "mirror", server.URL + "/invalid...", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsError, Equals, true)

--- a/diff-main.go
+++ b/diff-main.go
@@ -78,15 +78,15 @@ func mainDiff(ctx *cli.Context) {
 	secondURL := getAliasURL(secondArg, config.Aliases)
 
 	newFirstURL := stripRecursiveURL(firstURL)
-	for diff := range doDiffCmd(newFirstURL, secondURL, isURLRecursive(firstURL)) {
+	for diff := range doDiff(newFirstURL, secondURL, isURLRecursive(firstURL)) {
 		fatalIf(diff.Error.Trace(newFirstURL, secondURL), "Failed to diff ‘"+firstURL+"’ and ‘"+secondURL+"’.")
 
 		Prints("%s\n", diff)
 	}
 }
 
-// doDiffCmd - Execute the diff command
-func doDiffCmd(firstURL, secondURL string, recursive bool) <-chan DiffMessage {
+// doDiff - Execute the diff command
+func doDiff(firstURL, secondURL string, recursive bool) <-chan DiffMessage {
 	ch := make(chan DiffMessage, 10000)
 	go doDiffInRoutine(firstURL, secondURL, recursive, ch)
 	return ch

--- a/diff_test.go
+++ b/diff_test.go
@@ -28,7 +28,7 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestDiffObjects(c *C) {
+func (s *TestSuite) TestDiffObjects(c *C) {
 	/// filesystem
 	root1, err := ioutil.TempDir(os.TempDir(), "cmd-")
 	c.Assert(err, IsNil)
@@ -50,12 +50,12 @@ func (s *CmdTestSuite) TestDiffObjects(c *C) {
 	perr = putTarget(objectPath2, int64(dataLen), bytes.NewReader([]byte(data)))
 	c.Assert(perr, IsNil)
 
-	for diff := range doDiffCmd(objectPath1, objectPath2, false) {
+	for diff := range doDiff(objectPath1, objectPath2, false) {
 		c.Assert(diff.Error, IsNil)
 	}
 }
 
-func (s *CmdTestSuite) TestDiffDirs(c *C) {
+func (s *TestSuite) TestDiffDirs(c *C) {
 	/// filesystem
 	root1, err := ioutil.TempDir(os.TempDir(), "cmd-")
 	c.Assert(err, IsNil)
@@ -82,12 +82,12 @@ func (s *CmdTestSuite) TestDiffDirs(c *C) {
 		c.Assert(perr, IsNil)
 	}
 
-	for diff := range doDiffCmd(root1, root2, false) {
+	for diff := range doDiff(root1, root2, false) {
 		c.Assert(diff.Error, IsNil)
 	}
 }
 
-func (s *CmdTestSuite) TestDiffContext(c *C) {
+func (s *TestSuite) TestDiffContext(c *C) {
 	err := app.Run([]string{os.Args[0], "diff", server.URL + "/bucket", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsExited, Equals, false)

--- a/error.go
+++ b/error.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
@@ -58,7 +57,7 @@ func fatalIf(err *probe.Error, msg string) {
 			console.Fatalln(probe.NewError(err))
 		}
 		console.Println(string(json))
-		os.Exit(1)
+		console.Fatal("")
 	}
 	if !globalDebugFlag {
 		console.Fatalln(fmt.Sprintf("%s %s", msg, err.ToGoError()))
@@ -90,6 +89,7 @@ func errorIf(err *probe.Error, msg string) {
 			console.Fatalln(probe.NewError(err))
 		}
 		console.Println(string(json))
+		console.Error("")
 		return
 	}
 	if !globalDebugFlag {

--- a/ls-main.go
+++ b/ls-main.go
@@ -106,8 +106,14 @@ func mainList(ctx *cli.Context) {
 	})
 
 	config := mustGetMcConfig()
+	showFolderNames := len(args) > 1
+
 	for _, arg := range args {
 		targetURL := getAliasURL(arg, config.Aliases)
+
+		if !globalJSONFlag && showFolderNames {
+			console.Println(arg + ":")
+		}
 
 		// if recursive strip off the "..."
 		err := doListCmd(stripRecursiveURL(targetURL), isURLRecursive(targetURL))

--- a/ls.go
+++ b/ls.go
@@ -103,8 +103,15 @@ func parseContent(c *client.Content) ContentMessage {
 }
 
 // doList - list all entities inside a folder.
-func doList(clnt client.Client, recursive bool) *probe.Error {
+func doList(clnt client.Client, recursive, lsPrefixMode bool) *probe.Error {
 	var err *probe.Error
+	parentContent, err := clnt.Stat()
+	if err != nil {
+		return err.Trace(clnt.URL().String())
+	}
+	if parentContent.Type.IsDir() && lsPrefixMode {
+		console.Println(console.Colorize("Dir", fmt.Sprintf("%s", clnt.URL().String())))
+	}
 	for contentCh := range clnt.List(recursive) {
 		if contentCh.Err != nil {
 			switch contentCh.Err.ToGoError().(type) {

--- a/ls.go
+++ b/ls.go
@@ -104,13 +104,12 @@ func parseContent(c *client.Content) ContentMessage {
 
 // doList - list all entities inside a folder.
 func doList(clnt client.Client, recursive, lsPrefixMode bool) *probe.Error {
-	var err *probe.Error
 	parentContent, err := clnt.Stat()
 	if err != nil {
 		return err.Trace(clnt.URL().String())
 	}
 	if parentContent.Type.IsDir() && lsPrefixMode {
-		console.Println(console.Colorize("Dir", fmt.Sprintf("%s", clnt.URL().String())))
+		console.Println(console.Colorize("Dir", fmt.Sprintf("%s:", clnt.URL().String())))
 	}
 	for contentCh := range clnt.List(recursive) {
 		if contentCh.Err != nil {
@@ -131,6 +130,9 @@ func doList(clnt client.Client, recursive, lsPrefixMode bool) *probe.Error {
 			}
 			err = contentCh.Err.Trace()
 			break
+		}
+		if parentContent.Type.IsRegular() && lsPrefixMode {
+			console.Println("")
 		}
 		Prints("%s\n", parseContent(contentCh.Content))
 	}

--- a/ls.go
+++ b/ls.go
@@ -103,14 +103,8 @@ func parseContent(c *client.Content) ContentMessage {
 }
 
 // doList - list all entities inside a folder.
-func doList(clnt client.Client, recursive, lsPrefixMode bool) *probe.Error {
-	parentContent, err := clnt.Stat()
-	if err != nil {
-		return err.Trace(clnt.URL().String())
-	}
-	if parentContent.Type.IsDir() && lsPrefixMode {
-		console.Println(console.Colorize("Dir", fmt.Sprintf("%s:", clnt.URL().String())))
-	}
+func doList(clnt client.Client, recursive bool) *probe.Error {
+	var err *probe.Error
 	for contentCh := range clnt.List(recursive) {
 		if contentCh.Err != nil {
 			switch contentCh.Err.ToGoError().(type) {
@@ -130,9 +124,6 @@ func doList(clnt client.Client, recursive, lsPrefixMode bool) *probe.Error {
 			}
 			err = contentCh.Err.Trace()
 			break
-		}
-		if parentContent.Type.IsRegular() && lsPrefixMode {
-			console.Println("")
 		}
 		Prints("%s\n", parseContent(contentCh.Content))
 	}

--- a/ls_test.go
+++ b/ls_test.go
@@ -23,12 +23,13 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/minio/mc/pkg/client"
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestLSCmd(c *C) {
+func (s *TestSuite) TestLS(c *C) {
 	/// filesystem
 	root, err := ioutil.TempDir(os.TempDir(), "cmd-")
 	c.Assert(err, IsNil)
@@ -44,10 +45,14 @@ func (s *CmdTestSuite) TestLSCmd(c *C) {
 		c.Assert(perr, IsNil)
 	}
 
-	perr = doListCmd(root, false)
+	var clnt client.Client
+	clnt, perr = target2Client(root)
 	c.Assert(perr, IsNil)
 
-	perr = doListCmd(root, true)
+	perr = doList(clnt, false, false)
+	c.Assert(perr, IsNil)
+
+	perr = doList(clnt, true, false)
 	c.Assert(perr, IsNil)
 
 	for i := 0; i < 10; i++ {
@@ -57,14 +62,18 @@ func (s *CmdTestSuite) TestLSCmd(c *C) {
 		perr := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
 		c.Assert(perr, IsNil)
 	}
-	perr = doListCmd(server.URL+"/bucket", false)
+
+	clnt, perr = target2Client(server.URL + "/bucket")
 	c.Assert(perr, IsNil)
 
-	perr = doListCmd(server.URL+"/bucket", true)
+	perr = doList(clnt, false, false)
+	c.Assert(perr, IsNil)
+
+	perr = doList(clnt, true, false)
 	c.Assert(perr, IsNil)
 }
 
-func (s *CmdTestSuite) TestLSContext(c *C) {
+func (s *TestSuite) TestLSContext(c *C) {
 	err := app.Run([]string{os.Args[0], "ls", server.URL + "/bucket"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsError, Equals, false)

--- a/ls_test.go
+++ b/ls_test.go
@@ -49,10 +49,10 @@ func (s *TestSuite) TestLS(c *C) {
 	clnt, perr = target2Client(root)
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, false, false)
+	perr = doList(clnt, false)
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, true, false)
+	perr = doList(clnt, true)
 	c.Assert(perr, IsNil)
 
 	for i := 0; i < 10; i++ {
@@ -66,10 +66,10 @@ func (s *TestSuite) TestLS(c *C) {
 	clnt, perr = target2Client(server.URL + "/bucket")
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, false, false)
+	perr = doList(clnt, false)
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, true, false)
+	perr = doList(clnt, true)
 	c.Assert(perr, IsNil)
 }
 

--- a/mb-main.go
+++ b/mb-main.go
@@ -91,7 +91,7 @@ func mainMakeBucket(ctx *cli.Context) {
 	for _, arg := range ctx.Args() {
 		targetURL := getAliasURL(arg, config.Aliases)
 
-		fatalIf(doMakeBucketCmd(targetURL).Trace(targetURL), "Unable to make bucket ‘"+targetURL+"’.")
+		fatalIf(doMakeBucket(targetURL).Trace(targetURL), "Unable to make bucket ‘"+targetURL+"’.")
 		Prints("%s\n", MakeBucketMessage{
 			Status: "success",
 			Bucket: targetURL,
@@ -99,8 +99,8 @@ func mainMakeBucket(ctx *cli.Context) {
 	}
 }
 
-// doMakeBucketCmd -
-func doMakeBucketCmd(targetURL string) *probe.Error {
+// doMakeBucket -
+func doMakeBucket(targetURL string) *probe.Error {
 	clnt, err := target2Client(targetURL)
 	if err != nil {
 		return err.Trace(targetURL)

--- a/mb_access_test.go
+++ b/mb_access_test.go
@@ -23,8 +23,8 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestMbAndAccessCmd(c *C) {
-	perr := doMakeBucketCmd(server.URL + "/bucket")
+func (s *TestSuite) TestMbAndAccess(c *C) {
+	perr := doMakeBucket(server.URL + "/bucket")
 	c.Assert(perr, IsNil)
 
 	perr = doSetAccess(server.URL+"/bucket", "public-read-write")
@@ -34,7 +34,7 @@ func (s *CmdTestSuite) TestMbAndAccessCmd(c *C) {
 	c.Assert(perr, Not(IsNil))
 }
 
-func (s *CmdTestSuite) TestMBContext(c *C) {
+func (s *TestSuite) TestMBContext(c *C) {
 	console.IsExited = false
 
 	err := app.Run([]string{os.Args[0], "mb", server.URL + "/bucket"})
@@ -52,7 +52,7 @@ func (s *CmdTestSuite) TestMBContext(c *C) {
 	console.IsExited = false
 }
 
-func (s *CmdTestSuite) TestAccessContext(c *C) {
+func (s *TestSuite) TestAccessContext(c *C) {
 	console.IsExited = false
 
 	err := app.Run([]string{os.Args[0], "access", "set", "private", server.URL + "/bucket"})

--- a/session_test.go
+++ b/session_test.go
@@ -24,14 +24,14 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *CmdTestSuite) TestValidSessionID(c *C) {
+func (s *TestSuite) TestValidSessionID(c *C) {
 	validSid := regexp.MustCompile("^[a-zA-Z]+$")
 	sid := newSID(8)
 	c.Assert(len(sid), Equals, 8)
 	c.Assert(validSid.MatchString(sid), Equals, true)
 }
 
-func (s *CmdTestSuite) TestSession(c *C) {
+func (s *TestSuite) TestSession(c *C) {
 	perr := createSessionDir()
 	c.Assert(perr, IsNil)
 	c.Assert(isSessionDirExists(), Equals, true)
@@ -54,7 +54,7 @@ func (s *CmdTestSuite) TestSession(c *C) {
 	c.Assert(perr, IsNil)
 }
 
-func (s *CmdTestSuite) TestSessionContext(c *C) {
+func (s *TestSuite) TestSessionContext(c *C) {
 	err := app.Run([]string{os.Args[0], "session", "list"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsExited, Equals, false)


### PR DESCRIPTION
This change is for compatibility reason with GNU ls, for being able to differentiate different outputs. This is also quite useful in case of doing 'ls' on different buckets. 