### PR TITLE
fixed variable naming conventions

### DIFF
--- a/common_methods_test.go
+++ b/common_methods_test.go
@@ -28,8 +28,8 @@ import (
 
 func (s *TestSuite) TestCommonMethods(c *C) {
 	/// filesystem
-	root, err := ioutil.TempDir(os.TempDir(), "cmd-")
-	c.Assert(err, IsNil)
+	root, e := ioutil.TempDir(os.TempDir(), "cmd-")
+	c.Assert(e, IsNil)
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object1")
@@ -40,42 +40,42 @@ func (s *TestSuite) TestCommonMethods(c *C) {
 	objectPathServer := server.URL + "/bucket/object1"
 	data := "hello"
 	dataLen := len(data)
-	perr := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
-	c.Assert(perr, IsNil)
-	perr = putTarget(objectPathServer, int64(dataLen), bytes.NewReader([]byte(data)))
-	c.Assert(perr, IsNil)
+	err := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
+	c.Assert(err, IsNil)
+	err = putTarget(objectPathServer, int64(dataLen), bytes.NewReader([]byte(data)))
+	c.Assert(err, IsNil)
 
 	c.Assert(isTargetURLDir(objectPathServer), Equals, false)
 	c.Assert(isTargetURLDir(server.URL+"/bucket"), Equals, true)
 
-	reader, size, perr := getSource(objectPathServer)
-	c.Assert(perr, IsNil)
+	reader, size, err := getSource(objectPathServer)
+	c.Assert(err, IsNil)
 	c.Assert(size, Not(Equals), 0)
 	var results bytes.Buffer
-	_, err = io.CopyN(&results, reader, int64(size))
-	c.Assert(err, IsNil)
+	_, e = io.CopyN(&results, reader, int64(size))
+	c.Assert(e, IsNil)
 	c.Assert([]byte(data), DeepEquals, results.Bytes())
 
-	_, content, perr := url2Stat(objectPathServer)
-	c.Assert(perr, IsNil)
+	_, content, err := url2Stat(objectPathServer)
+	c.Assert(err, IsNil)
 	c.Assert(content.Name, Equals, "object1")
 	c.Assert(content.Type.IsRegular(), Equals, true)
 
-	_, _, perr = getSource(objectPathServer + "invalid")
-	c.Assert(perr, Not(IsNil))
+	_, _, err = getSource(objectPathServer + "invalid")
+	c.Assert(err, Not(IsNil))
 
-	_, _, perr = url2Stat(objectPath + "invalid")
-	c.Assert(perr, Not(IsNil))
+	_, _, err = url2Stat(objectPath + "invalid")
+	c.Assert(err, Not(IsNil))
 
-	_, perr = url2Client(objectPathServer)
-	c.Assert(perr, IsNil)
+	_, err = url2Client(objectPathServer)
+	c.Assert(err, IsNil)
 
-	_, perr = url2Client(objectPathServer)
-	c.Assert(perr, IsNil)
+	_, err = url2Client(objectPathServer)
+	c.Assert(err, IsNil)
 
-	_, perr = url2Client("http://test.minio.io" + "/bucket/fail")
-	c.Assert(perr, Not(IsNil))
+	_, err = url2Client("http://test.minio.io" + "/bucket/fail")
+	c.Assert(err, Not(IsNil))
 
-	_, perr = url2Client("http://test.minio.io" + "/bucket/fail")
-	c.Assert(perr, Not(IsNil))
+	_, err = url2Client("http://test.minio.io" + "/bucket/fail")
+	c.Assert(err, Not(IsNil))
 }

--- a/cp_mirror_test.go
+++ b/cp_mirror_test.go
@@ -72,8 +72,8 @@ func (s *TestSuite) TestMirror(c *C) {
 		objectPath := filepath.Join(source, "object"+strconv.Itoa(i))
 		data := "hello"
 		dataLen := len(data)
-		perr := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
-		c.Assert(perr, IsNil)
+		err := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
+		c.Assert(err, IsNil)
 	}
 
 	// reset back
@@ -107,8 +107,8 @@ func (s *TestSuite) TestCopy(c *C) {
 		objectPath := filepath.Join(source, "object"+strconv.Itoa(i))
 		data := "hello"
 		dataLen := len(data)
-		perr := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
-		c.Assert(perr, IsNil)
+		err := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
+		c.Assert(err, IsNil)
 	}
 
 	// reset back

--- a/ls_test.go
+++ b/ls_test.go
@@ -24,63 +24,61 @@ import (
 	"strconv"
 
 	"github.com/minio/mc/pkg/console"
-	"github.com/minio/minio-xl/pkg/probe"
 	. "gopkg.in/check.v1"
 )
 
 func (s *TestSuite) TestLSContext(c *C) {
 	/// filesystem
-	root, err := ioutil.TempDir(os.TempDir(), "cmd-")
-	c.Assert(err, IsNil)
+	root, e := ioutil.TempDir(os.TempDir(), "cmd-")
+	c.Assert(e, IsNil)
 	defer os.RemoveAll(root)
 
-	var perr *probe.Error
 	for i := 0; i < 10; i++ {
 		objectPath := filepath.Join(root, "object"+strconv.Itoa(i))
 		data := "hello"
 		dataLen := len(data)
-		perr = putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
-		c.Assert(perr, IsNil)
+		err := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
+		c.Assert(err, IsNil)
 	}
 
 	for i := 0; i < 10; i++ {
 		objectPath := server.URL + "/bucket/object" + strconv.Itoa(i)
 		data := "hello"
 		dataLen := len(data)
-		perr := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
-		c.Assert(perr, IsNil)
+		err := putTarget(objectPath, int64(dataLen), bytes.NewReader([]byte(data)))
+		c.Assert(err, IsNil)
 	}
 
-	err = app.Run([]string{os.Args[0], "ls", root})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "ls", root})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsError, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "ls", root + "..."})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "ls", root + "..."})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsError, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "ls", server.URL + "/bucket"})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "ls", server.URL + "/bucket"})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsError, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "ls", server.URL + "/bucket..."})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "ls", server.URL + "/bucket..."})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsError, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "ls", server.URL + "/invalid"})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "ls", server.URL + "/invalid"})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsExited, Equals, true)
 
 	// reset back

--- a/mc_test.go
+++ b/mc_test.go
@@ -52,8 +52,8 @@ func (s *TestSuite) SetUpSuite(c *C) {
 	// do not set it elsewhere, leads to data races since this is a global flag
 	globalQuietFlag = true // quiet is set to turn of progress bar
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "cmd-")
-	c.Assert(err, IsNil)
+	tmpDir, e := ioutil.TempDir(os.TempDir(), "cmd-")
+	c.Assert(e, IsNil)
 
 	// For windows the path is slightly different.
 	if runtime.GOOS == "windows" {
@@ -63,11 +63,11 @@ func (s *TestSuite) SetUpSuite(c *C) {
 	}
 	setMcConfigDir(customConfigDir)
 
-	perr := createMcConfigDir()
-	c.Assert(perr, IsNil)
+	err := createMcConfigDir()
+	c.Assert(err, IsNil)
 
-	config, perr := newConfig()
-	c.Assert(perr, IsNil)
+	config, err := newConfig()
+	c.Assert(err, IsNil)
 
 	config.Data().(*configV5).Hosts["127.0.0.1:*"] = hostConfig{
 		AccessKeyID:     "WLGDGYAQYIGI833EV05A",
@@ -75,11 +75,11 @@ func (s *TestSuite) SetUpSuite(c *C) {
 		API:             "S3v4",
 	}
 
-	perr = writeConfig(config)
-	c.Assert(perr, IsNil)
+	err = writeConfig(config)
+	c.Assert(err, IsNil)
 
-	perr = createSessionDir()
-	c.Assert(perr, IsNil)
+	err = createSessionDir()
+	c.Assert(err, IsNil)
 
 	app = registerApp()
 }
@@ -105,21 +105,21 @@ func (s *TestSuite) TestGetNewClient(c *C) {
 }
 
 func (s *TestSuite) TestNewConfigV5(c *C) {
-	root, err := ioutil.TempDir(os.TempDir(), "mc-")
-	c.Assert(err, IsNil)
+	root, e := ioutil.TempDir(os.TempDir(), "mc-")
+	c.Assert(e, IsNil)
 	defer os.RemoveAll(root)
 
-	conf, perr := newConfig()
-	c.Assert(perr, IsNil)
+	conf, err := newConfig()
+	c.Assert(err, IsNil)
 	configFile := filepath.Join(root, "config.json")
-	perr = conf.Save(configFile)
-	c.Assert(perr, IsNil)
+	err = conf.Save(configFile)
+	c.Assert(err, IsNil)
 
 	confNew := newConfigV5()
-	config, perr := quick.New(confNew)
-	c.Assert(perr, IsNil)
-	perr = config.Load(configFile)
-	c.Assert(perr, IsNil)
+	config, err := quick.New(confNew)
+	c.Assert(err, IsNil)
+	err = config.Load(configFile)
+	c.Assert(err, IsNil)
 	data := config.Data().(*configV5)
 
 	type aliases struct {

--- a/session_test.go
+++ b/session_test.go
@@ -32,59 +32,59 @@ func (s *TestSuite) TestValidSessionID(c *C) {
 }
 
 func (s *TestSuite) TestSession(c *C) {
-	perr := createSessionDir()
-	c.Assert(perr, IsNil)
+	err := createSessionDir()
+	c.Assert(err, IsNil)
 	c.Assert(isSessionDirExists(), Equals, true)
 
 	session := newSessionV2()
 	c.Assert(session.Header.CommandArgs, IsNil)
 	c.Assert(len(session.SessionID), Equals, 8)
 
-	perr = session.Close()
-	c.Assert(perr, IsNil)
+	err = session.Close()
+	c.Assert(err, IsNil)
 
-	savedSession, perr := loadSessionV2(session.SessionID)
-	c.Assert(perr, IsNil)
+	savedSession, err := loadSessionV2(session.SessionID)
+	c.Assert(err, IsNil)
 	c.Assert(session.SessionID, Equals, savedSession.SessionID)
 
-	perr = savedSession.Close()
-	c.Assert(perr, IsNil)
+	err = savedSession.Close()
+	c.Assert(err, IsNil)
 
-	perr = savedSession.Delete()
-	c.Assert(perr, IsNil)
+	err = savedSession.Delete()
+	c.Assert(err, IsNil)
 }
 
 func (s *TestSuite) TestSessionContext(c *C) {
-	err := app.Run([]string{os.Args[0], "session", "list"})
-	c.Assert(err, IsNil)
+	e := app.Run([]string{os.Args[0], "session", "list"})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsExited, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "session", "clear", "all"})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "session", "clear", "all"})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsExited, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "session", "resume", "invalid"})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "session", "resume", "invalid"})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsExited, Equals, true)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "session", "clear", "invalid"})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "session", "clear", "invalid"})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsExited, Equals, true)
 
 	// reset back
 	console.IsExited = false
 
-	perr := createSessionDir()
-	c.Assert(perr, IsNil)
+	err := createSessionDir()
+	c.Assert(err, IsNil)
 	c.Assert(isSessionDirExists(), Equals, true)
 
 	// reset back
@@ -94,13 +94,13 @@ func (s *TestSuite) TestSessionContext(c *C) {
 	c.Assert(session.Header.CommandArgs, IsNil)
 	c.Assert(len(session.SessionID), Equals, 8)
 
-	perr = session.Save()
-	c.Assert(perr, IsNil)
+	err = session.Save()
+	c.Assert(err, IsNil)
 
 	c.Assert(session.Close(), IsNil)
 
-	err = app.Run([]string{os.Args[0], "session", "clear", session.SessionID})
-	c.Assert(err, IsNil)
+	e = app.Run([]string{os.Args[0], "session", "clear", session.SessionID})
+	c.Assert(e, IsNil)
 	c.Assert(console.IsExited, Equals, false)
 
 	// reset back


### PR DESCRIPTION
use 'e' for golang's native 'error' and err for probe.Error.