### PR TITLE
set globals from context from each command main

### DIFF
--- a/access-main.go
+++ b/access-main.go
@@ -161,6 +161,9 @@ func mainAccess(ctx *cli.Context) {
 	// Additional command speific theme customization.
 	console.SetColor("Access", color.New(color.FgGreen, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	switch ctx.Args().First() {
 	case "set":
 		perms := accessPerms(ctx.Args().Tail().First())

--- a/cat-main.go
+++ b/cat-main.go
@@ -123,6 +123,10 @@ func catOut(r io.Reader) *probe.Error {
 func mainCat(ctx *cli.Context) {
 	checkCatSyntax(ctx)
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// Set command flags from context.
 	stdinMode := false
 	if !ctx.Args().Present() {
 		stdinMode = true

--- a/config-alias-main.go
+++ b/config-alias-main.go
@@ -165,30 +165,6 @@ func checkConfigAliasSyntax(ctx *cli.Context) {
 	}
 }
 
-func mainConfigAlias(ctx *cli.Context) {
-	checkConfigAliasSyntax(ctx)
-
-	// Additional customization speific to each command.
-	console.SetColor("Alias", color.New(color.FgCyan, color.Bold))
-	console.SetColor("AliasMessage", color.New(color.FgGreen, color.Bold))
-	console.SetColor("URL", color.New(color.FgWhite, color.Bold))
-
-	arg := ctx.Args().First()
-	tailArgs := ctx.Args().Tail()
-
-	switch strings.TrimSpace(arg) {
-	case "add":
-		aliasName := tailArgs.Get(0)
-		aliasedURL := tailArgs.Get(1)
-		addAlias(aliasName, aliasedURL) // add alias name for aliased URL.
-	case "remove":
-		aliasName := tailArgs.Get(0)
-		removeAlias(aliasName) // remove alias name.
-	case "list":
-		listAliases() // list all aliases.
-	}
-}
-
 // addAlias - adds an alias entry.
 func addAlias(aliasName, aliasedURL string) {
 	conf, err := loadMcConfig()
@@ -222,5 +198,32 @@ func listAliases() {
 
 	for aliasName, aliasedURL := range conf.Aliases {
 		printMsg(aliasMessage{op: "list", Alias: aliasName, URL: aliasedURL})
+	}
+}
+
+func mainConfigAlias(ctx *cli.Context) {
+	checkConfigAliasSyntax(ctx)
+
+	// Additional customization speific to each command.
+	console.SetColor("Alias", color.New(color.FgCyan, color.Bold))
+	console.SetColor("AliasMessage", color.New(color.FgGreen, color.Bold))
+	console.SetColor("URL", color.New(color.FgWhite, color.Bold))
+
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	arg := ctx.Args().First()
+	tailArgs := ctx.Args().Tail()
+
+	switch strings.TrimSpace(arg) {
+	case "add":
+		aliasName := tailArgs.Get(0)
+		aliasedURL := tailArgs.Get(1)
+		addAlias(aliasName, aliasedURL) // add alias name for aliased URL.
+	case "remove":
+		aliasName := tailArgs.Get(0)
+		removeAlias(aliasName) // remove alias name.
+	case "list":
+		listAliases() // list all aliases.
 	}
 }

--- a/config-host-main.go
+++ b/config-host-main.go
@@ -223,6 +223,9 @@ func mainConfigHost(ctx *cli.Context) {
 	console.SetColor("AccessKeyID", color.New(color.FgBlue, color.Bold))
 	console.SetColor("SecretAccessKey", color.New(color.FgRed, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	arg := ctx.Args().First()
 	tailArgs := ctx.Args().Tail()
 

--- a/config-main.go
+++ b/config-main.go
@@ -63,6 +63,9 @@ COMMANDS:
 
 // mainConfig is the handle for "mc config" command. provides sub-commands which write configuration data in json format to config file.
 func mainConfig(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())
 	} else {

--- a/config-version-main.go
+++ b/config-version-main.go
@@ -51,6 +51,9 @@ func mainConfigVersion(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "version", 1) // last argument is exit code
 	}
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	config, err := loadMcConfig()
 	fatalIf(err.Trace(), "Unable to load config version ‘"+globalMCConfigVersion+"’.")
 

--- a/cp-main.go
+++ b/cp-main.go
@@ -385,6 +385,9 @@ func mainCopy(ctx *cli.Context) {
 	// Additional command speific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	session := newSessionV5()
 	session.Header.CommandType = "cp"
 	session.Header.CommandBoolFlags["recursive"] = ctx.Bool("recursive")

--- a/diff-main.go
+++ b/diff-main.go
@@ -178,6 +178,9 @@ func mainDiff(ctx *cli.Context) {
 	console.SetColor("DiffType", color.New(color.FgYellow, color.Bold))
 	console.SetColor("DiffSize", color.New(color.FgMagenta, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	URLs, err := args2URLs(ctx.Args())
 	fatalIf(err.Trace(ctx.Args()...), "Unable to convert args 2 URLs")
 

--- a/globals.go
+++ b/globals.go
@@ -17,7 +17,10 @@
 // This package contains all the global variables and constants. ONLY TO BE ACCESSED VIA GET/SET FUNCTIONS.
 package main
 
-import "github.com/minio/mc/pkg/console"
+import (
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/console"
+)
 
 // mc configuration related constants.
 const (
@@ -65,4 +68,13 @@ func setGlobals(quiet, debug, json, noColor bool) {
 	if globalNoColor == true {
 		console.SetColorOff()
 	}
+}
+
+// Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
+func setGlobalsFromContext(ctx *cli.Context) {
+	quiet := ctx.Bool("quiet")
+	debug := ctx.Bool("debug")
+	json := ctx.Bool("json")
+	noColor := ctx.Bool("no-color")
+	setGlobals(quiet, debug, json, noColor)
 }

--- a/ls-main.go
+++ b/ls-main.go
@@ -112,10 +112,14 @@ func mainList(ctx *cli.Context) {
 	// check 'ls' cli arguments
 	checkListSyntax(ctx)
 
-	args := ctx.Args()
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// Set command flags from context.
 	isRecursive := ctx.Bool("recursive")
 	isIncomplete := ctx.Bool("incomplete")
 
+	args := ctx.Args()
 	// mimic operating system tool behavior
 	if !ctx.Args().Present() {
 		args = []string{"."}

--- a/mb-main.go
+++ b/mb-main.go
@@ -101,6 +101,9 @@ func mainMakeBucket(ctx *cli.Context) {
 	// Additional command speific theme customization.
 	console.SetColor("MakeBucket", color.New(color.FgGreen, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	URLs, err := args2URLs(ctx.Args())
 	fatalIf(err.Trace(ctx.Args()...), "Unable to convert args to URLs.")
 

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -378,7 +378,10 @@ func mainMirror(ctx *cli.Context) {
 		fatalIf(probe.NewError(e), "Unable to get current working folder.")
 	}
 
-	// If force flag is set save it with in session
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// Set command flags from context.
 	isForce := ctx.Bool("force")
 	session.Header.CommandBoolFlags["force"] = isForce
 

--- a/pipe-main.go
+++ b/pipe-main.go
@@ -85,6 +85,9 @@ func pipe(targetURLs []string) *probe.Error {
 
 // mainPipe is the main entry point for pipe command.
 func mainPipe(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	// extract URLs.
 	URLs, err := args2URLs(ctx.Args())
 	fatalIf(err.Trace(ctx.Args()...), "Unable to parse arguments.")

--- a/rm-main.go
+++ b/rm-main.go
@@ -107,6 +107,10 @@ func (r rmMessage) JSON() string {
 
 // Validate command line arguments.
 func checkRmSyntax(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// Set command flags from context.
 	isForce := ctx.Bool("force")
 	isRecursive := ctx.Bool("recursive")
 

--- a/session-main.go
+++ b/session-main.go
@@ -201,6 +201,9 @@ func mainSession(ctx *cli.Context) {
 	console.SetColor("SessionTime", color.New(color.FgGreen))
 	console.SetColor("ClearSession", color.New(color.FgGreen, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	if !isSessionDirExists() {
 		fatalIf(createSessionDir().Trace(), "Unable to create session folder.")
 	}

--- a/share-download-main.go
+++ b/share-download-main.go
@@ -161,7 +161,10 @@ func mainShareDownload(ctx *cli.Context) {
 	// check input arguments.
 	checkShareDownloadSyntax(ctx)
 
-	// Extract arguments.
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// Set command flags from context.
 	isRecursive := ctx.Bool("recursive")
 	expiry := shareDefaultExpiry
 	if ctx.String("expire") != "" {

--- a/share-list-main.go
+++ b/share-list-main.go
@@ -110,6 +110,9 @@ func mainShareList(ctx *cli.Context) {
 	// Additional command speific theme customization.
 	shareSetColor()
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	// Initialize share config folder.
 	initShareConfig()
 

--- a/share-main.go
+++ b/share-main.go
@@ -76,6 +76,9 @@ func migrateShare() {
 
 // mainShare - main handler for mc share command.
 func mainShare(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())
 	} else { // mc help.

--- a/share-upload-main.go
+++ b/share-upload-main.go
@@ -167,6 +167,10 @@ func mainShareUpload(ctx *cli.Context) {
 	// check input arguments.
 	checkShareUploadSyntax(ctx)
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// Set command flags from context.
 	isRecursive := ctx.Bool("recursive")
 	expireArg := ctx.String("expire")
 	expiry := shareDefaultExpiry

--- a/update-main.go
+++ b/update-main.go
@@ -168,6 +168,9 @@ func mainUpdate(ctx *cli.Context) {
 	// Additional command speific theme customization.
 	console.SetColor("Update", color.New(color.FgGreen, color.Bold))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	// Check for update.
 	if ctx.Bool("experimental") {
 		getReleaseUpdate(mcUpdateExperimentalURL)

--- a/version-main.go
+++ b/version-main.go
@@ -83,6 +83,9 @@ func mainVersion(ctx *cli.Context) {
 	console.SetColor("ReleaseTag", color.New(color.FgGreen))
 	console.SetColor("CommitID", color.New(color.FgGreen))
 
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	verMsg := versionMessage{}
 	verMsg.CommitID = mcCommitID
 	verMsg.ReleaseTag = mcReleaseTag


### PR DESCRIPTION
After moving global flags to command level flags, globals were not set explicitly by the commands. It is fixed in this patch.