### PR TITLE
Move to new changes in minio-go and minio-go-legacy to use relative URL's in http request

### DIFF
--- a/vendor.json
+++ b/vendor.json
@@ -41,15 +41,15 @@
 			"canonical": "github.com/minio/minio-go",
 			"comment": "",
 			"local": "vendor/github.com/minio/minio-go",
-			"revision": "7b215c6781d0bf99bdf2182afd47bc4633cf67aa",
-			"revisionTime": "2015-10-01T10:26:02-07:00"
+			"revision": "4900c9c8695340456ca8409c2354d503f839a608",
+			"revisionTime": "2015-10-02T12:03:54-07:00"
 		},
 		{
 			"canonical": "github.com/minio/minio-go-legacy",
 			"comment": "",
 			"local": "vendor/github.com/minio/minio-go-legacy",
-			"revision": "e1b64561ec279d041bfeef719458030fb8fd7c52",
-			"revisionTime": "2015-09-24T11:38:07-07:00"
+			"revision": "e05bb3d90ec884a5f3952134906dfa22fb48edd9",
+			"revisionTime": "2015-10-02T12:38:52-07:00"
 		},
 		{
 			"canonical": "github.com/minio/minio/pkg/probe",

--- a/vendor/github.com/minio/minio-go-legacy/README.md
+++ b/vendor/github.com/minio/minio-go-legacy/README.md
@@ -1,6 +1,6 @@
 # Minio Go Library for Amazon S3 Legacy v2 Signature Compatible Cloud Storage [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-## Install [![Build Status](https://travis-ci.org/minio/minio-go-legacy.svg)](https://travis-ci.org/minio/minio-go-legacy)
+## Install
 
 ```sh
 $ go get github.com/minio/minio-go-legacy
@@ -63,3 +63,5 @@ func main() {
 ## Contribute
 
 [Contributors Guide](./CONTRIBUTING.md)
+
+[![Build Status](https://travis-ci.org/minio/minio-go-legacy.svg)](https://travis-ci.org/minio/minio-go-legacy) [![Build status](https://ci.appveyor.com/api/projects/status/1ep7n2resn6fk1w6?svg=true)](https://ci.appveyor.com/project/harshavardhana/minio-go)

--- a/vendor/github.com/minio/minio-go-legacy/api-core.go
+++ b/vendor/github.com/minio/minio-go-legacy/api-core.go
@@ -264,27 +264,14 @@ func (a apiCore) getBucketLocation(bucket string) (string, error) {
 func (a apiCore) listObjectsRequest(bucket, marker, prefix, delimiter string, maxkeys int) (*request, error) {
 	// resourceQuery - get resources properly escaped and lined up before using them in http request
 	resourceQuery := func() (*string, error) {
-		var err error
 		switch {
 		case marker != "":
-			marker, err = urlEncodeName(marker)
-			if err != nil {
-				return nil, err
-			}
 			marker = fmt.Sprintf("&marker=%s", marker)
 			fallthrough
 		case prefix != "":
-			prefix, err = urlEncodeName(prefix)
-			if err != nil {
-				return nil, err
-			}
 			prefix = fmt.Sprintf("&prefix=%s", prefix)
 			fallthrough
 		case delimiter != "":
-			delimiter, err = urlEncodeName(delimiter)
-			if err != nil {
-				return nil, err
-			}
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)
 		}
 		query := fmt.Sprintf("?max-keys=%d", maxkeys) + marker + prefix + delimiter
@@ -473,14 +460,10 @@ func (a apiCore) putObjectUnAuthenticatedRequest(bucket, object, contentType str
 	if strings.TrimSpace(contentType) == "" {
 		contentType = "application/octet-stream"
 	}
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "PUT",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newUnauthenticatedRequest(op, a.config, body)
 	if err != nil {
@@ -527,14 +510,10 @@ func (a apiCore) putObjectRequest(bucket, object, contentType string, md5SumByte
 	if strings.TrimSpace(contentType) == "" {
 		contentType = "application/octet-stream"
 	}
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "PUT",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newRequest(op, a.config, body)
 	if err != nil {
@@ -578,14 +557,10 @@ func (a apiCore) putObject(bucket, object, contentType string, md5SumBytes []byt
 }
 
 func (a apiCore) presignedGetObjectRequest(bucket, object string, expires, offset, length int64) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "GET",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newPresignedRequest(op, a.config, expires)
 	if err != nil {
@@ -615,14 +590,10 @@ func (a apiCore) presignedGetObject(bucket, object string, expires, offset, leng
 
 // getObjectRequest wrapper creates a new getObject request
 func (a apiCore) getObjectRequest(bucket, object string, offset, length int64) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "GET",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newRequest(op, a.config, nil)
 	if err != nil {
@@ -700,14 +671,10 @@ func (a apiCore) getObject(bucket, object string, offset, length int64) (io.Read
 
 // deleteObjectRequest wrapper creates a new deleteObject request
 func (a apiCore) deleteObjectRequest(bucket, object string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "DELETE",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -766,14 +733,10 @@ func (a apiCore) deleteObject(bucket, object string) error {
 
 // headObjectRequest wrapper creates a new headObject request
 func (a apiCore) headObjectRequest(bucket, object string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "HEAD",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	return newRequest(op, a.config, nil)
 }

--- a/vendor/github.com/minio/minio-go-legacy/api-multipart-core.go
+++ b/vendor/github.com/minio/minio-go-legacy/api-multipart-core.go
@@ -32,34 +32,17 @@ import (
 func (a apiCore) listMultipartUploadsRequest(bucket, keymarker, uploadIDMarker, prefix, delimiter string, maxuploads int) (*request, error) {
 	// resourceQuery - get resources properly escaped and lined up before using them in http request
 	resourceQuery := func() (string, error) {
-		var err error
 		switch {
 		case keymarker != "":
-			keymarker, err = urlEncodeName(keymarker)
-			if err != nil {
-				return "", err
-			}
 			keymarker = fmt.Sprintf("&key-marker=%s", keymarker)
 			fallthrough
 		case uploadIDMarker != "":
-			uploadIDMarker, err = urlEncodeName(uploadIDMarker)
-			if err != nil {
-				return "", err
-			}
 			uploadIDMarker = fmt.Sprintf("&upload-id-marker=%s", uploadIDMarker)
 			fallthrough
 		case prefix != "":
-			prefix, err = urlEncodeName(prefix)
-			if err != nil {
-				return "", err
-			}
 			prefix = fmt.Sprintf("&prefix=%s", prefix)
 			fallthrough
 		case delimiter != "":
-			delimiter, err = urlEncodeName(delimiter)
-			if err != nil {
-				return "", err
-			}
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)
 		}
 		query := fmt.Sprintf("?uploads&max-uploads=%d", maxuploads) + keymarker + uploadIDMarker + prefix + delimiter
@@ -117,14 +100,10 @@ func (a apiCore) listMultipartUploads(bucket, keymarker, uploadIDMarker, prefix,
 
 // initiateMultipartRequest wrapper creates a new initiateMultiPart request
 func (a apiCore) initiateMultipartRequest(bucket, object string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "POST",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?uploads",
+		HTTPPath:   separator + bucket + separator + object + "?uploads",
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -155,16 +134,13 @@ func (a apiCore) initiateMultipartUpload(bucket, object string) (initiateMultipa
 
 // completeMultipartUploadRequest wrapper creates a new CompleteMultipartUpload request
 func (a apiCore) completeMultipartUploadRequest(bucket, object, uploadID string, complete completeMultipartUpload) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "POST",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?uploadId=" + uploadID,
+		HTTPPath:   separator + bucket + separator + object + "?uploadId=" + uploadID,
 	}
 	var completeMultipartUploadBytes []byte
+	var err error
 	switch {
 	case a.config.AcceptType == "application/xml":
 		completeMultipartUploadBytes, err = xml.Marshal(complete)
@@ -211,14 +187,10 @@ func (a apiCore) completeMultipartUpload(bucket, object, uploadID string, c comp
 
 // abortMultipartUploadRequest wrapper creates a new AbortMultipartUpload request
 func (a apiCore) abortMultipartUploadRequest(bucket, object, uploadID string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "DELETE",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?uploadId=" + uploadID,
+		HTTPPath:   separator + bucket + separator + object + "?uploadId=" + uploadID,
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -269,10 +241,6 @@ func (a apiCore) abortMultipartUpload(bucket, object, uploadID string) error {
 
 // listObjectPartsRequest wrapper creates a new ListObjectParts request
 func (a apiCore) listObjectPartsRequest(bucket, object, uploadID string, partNumberMarker, maxParts int) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	// resourceQuery - get resources properly escaped and lined up before using them in http request
 	resourceQuery := func() string {
 		var partNumberMarkerStr string
@@ -285,7 +253,7 @@ func (a apiCore) listObjectPartsRequest(bucket, object, uploadID string, partNum
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "GET",
-		HTTPPath:   separator + bucket + separator + encodedObject + resourceQuery(),
+		HTTPPath:   separator + bucket + separator + object + resourceQuery(),
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -321,14 +289,10 @@ func (a apiCore) listObjectParts(bucket, object, uploadID string, partNumberMark
 
 // uploadPartRequest wrapper creates a new UploadPart request
 func (a apiCore) uploadPartRequest(bucket, object, uploadID string, md5SumBytes []byte, partNumber int, size int64, body io.ReadSeeker) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "PUT",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?partNumber=" + strconv.Itoa(partNumber) + "&uploadId=" + uploadID,
+		HTTPPath:   separator + bucket + separator + object + "?partNumber=" + strconv.Itoa(partNumber) + "&uploadId=" + uploadID,
 	}
 	r, err := newRequest(op, a.config, body)
 	if err != nil {

--- a/vendor/github.com/minio/minio-go-legacy/api_private_test.go
+++ b/vendor/github.com/minio/minio-go-legacy/api_private_test.go
@@ -103,11 +103,7 @@ func TestURLEncoding(t *testing.T) {
 	}
 
 	for _, u := range want {
-		encodedName, err := urlEncodeName(u.name)
-		if err != nil {
-			t.Fatalf("Error")
-		}
-		if u.encodedName != encodedName {
+		if u.encodedName != getURLEncodedPath(u.name) {
 			t.Errorf("Error")
 		}
 	}

--- a/vendor/github.com/minio/minio-go-legacy/appveyor.yml
+++ b/vendor/github.com/minio/minio-go-legacy/appveyor.yml
@@ -1,0 +1,41 @@
+# version format
+version: "{build}"
+
+# Operating system (build VM template)
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\minio\minio-go-legacy
+
+# environment variables
+environment:
+  GOPATH: c:\gopath
+  GO15VENDOREXPERIMENT: 1
+
+# scripts that run after cloning repository
+install:
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.5.1.windows-amd64.msi
+  - msiexec /i go1.5.1.windows-amd64.msi /q
+  - go version
+  - go env
+  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/tools/cmd/vet
+  - go get -u github.com/fzipp/gocyclo
+  - go get -u github.com/remyoudompheng/go-misc/deadcode
+
+# to run your custom scripts instead of automatic MSBuild
+build_script:
+  - go vet ./...
+  - gofmt -s -l .
+  - golint github.com/minio/minio-go-legacy...
+  - gocyclo -over 30 .
+  - deadcode
+  - go test
+  - go test -race
+
+# to disable automatic tests
+test: off
+
+# to disable deployment
+deploy: off

--- a/vendor/github.com/minio/minio-go-legacy/common.go
+++ b/vendor/github.com/minio/minio-go-legacy/common.go
@@ -17,14 +17,9 @@
 package minio
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
-	"errors"
 	"io"
-	"regexp"
-	"strings"
-	"unicode/utf8"
 )
 
 // decoder provides a unified decoding method interface
@@ -44,43 +39,4 @@ func acceptTypeDecoder(body io.Reader, acceptType string, v interface{}) error {
 		d = xml.NewDecoder(body)
 	}
 	return d.Decode(v)
-}
-
-// urlEncodedName encode the strings from UTF-8 byte representations to HTML hex escape sequences
-//
-// This is necessary since regular url.Parse() and url.Encode() functions do not support UTF-8
-// non english characters cannot be parsed due to the nature in which url.Encode() is written
-//
-// This function on the other hand is a direct replacement for url.Encode() technique to support
-// pretty much every UTF-8 character.
-func urlEncodeName(name string) (string, error) {
-	// if object matches reserved string, no need to encode them
-	reservedNames := regexp.MustCompile("^[a-zA-Z0-9-_.~/]+$")
-	if reservedNames.MatchString(name) {
-		return name, nil
-	}
-	var encodedName string
-	for _, s := range name {
-		if 'A' <= s && s <= 'Z' || 'a' <= s && s <= 'z' || '0' <= s && s <= '9' { // §2.3 Unreserved characters (mark)
-			encodedName = encodedName + string(s)
-			continue
-		}
-		switch s {
-		case '-', '_', '.', '~', '/': // §2.3 Unreserved characters (mark)
-			encodedName = encodedName + string(s)
-			continue
-		default:
-			len := utf8.RuneLen(s)
-			if len < 0 {
-				return "", errors.New("invalid utf-8")
-			}
-			u := make([]byte, len)
-			utf8.EncodeRune(u, s)
-			for _, r := range u {
-				hex := hex.EncodeToString([]byte{r})
-				encodedName = encodedName + "%" + strings.ToUpper(hex)
-			}
-		}
-	}
-	return encodedName, nil
 }

--- a/vendor/github.com/minio/minio-go-legacy/request.go
+++ b/vendor/github.com/minio/minio-go-legacy/request.go
@@ -21,16 +21,19 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // operation - rest operation
@@ -46,6 +49,46 @@ type request struct {
 	config  *Config
 	body    io.ReadSeeker
 	expires int64
+}
+
+// getURLEncodedPath encode the strings from UTF-8 byte representations to HTML hex escape sequences
+//
+// This is necessary since regular url.Parse() and url.Encode() functions do not support UTF-8
+// non english characters cannot be parsed due to the nature in which url.Encode() is written
+//
+// This function on the other hand is a direct replacement for url.Encode() technique to support
+// pretty much every UTF-8 character.
+func getURLEncodedPath(pathName string) string {
+	// if object matches reserved string, no need to encode them
+	reservedNames := regexp.MustCompile("^[a-zA-Z0-9-_.~/]+$")
+	if reservedNames.MatchString(pathName) {
+		return pathName
+	}
+	var encodedPathname string
+	for _, s := range pathName {
+		if 'A' <= s && s <= 'Z' || 'a' <= s && s <= 'z' || '0' <= s && s <= '9' { // §2.3 Unreserved characters (mark)
+			encodedPathname = encodedPathname + string(s)
+			continue
+		}
+		switch s {
+		case '-', '_', '.', '~', '/': // §2.3 Unreserved characters (mark)
+			encodedPathname = encodedPathname + string(s)
+			continue
+		default:
+			len := utf8.RuneLen(s)
+			if len < 0 {
+				// if utf8 cannot convert return the same string as is
+				return pathName
+			}
+			u := make([]byte, len)
+			utf8.EncodeRune(u, s)
+			for _, r := range u {
+				hex := hex.EncodeToString([]byte{r})
+				encodedPathname = encodedPathname + "%" + strings.ToUpper(hex)
+			}
+		}
+	}
+	return encodedPathname
 }
 
 func path2BucketAndObject(path string) (bucketName, objectName string) {
@@ -67,16 +110,13 @@ func path2BucketAndObject(path string) (bucketName, objectName string) {
 
 // path2Object gives objectName from URL path
 func path2Object(path string) (objectName string) {
-	pathSplits := strings.SplitN(path, "?", 2)
-	splits := strings.SplitN(pathSplits[0], separator, 3)
-	switch len(splits) {
-	case 0, 1:
-		fallthrough
-	case 2:
-		objectName = ""
-	case 3:
-		objectName = splits[2]
-	}
+	_, objectName = path2BucketAndObject(path)
+	return
+}
+
+// path2Bucket gives bucketName from URL path
+func path2Bucket(path string) (bucketName string) {
+	bucketName, _ = path2BucketAndObject(path)
 	return
 }
 
@@ -91,66 +131,24 @@ func path2Query(path string) (query string) {
 
 func (op *operation) getRequestURL(config Config) (url string) {
 	// parse URL for the combination of HTTPServer + HTTPPath
-	if config.Region != "milkyway" {
-		// if virtual style hosts, bucket name is not needed to be part of path
-		if config.isVirtualStyle {
-			url = op.HTTPServer + separator + path2Object(op.HTTPPath)
-			query := path2Query(op.HTTPPath)
-			// verify if there is a query string to
-			if query != "" {
-				url = url + "?" + query
-			}
-		} else {
-			url = op.HTTPServer + op.HTTPPath
-		}
-	} else {
-		url = op.HTTPServer + op.HTTPPath
+	url = op.HTTPServer + separator
+	if !config.isVirtualStyle {
+		url += path2Bucket(op.HTTPPath)
+	}
+	objectName := getURLEncodedPath(path2Object(op.HTTPPath))
+	queryPath := path2Query(op.HTTPPath)
+	if objectName == "" && queryPath != "" {
+		url += "?" + queryPath
+		return
+	}
+	if objectName != "" && queryPath == "" {
+		url += separator + objectName
+		return
+	}
+	if objectName != "" && queryPath != "" {
+		url += separator + objectName + "?" + queryPath
 	}
 	return
-}
-
-func httpNewRequest(method, urlStr string, body io.Reader) (*http.Request, error) {
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	// make sure to encode properly, url.Parse in golang is buggy and creates erroneous encoding
-	uEncoded := u
-	bucketName, objectName := path2BucketAndObject(uEncoded.Path)
-	if objectName != "" {
-		encodedObjectName, err := urlEncodeName(objectName)
-		if err != nil {
-			return nil, err
-		}
-		uEncoded.Opaque = "//" + uEncoded.Host + separator + bucketName + separator + encodedObjectName
-	} else {
-		uEncoded.Opaque = "//" + uEncoded.Host + separator + bucketName
-	}
-	rc, ok := body.(io.ReadCloser)
-	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
-	}
-	req := &http.Request{
-		Method:     method,
-		URL:        uEncoded,
-		Proto:      "HTTP/1.1",
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Header:     make(http.Header),
-		Body:       rc,
-		Host:       uEncoded.Host,
-	}
-	if body != nil {
-		switch v := body.(type) {
-		case *bytes.Buffer:
-			req.ContentLength = int64(v.Len())
-		case *bytes.Reader:
-			req.ContentLength = int64(v.Len())
-		case *strings.Reader:
-			req.ContentLength = int64(v.Len())
-		}
-	}
-	return req, nil
 }
 
 func newPresignedRequest(op *operation, config *Config, expires int64) (*request, error) {
@@ -163,7 +161,7 @@ func newPresignedRequest(op *operation, config *Config, expires int64) (*request
 	u := op.getRequestURL(*config)
 
 	// get a new HTTP request, for the requested method
-	req, err := httpNewRequest(method, u, nil)
+	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +195,7 @@ func newUnauthenticatedRequest(op *operation, config *Config, body io.Reader) (*
 	u := op.getRequestURL(*config)
 
 	// get a new HTTP request, for the requested method
-	req, err := httpNewRequest(method, u, nil)
+	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +235,7 @@ func newRequest(op *operation, config *Config, body io.ReadSeeker) (*request, er
 	u := op.getRequestURL(*config)
 
 	// get a new HTTP request, for the requested method
-	req, err := httpNewRequest(method, u, nil)
+	req, err := http.NewRequest(method, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -458,20 +456,12 @@ func (r *request) writeCanonicalizedResource(buf *bytes.Buffer) error {
 			if v == r.config.Region {
 				path := "/" + strings.TrimSuffix(requestURL.Host, "."+k)
 				path += requestURL.Path
-				encodedURLPath, err := urlEncodeName(path)
-				if err != nil {
-					return err
-				}
-				buf.WriteString(encodedURLPath)
+				buf.WriteString(getURLEncodedPath(path))
 				break
 			}
 		}
 	} else {
-		encodedURLPath, err := urlEncodeName(requestURL.Path)
-		if err != nil {
-			return err
-		}
-		buf.WriteString(encodedURLPath)
+		buf.WriteString(getURLEncodedPath(requestURL.Path))
 	}
 	sort.Strings(resourceList)
 	if requestURL.RawQuery != "" {

--- a/vendor/github.com/minio/minio-go/api-core.go
+++ b/vendor/github.com/minio/minio-go/api-core.go
@@ -264,27 +264,14 @@ func (a apiCore) getBucketLocation(bucket string) (string, error) {
 func (a apiCore) listObjectsRequest(bucket, marker, prefix, delimiter string, maxkeys int) (*request, error) {
 	// resourceQuery - get resources properly escaped and lined up before using them in http request
 	resourceQuery := func() (*string, error) {
-		var err error
 		switch {
 		case marker != "":
-			marker, err = urlEncodeName(marker)
-			if err != nil {
-				return nil, err
-			}
 			marker = fmt.Sprintf("&marker=%s", marker)
 			fallthrough
 		case prefix != "":
-			prefix, err = urlEncodeName(prefix)
-			if err != nil {
-				return nil, err
-			}
 			prefix = fmt.Sprintf("&prefix=%s", prefix)
 			fallthrough
 		case delimiter != "":
-			delimiter, err = urlEncodeName(delimiter)
-			if err != nil {
-				return nil, err
-			}
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)
 		}
 		query := fmt.Sprintf("?max-keys=%d", maxkeys) + marker + prefix + delimiter
@@ -473,14 +460,10 @@ func (a apiCore) putObjectUnAuthenticatedRequest(bucket, object, contentType str
 	if strings.TrimSpace(contentType) == "" {
 		contentType = "application/octet-stream"
 	}
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "PUT",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newUnauthenticatedRequest(op, a.config, body)
 	if err != nil {
@@ -527,14 +510,10 @@ func (a apiCore) putObjectRequest(bucket, object, contentType string, md5SumByte
 	if strings.TrimSpace(contentType) == "" {
 		contentType = "application/octet-stream"
 	}
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "PUT",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newRequest(op, a.config, body)
 	if err != nil {
@@ -578,14 +557,10 @@ func (a apiCore) putObject(bucket, object, contentType string, md5SumBytes []byt
 }
 
 func (a apiCore) presignedGetObjectRequest(bucket, object string, expires, offset, length int64) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "GET",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newPresignedRequest(op, a.config, strconv.FormatInt(expires, 10))
 	if err != nil {
@@ -615,14 +590,10 @@ func (a apiCore) presignedGetObject(bucket, object string, expires, offset, leng
 
 // getObjectRequest wrapper creates a new getObject request
 func (a apiCore) getObjectRequest(bucket, object string, offset, length int64) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "GET",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	r, err := newRequest(op, a.config, nil)
 	if err != nil {
@@ -700,14 +671,10 @@ func (a apiCore) getObject(bucket, object string, offset, length int64) (io.Read
 
 // deleteObjectRequest wrapper creates a new deleteObject request
 func (a apiCore) deleteObjectRequest(bucket, object string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "DELETE",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -766,14 +733,10 @@ func (a apiCore) deleteObject(bucket, object string) error {
 
 // headObjectRequest wrapper creates a new headObject request
 func (a apiCore) headObjectRequest(bucket, object string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "HEAD",
-		HTTPPath:   separator + bucket + separator + encodedObject,
+		HTTPPath:   separator + bucket + separator + object,
 	}
 	return newRequest(op, a.config, nil)
 }

--- a/vendor/github.com/minio/minio-go/api-multipart-core.go
+++ b/vendor/github.com/minio/minio-go/api-multipart-core.go
@@ -32,34 +32,17 @@ import (
 func (a apiCore) listMultipartUploadsRequest(bucket, keymarker, uploadIDMarker, prefix, delimiter string, maxuploads int) (*request, error) {
 	// resourceQuery - get resources properly escaped and lined up before using them in http request
 	resourceQuery := func() (string, error) {
-		var err error
 		switch {
 		case keymarker != "":
-			keymarker, err = urlEncodeName(keymarker)
-			if err != nil {
-				return "", err
-			}
 			keymarker = fmt.Sprintf("&key-marker=%s", keymarker)
 			fallthrough
 		case uploadIDMarker != "":
-			uploadIDMarker, err = urlEncodeName(uploadIDMarker)
-			if err != nil {
-				return "", err
-			}
 			uploadIDMarker = fmt.Sprintf("&upload-id-marker=%s", uploadIDMarker)
 			fallthrough
 		case prefix != "":
-			prefix, err = urlEncodeName(prefix)
-			if err != nil {
-				return "", err
-			}
 			prefix = fmt.Sprintf("&prefix=%s", prefix)
 			fallthrough
 		case delimiter != "":
-			delimiter, err = urlEncodeName(delimiter)
-			if err != nil {
-				return "", err
-			}
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)
 		}
 		query := fmt.Sprintf("?uploads&max-uploads=%d", maxuploads) + keymarker + uploadIDMarker + prefix + delimiter
@@ -117,14 +100,10 @@ func (a apiCore) listMultipartUploads(bucket, keymarker, uploadIDMarker, prefix,
 
 // initiateMultipartRequest wrapper creates a new initiateMultiPart request
 func (a apiCore) initiateMultipartRequest(bucket, object string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "POST",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?uploads",
+		HTTPPath:   separator + bucket + separator + object + "?uploads",
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -155,16 +134,13 @@ func (a apiCore) initiateMultipartUpload(bucket, object string) (initiateMultipa
 
 // completeMultipartUploadRequest wrapper creates a new CompleteMultipartUpload request
 func (a apiCore) completeMultipartUploadRequest(bucket, object, uploadID string, complete completeMultipartUpload) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "POST",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?uploadId=" + uploadID,
+		HTTPPath:   separator + bucket + separator + object + "?uploadId=" + uploadID,
 	}
 	var completeMultipartUploadBytes []byte
+	var err error
 	switch {
 	case a.config.AcceptType == "application/xml":
 		completeMultipartUploadBytes, err = xml.Marshal(complete)
@@ -211,14 +187,10 @@ func (a apiCore) completeMultipartUpload(bucket, object, uploadID string, c comp
 
 // abortMultipartUploadRequest wrapper creates a new AbortMultipartUpload request
 func (a apiCore) abortMultipartUploadRequest(bucket, object, uploadID string) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "DELETE",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?uploadId=" + uploadID,
+		HTTPPath:   separator + bucket + separator + object + "?uploadId=" + uploadID,
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -269,10 +241,6 @@ func (a apiCore) abortMultipartUpload(bucket, object, uploadID string) error {
 
 // listObjectPartsRequest wrapper creates a new ListObjectParts request
 func (a apiCore) listObjectPartsRequest(bucket, object, uploadID string, partNumberMarker, maxParts int) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	// resourceQuery - get resources properly escaped and lined up before using them in http request
 	resourceQuery := func() string {
 		var partNumberMarkerStr string
@@ -285,7 +253,7 @@ func (a apiCore) listObjectPartsRequest(bucket, object, uploadID string, partNum
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "GET",
-		HTTPPath:   separator + bucket + separator + encodedObject + resourceQuery(),
+		HTTPPath:   separator + bucket + separator + object + resourceQuery(),
 	}
 	return newRequest(op, a.config, nil)
 }
@@ -321,14 +289,10 @@ func (a apiCore) listObjectParts(bucket, object, uploadID string, partNumberMark
 
 // uploadPartRequest wrapper creates a new UploadPart request
 func (a apiCore) uploadPartRequest(bucket, object, uploadID string, md5SumBytes []byte, partNumber int, size int64, body io.ReadSeeker) (*request, error) {
-	encodedObject, err := urlEncodeName(object)
-	if err != nil {
-		return nil, err
-	}
 	op := &operation{
 		HTTPServer: a.config.Endpoint,
 		HTTPMethod: "PUT",
-		HTTPPath:   separator + bucket + separator + encodedObject + "?partNumber=" + strconv.Itoa(partNumber) + "&uploadId=" + uploadID,
+		HTTPPath:   separator + bucket + separator + object + "?partNumber=" + strconv.Itoa(partNumber) + "&uploadId=" + uploadID,
 	}
 	r, err := newRequest(op, a.config, body)
 	if err != nil {

--- a/vendor/github.com/minio/minio-go/api_handlers_test.go
+++ b/vendor/github.com/minio/minio-go/api_handlers_test.go
@@ -56,8 +56,19 @@ func (h bucketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case r.URL.Path == h.resource:
 			_, ok := r.URL.Query()["acl"]
 			if ok {
-				if r.Header.Get("x-amz-acl") != "public-read-write" {
+				switch r.Header.Get("x-amz-acl") {
+				case "public-read-write":
+					fallthrough
+				case "public-read":
+					fallthrough
+				case "private":
+					fallthrough
+				case "authenticated-read":
+					w.WriteHeader(http.StatusOK)
+					return
+				default:
 					w.WriteHeader(http.StatusNotImplemented)
+					return
 				}
 			}
 			w.WriteHeader(http.StatusOK)

--- a/vendor/github.com/minio/minio-go/api_private_test.go
+++ b/vendor/github.com/minio/minio-go/api_private_test.go
@@ -103,11 +103,7 @@ func TestURLEncoding(t *testing.T) {
 	}
 
 	for _, u := range want {
-		encodedName, err := urlEncodeName(u.name)
-		if err != nil {
-			t.Fatalf("Error")
-		}
-		if u.encodedName != encodedName {
+		if u.encodedName != getURLEncodedPath(u.name) {
 			t.Errorf("Error")
 		}
 	}


### PR DESCRIPTION
This change is necessary to cater for S3 clones which do not support

 http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2

Fixes the issue https://github.com/minio/minio-go/issues/167