### PR TITLE
Relax `too many levels symlink error` when traversing folders/files

### DIFF
--- a/ls.go
+++ b/ls.go
@@ -114,8 +114,11 @@ func doList(clnt client.Client, recursive, multipleArgs bool) *probe.Error {
 		if contentCh.Err != nil {
 			switch contentCh.Err.ToGoError().(type) {
 			// handle this specifically for filesystem
-			case client.ISBrokenSymlink:
+			case client.BrokenSymlink:
 				errorIf(contentCh.Err.Trace(), "Unable to list broken link.")
+				continue
+			case client.TooManyLevelsSymlink:
+				errorIf(contentCh.Err.Trace(), "Unable to list too many levels link.")
 				continue
 			}
 			if os.IsNotExist(contentCh.Err.ToGoError()) || os.IsPermission(contentCh.Err.ToGoError()) {

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -150,25 +150,18 @@ func (e NotFound) Error() string {
 	return "Requested file ‘" + e.Path + "’ not found"
 }
 
-// ISFolder (EISDIR) - accessed file is a folder
-type ISFolder GenericFileError
+// BrokenSymlink (ENOTENT) - file has broken symlink
+type BrokenSymlink GenericFileError
 
-func (e ISFolder) Error() string {
-	return "Requested file ‘" + e.Path + "’ is a folder"
-}
-
-// NotFolder (ENOTDIR) - accessed file is not a folder
-type NotFolder GenericFileError
-
-func (e NotFolder) Error() string {
-	return "Requested file ‘" + e.Path + "’ is not a folder"
-}
-
-// ISBrokenSymlink (ENOTENT) - file has broken symlink
-type ISBrokenSymlink GenericFileError
-
-func (e ISBrokenSymlink) Error() string {
+func (e BrokenSymlink) Error() string {
 	return "Requested file ‘" + e.Path + "’ has broken symlink"
+}
+
+// TooManyLevelsSymlink (ELOOP) - file has too many levels of symlinks
+type TooManyLevelsSymlink GenericFileError
+
+func (e TooManyLevelsSymlink) Error() string {
+	return "Requested file ‘" + e.Path + "’ has too many levels of symlinks"
 }
 
 // EmptyPath (EINVAL) - invalid argument

--- a/sorted-list.go
+++ b/sorted-list.go
@@ -79,9 +79,13 @@ func (sl *sortedList) Create(clnt client.Client, id string) *probe.Error {
 	for content := range clnt.List(true) {
 		if content.Err != nil {
 			switch err := content.Err.ToGoError().(type) {
-			case client.ISBrokenSymlink:
+			case client.BrokenSymlink:
 				// FIXME: send the error to caller using channel
 				errorIf(content.Err.Trace(), fmt.Sprintf("Skipping broken Symlink ‘%s’.", err.Path))
+				continue
+			case client.TooManyLevelsSymlink:
+				// FIXME: send the error to caller using channel
+				errorIf(content.Err.Trace(), fmt.Sprintf("Skipping too many levels Symlink ‘%s’.", err.Path))
 				continue
 			}
 			if os.IsNotExist(content.Err.ToGoError()) || os.IsPermission(content.Err.ToGoError()) {


### PR DESCRIPTION
1. Rename ISBrokenSymlink error to BrokenSymlink, delete ISFolder and NotFolder errors since they are no more used
2. As broken links, do not immediatly exit when a looped symlink (or symlink with too many levels) is encountered

Since it seems there is no way to detect properly a looped symlink (strings.Contains was used), I need to get this patch tested on mac os !