### PR TITLE
mc: Fix setGlobalContext across all commands.

### DIFF
--- a/access-main.go
+++ b/access-main.go
@@ -156,13 +156,14 @@ func doGetAccess(targetURL string) (perms accessPerms, err *probe.Error) {
 }
 
 func mainAccess(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'access' cli arguments.
 	checkAccessSyntax(ctx)
 
 	// Additional command speific theme customization.
 	console.SetColor("Access", color.New(color.FgGreen, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	switch ctx.Args().First() {
 	case "set":

--- a/cat-main.go
+++ b/cat-main.go
@@ -121,10 +121,11 @@ func catOut(r io.Reader) *probe.Error {
 
 // mainCat is the main entry point for cat command.
 func mainCat(ctx *cli.Context) {
-	checkCatSyntax(ctx)
-
 	// Set global flags from context.
 	setGlobalsFromContext(ctx)
+
+	// check 'cat' cli arguments.
+	checkCatSyntax(ctx)
 
 	// Set command flags from context.
 	stdinMode := false

--- a/config-alias-main.go
+++ b/config-alias-main.go
@@ -202,15 +202,16 @@ func listAliases() {
 }
 
 func mainConfigAlias(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'config alias' cli arguments.
 	checkConfigAliasSyntax(ctx)
 
 	// Additional customization speific to each command.
 	console.SetColor("Alias", color.New(color.FgCyan, color.Bold))
 	console.SetColor("AliasMessage", color.New(color.FgGreen, color.Bold))
 	console.SetColor("URL", color.New(color.FgWhite, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	arg := ctx.Args().First()
 	tailArgs := ctx.Args().Tail()

--- a/config-host-main.go
+++ b/config-host-main.go
@@ -214,6 +214,10 @@ func checkConfigHostRemoveSyntax(ctx *cli.Context) {
 }
 
 func mainConfigHost(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'config host' cli arguments.
 	checkConfigHostSyntax(ctx)
 
 	// Additional command speific theme customization.
@@ -222,9 +226,6 @@ func mainConfigHost(ctx *cli.Context) {
 	console.SetColor("HostMessage", color.New(color.FgGreen, color.Bold))
 	console.SetColor("AccessKeyID", color.New(color.FgBlue, color.Bold))
 	console.SetColor("SecretAccessKey", color.New(color.FgRed, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	arg := ctx.Args().First()
 	tailArgs := ctx.Args().Tail()

--- a/config-main.go
+++ b/config-main.go
@@ -73,5 +73,5 @@ func mainConfig(ctx *cli.Context) {
 		cli.ShowAppHelp(ctx)
 	}
 
-	// sub-commands like "upload" and "download" have their own main.
+	// Sub-commands like "host" and "alias" have their own main.
 }

--- a/config-version-main.go
+++ b/config-version-main.go
@@ -42,15 +42,10 @@ var configVersionCmd = cli.Command{
 
 USAGE:
    mc config {{.Name}}
-
 `,
 }
 
 func mainConfigVersion(ctx *cli.Context) {
-	if ctx.Args().First() == "help" {
-		cli.ShowCommandHelpAndExit(ctx, "version", 1) // last argument is exit code
-	}
-
 	// Set global flags from context.
 	setGlobalsFromContext(ctx)
 

--- a/cp-main.go
+++ b/cp-main.go
@@ -380,13 +380,14 @@ func doCopySession(session *sessionV5) {
 
 // mainCopy is the entry point for cp command.
 func mainCopy(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'copy' cli arguments.
 	checkCopySyntax(ctx)
 
 	// Additional command speific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	session := newSessionV5()
 	session.Header.CommandType = "cp"

--- a/diff-main.go
+++ b/diff-main.go
@@ -170,6 +170,10 @@ func doDiffMain(firstURL, secondURL string) {
 
 // mainDiff main for 'diff'.
 func mainDiff(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'diff' cli arguments.
 	checkDiffSyntax(ctx)
 
 	// Additional command specific theme customization.
@@ -177,9 +181,6 @@ func mainDiff(ctx *cli.Context) {
 	console.SetColor("DiffOnlyInFirst", color.New(color.FgRed, color.Bold))
 	console.SetColor("DiffType", color.New(color.FgYellow, color.Bold))
 	console.SetColor("DiffSize", color.New(color.FgMagenta, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	URLs, err := args2URLs(ctx.Args())
 	fatalIf(err.Trace(ctx.Args()...), "Unable to convert args 2 URLs")

--- a/ls-main.go
+++ b/ls-main.go
@@ -109,18 +109,18 @@ func mainList(ctx *cli.Context) {
 	console.SetColor("Size", color.New(color.FgYellow))
 	console.SetColor("Time", color.New(color.FgGreen))
 
-	// check 'ls' cli arguments
-	checkListSyntax(ctx)
-
 	// Set global flags from context.
 	setGlobalsFromContext(ctx)
+
+	// check 'ls' cli arguments.
+	checkListSyntax(ctx)
 
 	// Set command flags from context.
 	isRecursive := ctx.Bool("recursive")
 	isIncomplete := ctx.Bool("incomplete")
 
 	args := ctx.Args()
-	// mimic operating system tool behavior
+	// mimic operating system tool behavior.
 	if !ctx.Args().Present() {
 		args = []string{"."}
 	}

--- a/main.go
+++ b/main.go
@@ -170,7 +170,6 @@ func main() {
 		if _, e := ts.GetSize(); e != nil {
 			globalQuiet = true
 		}
-
 		if globalDebug {
 			return getSystemData()
 		}

--- a/mb-main.go
+++ b/mb-main.go
@@ -96,13 +96,14 @@ func checkMakeBucketSyntax(ctx *cli.Context) {
 
 // mainMakeBucket is entry point for mb command.
 func mainMakeBucket(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'mb' cli arguments.
 	checkMakeBucketSyntax(ctx)
 
 	// Additional command speific theme customization.
 	console.SetColor("MakeBucket", color.New(color.FgGreen, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	URLs, err := args2URLs(ctx.Args())
 	fatalIf(err.Trace(ctx.Args()...), "Unable to convert args to URLs.")

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -364,6 +364,10 @@ func doMirrorSession(session *sessionV5) {
 
 // Main entry point for mirror command.
 func mainMirror(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'mirror' cli arguments.
 	checkMirrorSyntax(ctx)
 
 	// Additional command speific theme customization.
@@ -377,9 +381,6 @@ func mainMirror(ctx *cli.Context) {
 		session.Delete()
 		fatalIf(probe.NewError(e), "Unable to get current working folder.")
 	}
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// Set command flags from context.
 	isForce := ctx.Bool("force")

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -66,18 +66,21 @@ var (
 	// Fatal print a error message and exit.
 	Fatal = func(data ...interface{}) {
 		consolePrint("Fatal", Theme["Fatal"], data...)
+		os.Exit(1)
 		return
 	}
 
 	// Fatalf print a error message with a format specified and exit.
 	Fatalf = func(format string, data ...interface{}) {
 		consolePrintf("Fatal", Theme["Fatal"], format, data...)
+		os.Exit(1)
 		return
 	}
 
 	// Fatalln print a error message with a new line and exit.
 	Fatalln = func(data ...interface{}) {
 		consolePrintln("Fatal", Theme["Fatal"], data...)
+		os.Exit(1)
 		return
 	}
 

--- a/rm-main.go
+++ b/rm-main.go
@@ -107,9 +107,6 @@ func (r rmMessage) JSON() string {
 
 // Validate command line arguments.
 func checkRmSyntax(ctx *cli.Context) {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
-
 	// Set command flags from context.
 	isForce := ctx.Bool("force")
 	isRecursive := ctx.Bool("recursive")
@@ -191,6 +188,10 @@ func rmAll(url string, isRecursive, isIncomplete, isFake bool) {
 
 // main for rm command.
 func mainRm(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'rm' cli arguments.
 	checkRmSyntax(ctx)
 
 	// rm specific flags.

--- a/session-main.go
+++ b/session-main.go
@@ -193,6 +193,10 @@ func findClosestSessions(session string) []string {
 }
 
 func mainSession(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check 'session' cli arguments.
 	checkSessionSyntax(ctx)
 
 	// Additional command speific theme customization.
@@ -200,9 +204,6 @@ func mainSession(ctx *cli.Context) {
 	console.SetColor("SessionID", color.New(color.FgYellow, color.Bold))
 	console.SetColor("SessionTime", color.New(color.FgGreen))
 	console.SetColor("ClearSession", color.New(color.FgGreen, color.Bold))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if !isSessionDirExists() {
 		fatalIf(createSessionDir().Trace(), "Unable to create session folder.")

--- a/share-download-main.go
+++ b/share-download-main.go
@@ -152,17 +152,17 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 
 // main for share download.
 func mainShareDownload(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check input arguments.
+	checkShareDownloadSyntax(ctx)
+
 	// Initialize share config folder.
 	initShareConfig()
 
 	// Additional command speific theme customization.
 	shareSetColor()
-
-	// check input arguments.
-	checkShareDownloadSyntax(ctx)
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// Set command flags from context.
 	isRecursive := ctx.Bool("recursive")

--- a/share-list-main.go
+++ b/share-list-main.go
@@ -104,14 +104,14 @@ func doShareList(cmd string) *probe.Error {
 
 // main entry point for share list.
 func mainShareList(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	// validate command-line args.
 	checkShareListSyntax(ctx)
 
 	// Additional command speific theme customization.
 	shareSetColor()
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// Initialize share config folder.
 	initShareConfig()

--- a/share-upload-main.go
+++ b/share-upload-main.go
@@ -158,17 +158,17 @@ func doShareUploadURL(objectURL string, recursive bool, expiry time.Duration, co
 
 // main for share upload command.
 func mainShareUpload(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
+	// check input arguments.
+	checkShareUploadSyntax(ctx)
+
 	// Initialize share config folder.
 	initShareConfig()
 
 	// Additional command speific theme customization.
 	shareSetColor()
-
-	// check input arguments.
-	checkShareUploadSyntax(ctx)
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// Set command flags from context.
 	isRecursive := ctx.Bool("recursive")

--- a/update-main.go
+++ b/update-main.go
@@ -165,11 +165,11 @@ func getReleaseUpdate(updateURL string) {
 
 // main entry point for update command.
 func mainUpdate(ctx *cli.Context) {
-	// Additional command speific theme customization.
-	console.SetColor("Update", color.New(color.FgGreen, color.Bold))
-
 	// Set global flags from context.
 	setGlobalsFromContext(ctx)
+
+	// Additional command speific theme customization.
+	console.SetColor("Update", color.New(color.FgGreen, color.Bold))
 
 	// Check for update.
 	if ctx.Bool("experimental") {

--- a/version-main.go
+++ b/version-main.go
@@ -78,13 +78,13 @@ func (v versionMessage) JSON() string {
 }
 
 func mainVersion(ctx *cli.Context) {
+	// Set global flags from context.
+	setGlobalsFromContext(ctx)
+
 	// Additional command speific theme customization.
 	console.SetColor("Version", color.New(color.FgGreen, color.Bold))
 	console.SetColor("ReleaseTag", color.New(color.FgGreen))
 	console.SetColor("CommitID", color.New(color.FgGreen))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	verMsg := versionMessage{}
 	verMsg.CommitID = mcCommitID


### PR DESCRIPTION
- Always set globals from context before validating input arguments.
- Add missing os.Exit(1) from console.Fatal{f,ln} which was
  accidentally removed from previous commits.

Fixes #1472