### PR TITLE
Remove usage of strings.Compare - always golangs native checks like "…

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -272,9 +272,7 @@ func dodiffRecursive(firstClnt, secondClnt client.Client, ch chan DiffMessage) {
 		}
 		fC := f.Content
 		sC := s.Content
-		compare := strings.Compare(fC.Name, sC.Name)
-
-		if compare == 0 {
+		if fC.Name == sC.Name {
 			if fC.Type.IsRegular() {
 				if !sC.Type.IsRegular() {
 					ch <- DiffMessage{
@@ -301,7 +299,7 @@ func dodiffRecursive(firstClnt, secondClnt client.Client, ch chan DiffMessage) {
 			f, fok = <-fch
 			s, sok = <-sch
 		}
-		if compare < 0 {
+		if fC.Name < sC.Name {
 			ch <- DiffMessage{
 				FirstURL:  firstURL,
 				SecondURL: secondURL,
@@ -309,7 +307,7 @@ func dodiffRecursive(firstClnt, secondClnt client.Client, ch chan DiffMessage) {
 			}
 			f, fok = <-fch
 		}
-		if compare > 0 {
+		if fC.Name > sC.Name {
 			s, sok = <-sch
 		}
 	}

--- a/sorted-list.go
+++ b/sorted-list.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/minio/mc/pkg/client"
 	"github.com/minio/minio-xl/pkg/probe"
@@ -143,14 +142,13 @@ func (sl *sortedList) Match(source *client.Content) (bool, *probe.Error) {
 		}
 	}
 	for {
-		compare := strings.Compare(source.Name, sl.current.Name)
-		if compare == 0 {
+		if source.Name == sl.current.Name {
 			if source.Type.IsRegular() && sl.current.Type.IsRegular() && source.Size == sl.current.Size {
 				return true, nil
 			}
 			return false, nil
 		}
-		if compare < 0 {
+		if source.Name < sl.current.Name {
 			return false, nil
 		}
 		// assign zero values to fields because if s.current's previous decode had non zero value


### PR DESCRIPTION
…>, <, ==" for strings