### PR TITLE
Add new --colors option for choosing different coloring styles for co…

### DIFF
--- a/access-main.go
+++ b/access-main.go
@@ -116,12 +116,25 @@ func checkAccessSyntax(ctx *cli.Context) {
 	}
 }
 
-func mainAccess(ctx *cli.Context) {
-	checkAccessSyntax(ctx)
-
+func setAccessPalette(style string) {
 	console.SetCustomPalette(map[string]*color.Color{
 		"Access": color.New(color.FgGreen, color.Bold),
 	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Access": color.New(color.FgWhite, color.Bold),
+		})
+	}
+	if style == "nocolor" {
+		// ALl coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
+func mainAccess(ctx *cli.Context) {
+	checkAccessSyntax(ctx)
+
+	setAccessPalette(ctx.GlobalString("colors"))
 
 	config := mustGetMcConfig()
 

--- a/config-alias-main.go
+++ b/config-alias-main.go
@@ -114,16 +114,32 @@ func checkConfigAliasSyntax(ctx *cli.Context) {
 	}
 }
 
-//
-func mainConfigAlias(ctx *cli.Context) {
-	checkConfigAliasSyntax(ctx)
-
-	// set new custom coloring
+func setConfigAliasPalette(style string) {
 	console.SetCustomPalette(map[string]*color.Color{
 		"Alias":        color.New(color.FgCyan, color.Bold),
 		"AliasMessage": color.New(color.FgGreen, color.Bold),
 		"URL":          color.New(color.FgWhite, color.Bold),
 	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Alias":        color.New(color.FgWhite, color.Bold),
+			"AliasMessage": color.New(color.FgWhite, color.Bold),
+			"URL":          color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
+//
+func mainConfigAlias(ctx *cli.Context) {
+	checkConfigAliasSyntax(ctx)
+
+	setConfigAliasPalette(ctx.GlobalString("colors"))
 
 	arg := ctx.Args().First()
 	tailArgs := ctx.Args().Tail()

--- a/config-host-main.go
+++ b/config-host-main.go
@@ -109,10 +109,7 @@ func checkConfigHostSyntax(ctx *cli.Context) {
 	}
 }
 
-func mainConfigHost(ctx *cli.Context) {
-	checkConfigHostSyntax(ctx)
-
-	// set new custom coloring
+func setConfigHostPalette(style string) {
 	console.SetCustomPalette(map[string]*color.Color{
 		"Host":            color.New(color.FgCyan, color.Bold),
 		"API":             color.New(color.FgYellow, color.Bold),
@@ -120,6 +117,27 @@ func mainConfigHost(ctx *cli.Context) {
 		"AccessKeyID":     color.New(color.FgBlue, color.Bold),
 		"SecretAccessKey": color.New(color.FgRed, color.Bold),
 	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Host":            color.New(color.FgWhite, color.Bold),
+			"API":             color.New(color.FgWhite, color.Bold),
+			"HostMessage":     color.New(color.FgWhite, color.Bold),
+			"AccessKeyID":     color.New(color.FgWhite, color.Bold),
+			"SecretAccessKey": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
+func mainConfigHost(ctx *cli.Context) {
+	checkConfigHostSyntax(ctx)
+
+	setConfigHostPalette(ctx.GlobalString("colors"))
 
 	arg := ctx.Args().First()
 	tailArgs := ctx.Args().Tail()

--- a/cp-main.go
+++ b/cp-main.go
@@ -308,13 +308,28 @@ func doCopySession(session *sessionV2) {
 	wg.Wait()
 }
 
+func setCopyPalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"Copy": color.New(color.FgGreen, color.Bold),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Copy": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
 // mainCopy is bound to sub-command
 func mainCopy(ctx *cli.Context) {
 	checkCopySyntax(ctx)
 
-	console.SetCustomPalette(map[string]*color.Color{
-		"Copy": color.New(color.FgGreen, color.Bold),
-	})
+	setCopyPalette(ctx.GlobalString("colors"))
 
 	session := newSessionV2()
 

--- a/diff-main.go
+++ b/diff-main.go
@@ -59,16 +59,34 @@ func checkDiffSyntax(ctx *cli.Context) {
 	}
 }
 
-// mainDiff - is a handler for mc diff command
-func mainDiff(ctx *cli.Context) {
-	checkDiffSyntax(ctx)
-
+func setDiffPalette(style string) {
 	console.SetCustomPalette(map[string]*color.Color{
 		"DiffMessage":     color.New(color.FgGreen, color.Bold),
 		"DiffOnlyInFirst": color.New(color.FgRed, color.Bold),
 		"DiffType":        color.New(color.FgYellow, color.Bold),
 		"DiffSize":        color.New(color.FgMagenta, color.Bold),
 	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"DiffMessage":     color.New(color.FgWhite, color.Bold),
+			"DiffOnlyInFirst": color.New(color.FgWhite, color.Bold),
+			"DiffType":        color.New(color.FgWhite, color.Bold),
+			"DiffSize":        color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
+// mainDiff - is a handler for mc diff command
+func mainDiff(ctx *cli.Context) {
+	checkDiffSyntax(ctx)
+
+	setDiffPalette(ctx.GlobalString("colors"))
 
 	config := mustGetMcConfig()
 	firstArg := ctx.Args().First()

--- a/flags.go
+++ b/flags.go
@@ -54,9 +54,10 @@ var (
 		Usage: "Enable debugging output.",
 	}
 
-	noColorFlag = cli.BoolFlag{
-		Name:  "nocolor",
-		Usage: "Disable console coloring.",
+	colorsFlag = cli.StringFlag{
+		Name:  "colors",
+		Value: "dark",
+		Usage: "Choose type of console coloring. Available options are [‘dark’, ‘light’, ‘nocolor’]",
 	}
 
 	// Add your new flags starting here

--- a/ls-main.go
+++ b/ls-main.go
@@ -88,6 +88,29 @@ func checkListSyntax(ctx *cli.Context) {
 	}
 }
 
+func setListPalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"File": color.New(color.FgWhite),
+		"Dir":  color.New(color.FgCyan, color.Bold),
+		"Size": color.New(color.FgYellow),
+		"Time": color.New(color.FgGreen),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"File": color.New(color.FgWhite, color.Bold),
+			"Dir":  color.New(color.FgWhite, color.Bold),
+			"Size": color.New(color.FgWhite, color.Bold),
+			"Time": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
 // mainList - is a handler for mc ls command
 func mainList(ctx *cli.Context) {
 	checkListSyntax(ctx)
@@ -98,12 +121,7 @@ func mainList(ctx *cli.Context) {
 		args = []string{"."}
 	}
 
-	console.SetCustomPalette(map[string]*color.Color{
-		"File": color.New(color.FgWhite),
-		"Dir":  color.New(color.FgCyan, color.Bold),
-		"Size": color.New(color.FgYellow),
-		"Time": color.New(color.FgGreen),
-	})
+	setListPalette(ctx.GlobalString("colors"))
 
 	targetURLs, err := args2URLs(args)
 	fatalIf(err.Trace(args...), "One or more unknown URL types passed.")

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
@@ -91,9 +92,8 @@ func registerBefore(ctx *cli.Context) error {
 	if globalDebugFlag {
 		console.NoDebugPrint = false
 	}
-	if ctx.GlobalBool("nocolor") {
-		console.SetNoColor()
-	}
+
+	setMainPalette(ctx.GlobalString("colors"))
 
 	// check if mc is being run as root
 	checkUser()
@@ -130,12 +130,12 @@ func registerApp() *cli.App {
 	registerCmd(versionCmd) // Print version.
 
 	// register all the flags
-	registerFlag(configFlag)  // Path to configuration folder.
-	registerFlag(quietFlag)   // Suppress chatty console output.
-	registerFlag(mimicFlag)   // Behave like operating system tools. Use with shell aliases.
-	registerFlag(jsonFlag)    // Enable json formatted output.
-	registerFlag(debugFlag)   // Enable debugging output.
-	registerFlag(noColorFlag) // Disable console coloring.
+	registerFlag(configFlag) // Path to configuration folder.
+	registerFlag(quietFlag)  // Suppress chatty console output.
+	registerFlag(mimicFlag)  // Behave like operating system tools. Use with shell aliases.
+	registerFlag(jsonFlag)   // Enable json formatted output.
+	registerFlag(debugFlag)  // Enable debugging output.
+	registerFlag(colorsFlag) // Choose different styles of console coloring.
 
 	app := cli.NewApp()
 	app.Usage = "Minio Client for cloud storage and filesystems."
@@ -175,6 +175,33 @@ VERSION:
 
 	}
 	return app
+}
+
+func setMainPalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"Debug":  color.New(color.FgWhite, color.Faint, color.Italic),
+		"Fatal":  color.New(color.FgRed, color.Italic, color.Bold),
+		"Error":  color.New(color.FgYellow, color.Italic),
+		"Info":   color.New(color.FgGreen, color.Bold),
+		"Print":  color.New(),
+		"PrintC": color.New(color.FgGreen, color.Bold),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Debug":  color.New(color.FgWhite, color.Faint, color.Italic),
+			"Fatal":  color.New(color.FgWhite, color.Italic, color.Bold),
+			"Error":  color.New(color.FgWhite, color.Italic, color.Bold),
+			"Info":   color.New(color.FgWhite, color.Bold),
+			"Print":  color.New(),
+			"PrintC": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
 }
 
 func main() {

--- a/mb-main.go
+++ b/mb-main.go
@@ -79,13 +79,27 @@ func checkMakeBucketSyntax(ctx *cli.Context) {
 	}
 }
 
+func setMakeBucketPalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"MakeBucket": color.New(color.FgGreen, color.Bold),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"MakeBucket": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
 // mainMakeBucket is the handler for mc mb command
 func mainMakeBucket(ctx *cli.Context) {
 	checkMakeBucketSyntax(ctx)
 
-	console.SetCustomPalette(map[string]*color.Color{
-		"MakeBucket": color.New(color.FgGreen, color.Bold),
-	})
+	setMakeBucketPalette(ctx.GlobalString("colors"))
 
 	config := mustGetMcConfig()
 	for _, arg := range ctx.Args() {

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -309,12 +309,27 @@ func doMirrorSession(session *sessionV2) {
 	wg.Wait()
 }
 
-func mainMirror(ctx *cli.Context) {
-	checkMirrorSyntax(ctx)
-
+func setMirrorPalette(style string) {
 	console.SetCustomPalette(map[string]*color.Color{
 		"Mirror": color.New(color.FgGreen, color.Bold),
 	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Mirror": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
+func mainMirror(ctx *cli.Context) {
+	checkMirrorSyntax(ctx)
+
+	setMirrorPalette(ctx.GlobalString("colors"))
 
 	var e error
 	session := newSessionV2()

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -42,14 +42,7 @@ var IsExited = false
 var IsError = false
 
 // Palette default map
-var Palette = map[string]*color.Color{
-	"Debug":  color.New(color.FgWhite, color.Faint, color.Italic),
-	"Fatal":  color.New(color.FgRed, color.Italic, color.Bold),
-	"Error":  color.New(color.FgYellow, color.Italic),
-	"Info":   color.New(color.FgGreen, color.Bold),
-	"Print":  color.New(),
-	"PrintC": color.New(color.FgGreen, color.Bold),
-}
+var Palette = map[string]*color.Color{}
 
 var (
 	// Used by the caller to print multiple lines atomically. Exposed by Lock/Unlock methods.

--- a/session-main.go
+++ b/session-main.go
@@ -163,19 +163,37 @@ func checkSessionSyntax(ctx *cli.Context) {
 	}
 }
 
-func mainSession(ctx *cli.Context) {
-	checkSessionSyntax(ctx)
-
-	if !isSessionDirExists() {
-		fatalIf(createSessionDir().Trace(), "Unable to create session directory.")
-	}
-
+func setSessionPalette(style string) {
 	console.SetCustomPalette(map[string]*color.Color{
 		"Command":      color.New(color.FgWhite, color.Bold),
 		"SessionID":    color.New(color.FgYellow, color.Bold),
 		"SessionTime":  color.New(color.FgGreen),
 		"ClearSession": color.New(color.FgGreen, color.Bold),
 	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Command":      color.New(color.FgWhite, color.Bold),
+			"SessionID":    color.New(color.FgWhite, color.Bold),
+			"SessionTime":  color.New(color.FgWhite, color.Bold),
+			"ClearSession": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
+func mainSession(ctx *cli.Context) {
+	checkSessionSyntax(ctx)
+
+	setSessionPalette(ctx.GlobalString("colors"))
+
+	if !isSessionDirExists() {
+		fatalIf(createSessionDir().Trace(), "Unable to create session directory.")
+	}
 
 	switch strings.TrimSpace(ctx.Args().First()) {
 	// list resumable sessions

--- a/share-main.go
+++ b/share-main.go
@@ -117,6 +117,28 @@ func checkShareSyntax(ctx *cli.Context) {
 	}
 }
 
+func setSharePalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"Share":   color.New(color.FgGreen, color.Bold),
+		"Expires": color.New(color.FgRed, color.Bold),
+		"URL":     color.New(color.FgCyan, color.Bold),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Share":   color.New(color.FgWhite, color.Bold),
+			"Expires": color.New(color.FgWhite, color.Bold),
+			"URL":     color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
 // mainShare - is a handler for mc share command
 func mainShare(ctx *cli.Context) {
 	checkShareSyntax(ctx)
@@ -134,11 +156,7 @@ func mainShare(ctx *cli.Context) {
 		fatalIf(createSharedURLsDataFile().Trace(), "Unable to create shared URL data file ‘"+shareFile+"’.")
 	}
 
-	console.SetCustomPalette(map[string]*color.Color{
-		"Share":   color.New(color.FgGreen, color.Bold),
-		"Expires": color.New(color.FgRed, color.Bold),
-		"URL":     color.New(color.FgCyan, color.Bold),
-	})
+	setSharePalette(ctx.GlobalString("colors"))
 
 	args := ctx.Args()
 	config := mustGetMcConfig()

--- a/update-main.go
+++ b/update-main.go
@@ -102,13 +102,28 @@ func checkUpdateSyntax(ctx *cli.Context) {
 	}
 }
 
+func setUpdatePalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"UpdateMessage": color.New(color.FgGreen, color.Bold),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"UpdateMessage": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
 // mainUpdate -
 func mainUpdate(ctx *cli.Context) {
 	checkUpdateSyntax(ctx)
 
-	console.SetCustomPalette(map[string]*color.Color{
-		"UpdateMessage": color.New(color.FgGreen, color.Bold),
-	})
+	setUpdatePalette(ctx.GlobalString("colors"))
 
 	arg := strings.TrimSpace(ctx.Args().First())
 	switch arg {

--- a/version-main.go
+++ b/version-main.go
@@ -40,13 +40,30 @@ USAGE:
 `,
 }
 
+func setVersionPalette(style string) {
+	console.SetCustomPalette(map[string]*color.Color{
+		"Version": color.New(color.FgGreen, color.Bold),
+	})
+	if style == "light" {
+		console.SetCustomPalette(map[string]*color.Color{
+			"Version": color.New(color.FgWhite, color.Bold),
+		})
+		return
+	}
+	/// Add more styles here
+	if style == "nocolor" {
+		// All coloring options exhausted, setting nocolor safely
+		console.SetNoColor()
+	}
+}
+
 func mainVersion(ctx *cli.Context) {
 	if ctx.Args().First() == "help" {
 		cli.ShowCommandHelpAndExit(ctx, "version", 1) // last argument is exit code
 	}
-	console.SetCustomPalette(map[string]*color.Color{
-		"Version": color.New(color.FgGreen, color.Bold),
-	})
+
+	setVersionPalette(ctx.GlobalString("colors"))
+
 	if globalJSONFlag {
 		tB, e := json.Marshal(
 			struct {


### PR DESCRIPTION
…nsole printing

Each command implements and interprets the following coloring styles

 - ``dark`` - default coloring style picks up palette colors Cyan, Red, Blue, White etc
 - ``light`` - lighter chooses white colored console printing.
 - ``nocolor`` - nocolor is for console printing without any colors.

All coloring internally use ASCII color schemes, portable across all known OS.