### PR TITLE
s3/gcs: now all combinations and permutations work for URLs with buck…

### DIFF
--- a/common-methods.go
+++ b/common-methods.go
@@ -196,12 +196,3 @@ func url2Client(url string) (client.Client, *probe.Error) {
 	}
 	return client, nil
 }
-
-// bucketExists returns error
-func bucketExists(URL string) *probe.Error {
-	_, _, err := url2Stat(URL)
-	if err != nil {
-		return err.Trace()
-	}
-	return nil
-}

--- a/cp-url.go
+++ b/cp-url.go
@@ -80,11 +80,6 @@ func checkCopySyntax(ctx *cli.Context) {
 		if url.Path == string(url.Separator) {
 			fatalIf(errInvalidArgument().Trace(), fmt.Sprintf("Target ‘%s’ does not contain bucket name.", tgtURL))
 		}
-		if strings.Count(url.Path, "/") < 2 {
-			if err := bucketExists(tgtURL); err != nil {
-				fatalIf(err.Trace(), fmt.Sprintf("Unable to stat target ‘%s’.", tgtURL))
-			}
-		}
 	}
 	switch guessCopyURLType(srcURLs, tgtURL) {
 	case copyURLsTypeA: // File -> File.

--- a/vendor/github.com/minio/minio-go/request-common.go
+++ b/vendor/github.com/minio/minio-go/request-common.go
@@ -157,7 +157,7 @@ func getURLEncodedPath(pathName string) string {
 func (op *operation) getRequestURL(config Config) (url string) {
 	// parse URL for the combination of HTTPServer + HTTPPath
 	url = op.HTTPServer + separator
-	if !config.isVirtualStyle {
+	if !config.isVirtualHostedStyle {
 		url += path2Bucket(op.HTTPPath)
 	}
 	objectName := getURLEncodedPath(path2Object(op.HTTPPath))

--- a/vendor/github.com/minio/minio-go/request-v2.go
+++ b/vendor/github.com/minio/minio-go/request-v2.go
@@ -44,7 +44,7 @@ func (r *Request) PreSignV2() (string, error) {
 	}
 	epochExpires := d.Unix() + r.expires
 	var path string
-	if r.config.isVirtualStyle {
+	if r.config.isVirtualHostedStyle {
 		for k, v := range regions {
 			if v == r.config.Region {
 				path = "/" + strings.TrimSuffix(r.req.URL.Host, "."+k)
@@ -215,7 +215,7 @@ var resourceList = []string{
 // 	  [ sub-resource, if present. For example "?acl", "?location", "?logging", or "?torrent"];
 func (r *Request) writeCanonicalizedResource(buf *bytes.Buffer) error {
 	requestURL := r.req.URL
-	if r.config.isVirtualStyle {
+	if r.config.isVirtualHostedStyle {
 		for k, v := range regions {
 			if v == r.config.Region {
 				path := "/" + strings.TrimSuffix(requestURL.Host, "."+k)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -29,8 +29,8 @@
 		},
 		{
 			"path": "github.com/minio/minio-go",
-			"revision": "75080104fbebe0e0ccf9c97a332eba0b2a447831",
-			"revisionTime": "2015-11-12T14:56:32-08:00"
+			"revision": "11d470378cca55f1f2b67860f21a0d6ee3a16b60",
+			"revisionTime": "2015-11-12T20:28:50-08:00"
 		},
 		{
 			"path": "github.com/minio/minio-xl/pkg/probe",


### PR DESCRIPTION
…ets in different regions.

 - <bucket>.s3.amazonaws.com with <bucket> in us-west-2 re-writes
   the URL to s3-us-west-2.amazonaws.com.
 - <bucket>.s3-us-west-2.amazonaws.com doesn't need and translation,
   call goes directly to s3-us-west-2.amazonaws.com