### PR TITLE
config: Remove support for glob URLs, simply rely on strings suffix matching

### DIFF
--- a/config-host-main.go
+++ b/config-host-main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -216,8 +215,8 @@ func isValidAccessKey(accessKeyID string) bool {
 }
 
 // addHost - add new host
-func addHost(hostGlob, accessKeyID, secretAccessKey, api string) {
-	if strings.TrimSpace(hostGlob) == "" {
+func addHost(newHost, accessKeyID, secretAccessKey, api string) {
+	if strings.TrimSpace(newHost) == "" {
 		fatalIf(errDummy().Trace(), "Unable to proceed, empty arguments provided.")
 	}
 	if len(accessKeyID) != 0 {
@@ -244,19 +243,15 @@ func addHost(hostGlob, accessKeyID, secretAccessKey, api string) {
 	fatalIf(err.Trace(configPath), "Unable to load config path")
 
 	newConf := config.Data().(*configV6)
-	for globURL := range newConf.Hosts {
-		match, err := filepath.Match(globURL, hostGlob)
-		if err != nil {
-			fatalIf(errInvalidGlobURL(globURL, hostGlob).Trace(), "Unable to match.")
-		}
-		if match {
-			newConf.Hosts[globURL] = hostConfig{
+	for savedHost := range newConf.Hosts {
+		if savedHost == newHost {
+			newConf.Hosts[savedHost] = hostConfig{
 				AccessKeyID:     accessKeyID,
 				SecretAccessKey: secretAccessKey,
 				API:             api,
 			}
 		} else {
-			newConf.Hosts[hostGlob] = hostConfig{
+			newConf.Hosts[newHost] = hostConfig{
 				AccessKeyID:     accessKeyID,
 				SecretAccessKey: secretAccessKey,
 				API:             api,
@@ -268,11 +263,11 @@ func addHost(hostGlob, accessKeyID, secretAccessKey, api string) {
 	fatalIf(err.Trace(globalMCConfigVersion), "Failed to initialize ‘quick’ configuration data structure.")
 
 	err = writeConfig(newConfig)
-	fatalIf(err.Trace(hostGlob), "Unable to save host glob ‘"+hostGlob+"’.")
+	fatalIf(err.Trace(newHost), "Unable to save new host ‘"+newHost+"’.")
 
 	printMsg(hostMessage{
 		op:              "add",
-		Host:            hostGlob,
+		Host:            newHost,
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
 		API:             api,

--- a/config.go
+++ b/config.go
@@ -213,12 +213,11 @@ func newConfigV6() *configV6 {
 	}
 
 	conf.Hosts[globalExampleHostURL] = exampleHostConf
-	conf.Hosts["localhost:*"] = localHostConfig
-	conf.Hosts["127.0.0.1:*"] = localHostConfig
+	conf.Hosts["localhost:9000"] = localHostConfig
 	conf.Hosts["dl.minio.io:9000"] = dlHostConfig
-	conf.Hosts["*s3*amazonaws.com"] = s3HostConf
+	conf.Hosts["s3.amazonaws.com"] = s3HostConf
 	conf.Hosts["play.minio.io:9000"] = playHostConfig
-	conf.Hosts["*storage.googleapis.com"] = googlHostConf
+	conf.Hosts["storage.googleapis.com"] = googlHostConf
 
 	aliases := make(map[string]string)
 	aliases["s3"] = "https://s3.amazonaws.com"

--- a/hostconfig.go
+++ b/hostconfig.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	"path/filepath"
+	"strings"
 
 	"github.com/minio/mc/pkg/client"
 	"github.com/minio/minio-xl/pkg/probe"
@@ -48,12 +48,8 @@ func getHostConfig(URL string) (hostConfig, *probe.Error) {
 	if _, ok := config.Hosts[url.Host]; ok {
 		return config.Hosts[url.Host], nil
 	}
-	for globURL, hostCfg := range config.Hosts {
-		match, err := filepath.Match(globURL, url.Host)
-		if err != nil {
-			return hostConfig{}, errInvalidGlobURL(globURL, URL).Trace()
-		}
-		if match {
+	for savedURL, hostCfg := range config.Hosts {
+		if strings.HasSuffix(url.Host, savedURL) {
 			return hostCfg, nil
 		}
 	}

--- a/mc_test.go
+++ b/mc_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -28,6 +29,7 @@ import (
 	"net/http/httptest"
 
 	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/client"
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio-xl/pkg/quick"
 	. "gopkg.in/check.v1"
@@ -69,12 +71,14 @@ func (s *TestSuite) SetUpSuite(c *C) {
 	config, err := newConfig()
 	c.Assert(err, IsNil)
 
-	config.Data().(*configV6).Hosts["127.0.0.1:*"] = hostConfig{
+	url := client.NewURL(server.URL)
+	config.Data().(*configV6).Hosts[url.Host] = hostConfig{
 		AccessKeyID:     "WLGDGYAQYIGI833EV05A",
 		SecretAccessKey: "BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF",
 		API:             "S3v4",
 	}
 
+	fmt.Println(config.Data().(*configV6).Hosts)
 	err = writeConfig(config)
 	c.Assert(err, IsNil)
 
@@ -148,12 +152,11 @@ func (s *TestSuite) TestNewConfigV6(c *C) {
 	}
 
 	wantHosts := []string{
-		"localhost:*",
-		"127.0.0.1:*",
+		"localhost:9000",
 		"play.minio.io:9000",
 		"dl.minio.io:9000",
-		"*s3*amazonaws.com",
-		"*storage.googleapis.com",
+		"s3.amazonaws.com",
+		"storage.googleapis.com",
 	}
 	for _, host := range wantHosts {
 		_, ok := data.Hosts[host]

--- a/typed-errors.go
+++ b/typed-errors.go
@@ -35,10 +35,6 @@ var (
 		return probe.NewError(errors.New("Source argument list is empty.")).Untrace()
 	}
 
-	errInvalidGlobURL = func(glob, request string) *probe.Error {
-		return probe.NewError(errors.New("Error reading glob URL ‘" + glob + "’ while comparing with ‘" + request + "’.")).Untrace()
-	}
-
 	errNoMatchingHost = func(URL string) *probe.Error {
 		return probe.NewError(errors.New("No matching host found for the given URL ‘" + URL + "’.")).Untrace()
 	}


### PR DESCRIPTION
Fixes #1382 