### PR TITLE
Fix printing fatal message prefix when json flag is enabled

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -83,72 +83,66 @@ var (
 		return
 	}
 
-	// Fatal print a error message and exit
-	Fatal = func(data ...interface{}) {
-		consolePrint("Fatal", Theme["Fatal"], data...)
+	// fatalQuitRoutine called after fatal message printing
+	// by the user specific version
+	fatalQuitRoutine = func() {
 		if !IsTesting {
 			os.Exit(1)
 		}
 		defer func() {
 			IsExited = true
 		}()
+	}
+
+	// Fatal print a error message and exit
+	Fatal = func(data ...interface{}) {
+		consolePrint("Fatal", Theme["Fatal"], data...)
+		fatalQuitRoutine()
 		return
 	}
 
 	// Fatalf print a error message with a format specified and exit
 	Fatalf = func(format string, data ...interface{}) {
 		consolePrintf("Fatal", Theme["Fatal"], format, data...)
-		if !IsTesting {
-			os.Exit(1)
-		}
-		defer func() {
-			IsExited = true
-		}()
+		fatalQuitRoutine()
 		return
 	}
 
 	// Fatalln print a error message with a new line and exit
 	Fatalln = func(data ...interface{}) {
 		consolePrintln("Fatal", Theme["Fatal"], data...)
-		if !IsTesting {
-			os.Exit(1)
-		}
-		defer func() {
-			IsExited = true
-		}()
+		fatalQuitRoutine()
 		return
 	}
 
-	// Error prints a error message
-	Error = func(data ...interface{}) {
+	// errorQuitRoutine called after error message printing
+	// by the user specific version
+	errorQuitRoutine = func() {
 		if IsTesting {
 			defer func() {
 				IsError = true
 			}()
 		}
+	}
+
+	// Error prints a error message
+	Error = func(data ...interface{}) {
 		consolePrint("Error", Theme["Error"], data...)
+		errorQuitRoutine()
 		return
 	}
 
 	// Errorf print a error message with a format specified
 	Errorf = func(format string, data ...interface{}) {
-		if IsTesting {
-			defer func() {
-				IsError = true
-			}()
-		}
 		consolePrintf("Error", Theme["Error"], format, data...)
+		errorQuitRoutine()
 		return
 	}
 
 	// Errorln prints a error message with a new line
 	Errorln = func(data ...interface{}) {
-		if IsTesting {
-			defer func() {
-				IsError = true
-			}()
-		}
 		consolePrintln("Error", Theme["Error"], data...)
+		errorQuitRoutine()
 		return
 	}
 


### PR DESCRIPTION
This patch fixes primarily the bug of printing fatal and error prefix when json flag is enabled.. (``` mc --json ls /tmp/non_existant_directory /usr/```)
but also it could help later to :
*) control mc exit codes since we can control fatal/error post hook callbacks
*) move out the logic of IsTesting/IsError/IsExit outside of the console package