### PR TITLE
Change the 'ls' output behavior

### DIFF
--- a/ls-main.go
+++ b/ls-main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
@@ -109,50 +108,13 @@ func mainList(ctx *cli.Context) {
 	targetURLs, err := args2URLs(args)
 	fatalIf(err.Trace(args...), "One or more unknown URL types passed.")
 
-	if len(targetURLs) == 1 {
-		// if recursive strip off the "..."
-		var clnt client.Client
-		clnt, err = target2Client(stripRecursiveURL(targetURLs[0]))
-		fatalIf(err.Trace(targetURLs[0]), "Unable to initialize target ‘"+targetURLs[0]+"’.")
-
-		err = doList(clnt, isURLRecursive(targetURLs[0]))
-		fatalIf(err.Trace(targetURLs[0]), "Unable to list target ‘"+targetURLs[0]+"’.")
-		return
-	}
-	var newTargetFiles []client.Client
-	newTargetFolders := make(map[client.Client]bool)
 	for _, targetURL := range targetURLs {
 		// if recursive strip off the "..."
 		var clnt client.Client
 		clnt, err = target2Client(stripRecursiveURL(targetURL))
 		fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
 
-		var content *client.Content
-		content, err = clnt.Stat()
-		fatalIf(err.Trace(targetURL), "Unable to stat target ‘"+targetURL+"’.")
-
-		// Following code is an attempt to always order files
-		// first than directories when there are more than one
-		// command line arguments for 'ls'
-		if content.Type.IsDir() {
-			newTargetFolders[clnt] = isURLRecursive(targetURL)
-		}
-		if content.Type.IsRegular() {
-			newTargetFiles = append(newTargetFiles, clnt)
-		}
+		err = doList(clnt, isURLRecursive(targetURL), len(targetURLs) > 1)
+		fatalIf(err.Trace(clnt.URL().String()), "Unable to list target ‘"+clnt.URL().String()+"’.")
 	}
-	for _, targetClnt := range newTargetFiles {
-		err = doList(targetClnt, false)
-		fatalIf(err.Trace(targetClnt.URL().String()), "Unable to list target ‘"+targetClnt.URL().String()+"’.")
-	}
-	for targetClnt, recursive := range newTargetFolders {
-		if len(newTargetFiles) > 0 {
-			console.Println(console.Colorize("Dir", fmt.Sprintf("\n%s:", targetClnt.URL().String())))
-		} else {
-			console.Println(console.Colorize("Dir", fmt.Sprintf("%s:", targetClnt.URL().String())))
-		}
-		err = doList(targetClnt, recursive)
-		fatalIf(err.Trace(targetClnt.URL().String()), "Unable to list target ‘"+targetClnt.URL().String()+"’.")
-	}
-	return
 }

--- a/ls_test.go
+++ b/ls_test.go
@@ -49,10 +49,10 @@ func (s *TestSuite) TestLS(c *C) {
 	clnt, perr = target2Client(root)
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, false)
+	perr = doList(clnt, false, false)
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, true)
+	perr = doList(clnt, true, false)
 	c.Assert(perr, IsNil)
 
 	for i := 0; i < 10; i++ {
@@ -66,10 +66,10 @@ func (s *TestSuite) TestLS(c *C) {
 	clnt, perr = target2Client(server.URL + "/bucket")
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, false)
+	perr = doList(clnt, false, false)
 	c.Assert(perr, IsNil)
 
-	perr = doList(clnt, true)
+	perr = doList(clnt, true, false)
 	c.Assert(perr, IsNil)
 }
 


### PR DESCRIPTION
- do not add odd prefixes like GNU 'ls' since it clobbers users view
- add minio specific to differentiate the users view of 'ls' output

Rather than having output in the following manner

```
$ mc ls pkg vendor
pkg:
client console

vendor:
github.com
```

It should be

```
$ mc ls pkg vendor
pkg/client
pkg/console
vendor/github.com
```

This way the differentiation and the API is not disturbed.

This patch fixes this issue.