### PR TITLE
Fix an infinite loop bug

### DIFF
--- a/vendor/github.com/minio/minio-go-legacy/README.md
+++ b/vendor/github.com/minio/minio-go-legacy/README.md
@@ -54,7 +54,11 @@ func main() {
 * [StatObject(bucket, object) (ObjectStat, error)](examples/statobject.go)
 * [RemoveObject(bucket, object) error](examples/removeobject.go)
 * [DropIncompleteUpload(bucket, object) <-chan error](examples/dropincompleteuploads.go)
-* [PresignedGetObject(bucket, object, expires) (string, error)](examples/presignedgetobject.go)
+
+### Presigned Bucket/Object Level
+* [PresignedGetObject(bucket, object, time.Duration) (string, error)](examples/s3/presignedgetobject.go)
+* [PresignedPutObject(bucket, object, time.Duration) (string, error)](examples/s3/presignedputobject.go)
+* [PresignedPostPolicy(NewPostPolicy()) (map[string]string, error)](examples/s3/presignedpostpolicy.go)
 
 ### API Reference
 

--- a/vendor/github.com/minio/minio-go-legacy/api-multipart-core.go
+++ b/vendor/github.com/minio/minio-go-legacy/api-multipart-core.go
@@ -34,13 +34,13 @@ func (a apiCore) listMultipartUploadsRequest(bucket, keymarker, uploadIDMarker, 
 	resourceQuery := func() (string, error) {
 		switch {
 		case keymarker != "":
-			keymarker = fmt.Sprintf("&key-marker=%s", keymarker)
+			keymarker = fmt.Sprintf("&key-marker=%s", getURLEncodedPath(keymarker))
 			fallthrough
 		case uploadIDMarker != "":
 			uploadIDMarker = fmt.Sprintf("&upload-id-marker=%s", uploadIDMarker)
 			fallthrough
 		case prefix != "":
-			prefix = fmt.Sprintf("&prefix=%s", prefix)
+			prefix = fmt.Sprintf("&prefix=%s", getURLEncodedPath(prefix))
 			fallthrough
 		case delimiter != "":
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)

--- a/vendor/github.com/minio/minio-go-legacy/api.go
+++ b/vendor/github.com/minio/minio-go-legacy/api.go
@@ -73,6 +73,7 @@ type ObjectAPI interface {
 // PresignedAPI - object specific for now
 type PresignedAPI interface {
 	PresignedGetObject(bucket, object string, expires time.Duration) (string, error)
+	PresignedPutObject(bucket, object string, expires time.Duration) (string, error)
 	PresignedPostPolicy(*PostPolicy) (map[string]string, error)
 }
 
@@ -235,6 +236,15 @@ func (a api) PresignedPostPolicy(p *PostPolicy) (map[string]string, error) {
 /// Object operations
 
 /// Expires maximum is 7days - ie. 604800 and minimum is 1
+
+// PresignedPutObject get a presigned URL to retrieve an object for third party apps
+func (a api) PresignedPutObject(bucket, object string, expires time.Duration) (string, error) {
+	expireSeconds := int64(expires / time.Second)
+	if expireSeconds < 1 || expireSeconds > 604800 {
+		return "", invalidArgumentError("")
+	}
+	return a.presignedPutObject(bucket, object, expireSeconds)
+}
 
 // PresignedGetObject get a presigned URL to retrieve an object for third party apps
 func (a api) PresignedGetObject(bucket, object string, expires time.Duration) (string, error) {

--- a/vendor/github.com/minio/minio-go-legacy/request.go
+++ b/vendor/github.com/minio/minio-go-legacy/request.go
@@ -306,7 +306,7 @@ func (r *request) PreSignV2() (string, error) {
 		r.Set("Date", d.Format(http.TimeFormat))
 	}
 	epochExpires := d.Unix() + r.expires
-	signText := fmt.Sprintf("GET\n\n\n%d\n%s", epochExpires, r.req.URL.Path)
+	signText := fmt.Sprintf("%s\n\n\n%d\n%s", r.req.Method, epochExpires, r.req.URL.Path)
 	hm := hmac.New(sha1.New, []byte(r.config.SecretAccessKey))
 	hm.Write([]byte(signText))
 

--- a/vendor/github.com/minio/minio-go/README.md
+++ b/vendor/github.com/minio/minio-go/README.md
@@ -55,6 +55,11 @@ func main() {
 * [StatObject(bucket, object) (ObjectStat, error)](examples/s3/statobject.go)
 * [RemoveObject(bucket, object) error](examples/s3/removeobject.go)
 
+### Presigned Bucket/Object Level
+* [PresignedGetObject(bucket, object, time.Duration) (string, error)](examples/s3/presignedgetobject.go)
+* [PresignedPutObject(bucket, object, time.Duration) (string, error)](examples/s3/presignedputobject.go)
+* [PresignedPostPolicy(NewPostPolicy()) (map[string]string, error)](examples/s3/presignedpostpolicy.go)
+
 ### API Reference
 
 [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/minio/minio-go)

--- a/vendor/github.com/minio/minio-go/api-multipart-core.go
+++ b/vendor/github.com/minio/minio-go/api-multipart-core.go
@@ -34,13 +34,13 @@ func (a apiCore) listMultipartUploadsRequest(bucket, keymarker, uploadIDMarker, 
 	resourceQuery := func() (string, error) {
 		switch {
 		case keymarker != "":
-			keymarker = fmt.Sprintf("&key-marker=%s", keymarker)
+			keymarker = fmt.Sprintf("&key-marker=%s", getURLEncodedPath(keymarker))
 			fallthrough
 		case uploadIDMarker != "":
 			uploadIDMarker = fmt.Sprintf("&upload-id-marker=%s", uploadIDMarker)
 			fallthrough
 		case prefix != "":
-			prefix = fmt.Sprintf("&prefix=%s", prefix)
+			prefix = fmt.Sprintf("&prefix=%s", getURLEncodedPath(prefix))
 			fallthrough
 		case delimiter != "":
 			delimiter = fmt.Sprintf("&delimiter=%s", delimiter)

--- a/vendor/github.com/minio/minio-go/api.go
+++ b/vendor/github.com/minio/minio-go/api.go
@@ -73,6 +73,7 @@ type ObjectAPI interface {
 // PresignedAPI - object specific for now
 type PresignedAPI interface {
 	PresignedGetObject(bucket, object string, expires time.Duration) (string, error)
+	PresignedPutObject(bucket, object string, expires time.Duration) (string, error)
 	PresignedPostPolicy(*PostPolicy) (map[string]string, error)
 }
 
@@ -222,6 +223,15 @@ func New(config Config) (API, error) {
 /// Object operations
 
 /// Expires maximum is 7days - ie. 604800 and minimum is 1
+
+// PresignedPutObject get a presigned URL to upload an object
+func (a api) PresignedPutObject(bucket, object string, expires time.Duration) (string, error) {
+	expireSeconds := int64(expires / time.Second)
+	if expireSeconds < 1 || expireSeconds > 604800 {
+		return "", invalidArgumentError("")
+	}
+	return a.presignedPutObject(bucket, object, expireSeconds)
+}
 
 // PresignedGetObject get a presigned URL to retrieve an object for third party apps
 func (a api) PresignedGetObject(bucket, object string, expires time.Duration) (string, error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -29,13 +29,13 @@
 		},
 		{
 			"path": "github.com/minio/minio-go",
-			"revision": "06751b70f167c449567508aa8655a84de50609a6",
-			"revisionTime": "2015-10-08T15:16:48-07:00"
+			"revision": "b20214d4c0f52c9efd000d6193fc46a44be44a9e",
+			"revisionTime": "2015-10-12T10:41:41-07:00"
 		},
 		{
 			"path": "github.com/minio/minio-go-legacy",
-			"revision": "89b0e06a751c2d987292db8c5e1c7a486b6420db",
-			"revisionTime": "2015-10-08T16:58:29-07:00"
+			"revision": "40941db1ca6fbe97479f5560a83133e6564abfbe",
+			"revisionTime": "2015-10-12T10:48:42-07:00"
 		},
 		{
 			"path": "github.com/minio/minio/pkg/probe",


### PR DESCRIPTION
While doing recursive listing of objects and object prefixes which have
non encoded characters for example ``++`` leads to S3 sending same replies
for all subsequent ``ListObjects()`` request. Essentially leading to an
infinite loop.