### PR TITLE
Fix mc share download for special character encoding

### DIFF
--- a/vendor/github.com/minio/minio-go/request.go
+++ b/vendor/github.com/minio/minio-go/request.go
@@ -177,11 +177,19 @@ func (op *operation) getRequestURL(config Config) (url string) {
 		return
 	}
 	if objectName != "" && queryPath == "" {
-		url += separator + objectName
+		if strings.HasSuffix(url, separator) {
+			url += objectName
+		} else {
+			url += separator + objectName
+		}
 		return
 	}
 	if objectName != "" && queryPath != "" {
-		url += separator + objectName + "?" + queryPath
+		if strings.HasSuffix(url, separator) {
+			url += objectName + "?" + queryPath
+		} else {
+			url += separator + objectName + "?" + queryPath
+		}
 	}
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -29,13 +29,13 @@
 		},
 		{
 			"path": "github.com/minio/minio-go",
-			"revision": "b20214d4c0f52c9efd000d6193fc46a44be44a9e",
-			"revisionTime": "2015-10-12T10:41:41-07:00"
+			"revision": "c031bbe3dd5e304e0f0bd154d97615fade8df23b",
+			"revisionTime": "2015-10-13T10:12:53-07:00"
 		},
 		{
 			"path": "github.com/minio/minio-go-legacy",
-			"revision": "40941db1ca6fbe97479f5560a83133e6564abfbe",
-			"revisionTime": "2015-10-12T10:48:42-07:00"
+			"revision": "49580a230a441dda8eedbf4440f15a4b3018a385",
+			"revisionTime": "2015-10-13T10:07:00-07:00"
 		},
 		{
 			"path": "github.com/minio/minio/pkg/probe",


### PR DESCRIPTION
mc share download would fail to generate or generate a wrong signature
for a URLs with special unencoded characters.

This issue was limited to signature v2.