### PR TITLE
mirror: Fix handling of preceding separators from source

### DIFF
--- a/mirror-url.go
+++ b/mirror-url.go
@@ -126,11 +126,11 @@ func getTargetContent(srcContent *client.Content, targetContent *client.Content,
 	for ; c != nil; c = getContent(targetCh) {
 		// Remove prefix so that we can properly validate.
 		targetURL := strings.TrimPrefix(c.URL.Path, targetClnt.GetURL().Path)
-		if srcContent.URL.Path <= targetURL {
+		sourceURL := strings.TrimPrefix(srcContent.URL.Path, string(srcContent.URL.Separator))
+		if sourceURL <= targetURL {
 			break
 		}
 	}
-
 	return
 }
 

--- a/pkg/client/fs/fs.go
+++ b/pkg/client/fs/fs.go
@@ -472,7 +472,7 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan client.ContentOnChannel
 				return err
 			}
 		}
-		if fi.Mode().IsRegular() || fi.Mode().IsDir() {
+		if fi.Mode().IsRegular() {
 			content := &client.Content{
 				URL:  *client.NewURL(fp),
 				Time: fi.ModTime(),

--- a/pkg/client/fs/fs_test.go
+++ b/pkg/client/fs/fs_test.go
@@ -117,21 +117,16 @@ func (s *MySuite) TestList(c *C) {
 	}
 
 	c.Assert(err, IsNil)
-	c.Assert(len(contents), Equals, 5)
+	c.Assert(len(contents), Equals, 3)
 
 	var regularFiles int
-	var folders int
 	for _, content := range contents {
 		if content.Type.IsRegular() {
 			regularFiles++
 			continue
 		}
-		if content.Type.IsDir() {
-			folders++
-		}
 	}
 	c.Assert(regularFiles, Equals, 3)
-	c.Assert(folders, Equals, 2)
 }
 
 func (s *MySuite) TestPutBucket(c *C) {


### PR DESCRIPTION
Filesystem now never replies back directories for recursive usecase.