### PR TITLE
config: Extensive changes to config and host handling

### DIFF
--- a/access-main.go
+++ b/access-main.go
@@ -160,14 +160,15 @@ func mainAccess(ctx *cli.Context) {
 
 	// Additional command speific theme customization.
 	console.SetColor("Access", color.New(color.FgGreen, color.Bold))
-	config := mustGetMcConfig()
 
 	switch ctx.Args().First() {
 	case "set":
 		perms := accessPerms(ctx.Args().Tail().First())
-		for _, arg := range ctx.Args().Tail().Tail() {
-			targetURL := getAliasURL(arg, config.Aliases)
 
+		URLs, err := args2URLs(ctx.Args().Tail().Tail())
+		fatalIf(err.Trace(ctx.Args().Tail().Tail()...), "Unable to convert args 2 URLs.")
+
+		for _, targetURL := range URLs {
 			err := doSetAccess(targetURL, perms)
 			// Upon error, print and continue.
 			if err != nil {
@@ -183,8 +184,10 @@ func mainAccess(ctx *cli.Context) {
 			})
 		}
 	case "get":
-		for _, arg := range ctx.Args().Tail() {
-			targetURL := getAliasURL(arg, config.Aliases)
+		URLs, err := args2URLs(ctx.Args().Tail())
+		fatalIf(err.Trace(ctx.Args().Tail()...), "Unable to convert args 2 URLs.")
+
+		for _, targetURL := range URLs {
 			perms, err := doGetAccess(targetURL)
 			if err != nil {
 				errorIf(err.Trace(targetURL), "Unable to get access permission for ‘"+targetURL+"’.")

--- a/common_methods_test.go
+++ b/common_methods_test.go
@@ -71,10 +71,4 @@ func (s *TestSuite) TestCommonMethods(c *C) {
 
 	_, err = url2Client(objectPathServer)
 	c.Assert(err, IsNil)
-
-	_, err = url2Client("http://test.minio.io" + "/bucket/fail")
-	c.Assert(err, Not(IsNil))
-
-	_, err = url2Client("http://test.minio.io" + "/bucket/fail")
-	c.Assert(err, Not(IsNil))
 }

--- a/config_test.go
+++ b/config_test.go
@@ -63,7 +63,7 @@ func (s *TestSuite) TestConfigHostContext(c *C) {
 		"config",
 		"host",
 		"add",
-		"*my-example.com",
+		"http://my-example.com",
 		"AKIKJAA5BMMU2RHO6IBB",
 		"V7f1CCwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr9",
 		"S3v2",
@@ -74,14 +74,14 @@ func (s *TestSuite) TestConfigHostContext(c *C) {
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "config", "host", "remove", "*my-example.com"})
+	err = app.Run([]string{os.Args[0], "config", "host", "remove", "http://my-example.com"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsExited, Equals, false)
 
 	// reset back
 	console.IsExited = false
 
-	err = app.Run([]string{os.Args[0], "config", "host", "remove", "dl.minio.io:9000"})
+	err = app.Run([]string{os.Args[0], "config", "host", "remove", "http://dl.minio.io:9000"})
 	c.Assert(err, IsNil)
 	c.Assert(console.IsExited, Equals, true)
 

--- a/diff-main.go
+++ b/diff-main.go
@@ -177,26 +177,25 @@ func mainDiff(ctx *cli.Context) {
 	console.SetColor("DiffType", color.New(color.FgYellow, color.Bold))
 	console.SetColor("DiffSize", color.New(color.FgMagenta, color.Bold))
 
-	config := mustGetMcConfig()
-	firstArg := ctx.Args().First()
-	secondArg := ctx.Args().Last()
+	URLs, err := args2URLs(ctx.Args())
+	fatalIf(err.Trace(ctx.Args()...), "Unable to convert args 2 URLs")
 
-	firstURL := getAliasURL(firstArg, config.Aliases)
-	secondURL := getAliasURL(secondArg, config.Aliases)
+	firstURL := URLs[0]
+	secondURL := URLs[1]
 
 	_, firstContent, err := url2Stat(firstURL)
 	if err != nil {
-		fatalIf(err.Trace(), fmt.Sprintf("Unable to stat '%s'.", firstURL))
+		fatalIf(err.Trace(firstURL), fmt.Sprintf("Unable to stat '%s'.", firstURL))
 	}
 	if !firstContent.Type.IsDir() {
-		fatalIf(errInvalidArgument().Trace(), fmt.Sprintf("‘%s’ is not a folder.", firstURL))
+		fatalIf(errInvalidArgument().Trace(firstURL), fmt.Sprintf("‘%s’ is not a folder.", firstURL))
 	}
 	_, secondContent, err := url2Stat(secondURL)
 	if err != nil {
-		fatalIf(err.Trace(), fmt.Sprintf("Unable to stat '%s'.", secondURL))
+		fatalIf(err.Trace(secondURL), fmt.Sprintf("Unable to stat '%s'.", secondURL))
 	}
 	if !secondContent.Type.IsDir() {
-		fatalIf(errInvalidArgument().Trace(), fmt.Sprintf("‘%s’ is not a folder.", secondURL))
+		fatalIf(errInvalidArgument().Trace(secondURL), fmt.Sprintf("‘%s’ is not a folder.", secondURL))
 	}
 	doDiffMain(firstURL, secondURL)
 }

--- a/hostconfig.go
+++ b/hostconfig.go
@@ -47,12 +47,13 @@ func getHostConfig(URL string) (hostConfig, *probe.Error) {
 		return hostCfg, nil
 	}
 	// if host is exact return quickly.
-	if _, ok := config.Hosts[url.Host]; ok {
-		return config.Hosts[url.Host], nil
+	if _, ok := config.Hosts[url.String()]; ok {
+		return config.Hosts[url.String()], nil
 	}
 	// if host matches a suffix return.
-	for savedURL, hostCfg := range config.Hosts {
-		if strings.HasSuffix(url.Host, savedURL) {
+	for savedURLStr, hostCfg := range config.Hosts {
+		savedURL := client.NewURL(savedURLStr)
+		if strings.HasSuffix(url.Host, savedURL.Host) {
 			return hostCfg, nil
 		}
 	}

--- a/mb-main.go
+++ b/mb-main.go
@@ -98,10 +98,10 @@ func mainMakeBucket(ctx *cli.Context) {
 	// Additional command speific theme customization.
 	console.SetColor("MakeBucket", color.New(color.FgGreen, color.Bold))
 
-	config := mustGetMcConfig()
-	for _, arg := range ctx.Args() {
-		targetURL := getAliasURL(arg, config.Aliases)
+	URLs, err := args2URLs(ctx.Args())
+	fatalIf(err.Trace(ctx.Args()...), "Unable to convert args to URLs.")
 
+	for _, targetURL := range URLs {
 		// Instantiate client for URL.
 		clnt, err := url2Client(targetURL)
 		fatalIf(err.Trace(targetURL), "Invalid target ‘"+targetURL+"’.")

--- a/url.go
+++ b/url.go
@@ -55,15 +55,14 @@ func stripRecursiveURL(urlStr string) string {
 
 // args2URLs extracts source and target URLs from command-line args.
 func args2URLs(args []string) ([]string, *probe.Error) {
-	config, err := getMcConfig()
-	if err != nil {
-		return nil, err.Trace()
-
-	}
 	// Convert arguments to URLs: expand alias, fix format...
 	URLs := []string{}
 	for _, arg := range args {
-		URLs = append(URLs, getAliasURL(arg, config.Aliases))
+		aliasedURL, err := getAliasURL(arg)
+		if err != nil {
+			return nil, err.Trace(arg)
+		}
+		URLs = append(URLs, aliasedURL)
 	}
 	return URLs, nil
 }


### PR DESCRIPTION
 - alias now expands for all match aliases and also any matching hosts.
   Example:-  mc ls -r s3.amazonaws.com/ferenginar/bin

 - not globs, no hosts - only fully qualified URLs are stored in config.
 - everywhere use 'args2URLs()' getAliasURL should be used internally.