### PR TITLE
remove the un-needed space character in help display which would make…

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ GLOBAL FLAGS:
   {{end}}{{end}}
 VERSION:
   ` + mcVersion +
-		`{{ "\n"}} {{range $key, $value := ExtraInfo}}
+		`{{ "\n"}}{{range $key, $value := ExtraInfo}}
 {{$key}}:
   {{$value}}
 {{end}}`


### PR DESCRIPTION

![mchelpbug](https://cloud.githubusercontent.com/assets/634494/10558175/4f3f7ea8-747b-11e5-8df2-1c16ad8d0aac.png)
… the shell prompt offset by a space char.