### PR TITLE
copy: Fix copyURLsTypeC style of copying with or without separator.

### DIFF
--- a/cp-url.go
+++ b/cp-url.go
@@ -304,7 +304,8 @@ func prepareCopyURLsTypeC(sourceURL, targetURL string) <-chan copyURLs {
 
 			// All OK.. We can proceed. Type B: source is a file, target is a folder and exists.
 			newTargetURL := client.NewURL(targetURL)
-			newTargetURL.Path = filepath.Join(newTargetURL.Path, sourceContent.Content.URL.Path)
+			newTargetURL.Path = filepath.Join(newTargetURL.Path,
+				strings.TrimPrefix(sourceContent.Content.URL.Path, url2Dir(sourceURL)))
 			copyURLsCh <- prepareCopyURLsTypeA(sourceContent.Content.URL.String(), newTargetURL.String())
 		}
 	}(sourceURL, targetURL, copyURLsCh)

--- a/ls-main.go
+++ b/ls-main.go
@@ -140,7 +140,7 @@ func mainList(ctx *cli.Context) {
 			clnt, err = url2Client(stripRecursiveURL(targetURL))
 			fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
 
-			err = doListIncomplete(clnt, isURLRecursive(targetURL), len(targetURLs) > 1)
+			err = doListIncomplete(clnt, isURLRecursive(targetURL))
 			fatalIf(err.Trace(clnt.GetURL().String()), "Unable to list target ‘"+clnt.GetURL().String()+"’.")
 		}
 	} else {
@@ -152,7 +152,7 @@ func mainList(ctx *cli.Context) {
 			clnt, err = url2Client(stripRecursiveURL(targetURL))
 			fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
 
-			err = doList(clnt, isURLRecursive(targetURL), len(targetURLs) > 1)
+			err = doList(clnt, isURLRecursive(targetURL))
 			fatalIf(err.Trace(clnt.GetURL().String()), "Unable to list target ‘"+clnt.GetURL().String()+"’.")
 		}
 	}

--- a/ls.go
+++ b/ls.go
@@ -140,7 +140,7 @@ func trimContent(parentContent, childContent *client.Content, recursive bool) *c
 }
 
 // doList - list all entities inside a folder.
-func doList(clnt client.Client, recursive, multipleArgs bool) *probe.Error {
+func doList(clnt client.Client, recursive bool) *probe.Error {
 	var err *probe.Error
 	var parentContent *client.Content
 	_, parentContent, err = url2Stat(clnt.GetURL().String())
@@ -187,7 +187,7 @@ func doList(clnt client.Client, recursive, multipleArgs bool) *probe.Error {
 }
 
 // doListIncomplete - list all incomplete uploads entities inside a folder.
-func doListIncomplete(clnt client.Client, recursive, multipleArgs bool) *probe.Error {
+func doListIncomplete(clnt client.Client, recursive bool) *probe.Error {
 	var err *probe.Error
 	var parentContent *client.Content
 	_, parentContent, err = url2Stat(clnt.GetURL().String())

--- a/mirror-url.go
+++ b/mirror-url.go
@@ -106,11 +106,9 @@ func getContent(ch <-chan client.ContentOnChannel) (c *client.Content) {
 			// ignore directories
 			continue
 		}
-
 		c = rv.Content
 		break
 	}
-
 	return
 }
 
@@ -142,6 +140,7 @@ func deltaSourceTargets(sourceURL string, targetURLs []string, mirrorURLsCh chan
 	if strings.HasSuffix(newSourceURL, "/") == false {
 		newSourceURL = newSourceURL + "/"
 	}
+
 	sourceClient, err := url2Client(newSourceURL)
 	if err != nil {
 		mirrorURLsCh <- mirrorURLs{Error: err.Trace(sourceURL)}

--- a/url.go
+++ b/url.go
@@ -29,6 +29,20 @@ const (
 	recursiveSeparator = "..."
 )
 
+// just like filepath.Dir but always has a trailing url.Seperator
+func url2Dir(urlStr string) string {
+	url := client.NewURL(urlStr)
+	if strings.HasSuffix(urlStr, string(url.Separator)) {
+		return urlStr
+	}
+	lastIndex := strings.LastIndex(urlStr, string(url.Separator))
+	dirname := urlStr[:lastIndex+1]
+	if dirname == "" {
+		return "."
+	}
+	return dirname
+}
+
 // urlJoinPath Join a path to existing URL.
 func urlJoinPath(url1, url2 string) string {
 	u1 := client.NewURL(url1)


### PR DESCRIPTION
- `mc cp pkg... test` copies all `pkg` including itself
- `mc cp pkg/... test` copies all content inside `pkg` excluding `pkg`