### PR TITLE
share/download: add --starts-with flag and remove '...' we don't have…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ NOTE:  Source installation is intended for only developers and advanced users. â
 If you do not have a working Golang environment, please follow [Install Golang](./INSTALLGO.md).
 
 ```sh
-$ go get -u github.com/minio/mc
+$ GO15VENDOREXPERIMENT=1 go get -u github.com/minio/mc
 ```
 
 ## Public Minio Server

--- a/pkg/client/fs/fs.go
+++ b/pkg/client/fs/fs.go
@@ -160,7 +160,7 @@ func (f *fsClient) ShareDownload(expires time.Duration) (string, *probe.Error) {
 }
 
 // ShareUpload - share upload not implemented for filesystem.
-func (f *fsClient) ShareUpload(recursive bool, expires time.Duration, contentType string) (map[string]string, *probe.Error) {
+func (f *fsClient) ShareUpload(startsWith bool, expires time.Duration, contentType string) (map[string]string, *probe.Error) {
 	return nil, probe.NewError(client.APINotImplemented{API: "ShareUpload", APIType: "filesystem"})
 }
 

--- a/pkg/client/s3/s3.go
+++ b/pkg/client/s3/s3.go
@@ -127,7 +127,7 @@ func (c *s3Client) ShareDownload(expires time.Duration) (string, *probe.Error) {
 }
 
 // ShareUpload - get data for presigned post http form upload.
-func (c *s3Client) ShareUpload(recursive bool, expires time.Duration, contentType string) (map[string]string, *probe.Error) {
+func (c *s3Client) ShareUpload(startsWith bool, expires time.Duration, contentType string) (map[string]string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	p := minio.NewPostPolicy()
 	if err := p.SetExpires(time.Now().UTC().Add(expires)); err != nil {
@@ -140,13 +140,15 @@ func (c *s3Client) ShareUpload(recursive bool, expires time.Duration, contentTyp
 	if err := p.SetBucket(bucket); err != nil {
 		return nil, probe.NewError(err)
 	}
-	if recursive {
-		if err := p.SetKeyStartsWith(object); err != nil {
-			return nil, probe.NewError(err)
-		}
-	} else {
-		if err := p.SetKey(object); err != nil {
-			return nil, probe.NewError(err)
+	if object != "" {
+		if startsWith {
+			if err := p.SetKeyStartsWith(object); err != nil {
+				return nil, probe.NewError(err)
+			}
+		} else {
+			if err := p.SetKey(object); err != nil {
+				return nil, probe.NewError(err)
+			}
 		}
 	}
 	m, err := c.api.PresignedPostPolicy(p)

--- a/share-download-main.go
+++ b/share-download-main.go
@@ -28,7 +28,7 @@ var (
 		Name:  "help, h",
 		Usage: "Help of share download",
 	}
-	shareFlagRecursive = cli.BoolFlag{
+	shareFlagDownloadRecursive = cli.BoolFlag{
 		Name:  "recursive, r",
 		Usage: "Share all objects recursively.",
 	}
@@ -39,7 +39,7 @@ var shareDownload = cli.Command{
 	Name:   "download",
 	Usage:  "Generate URLs for download access.",
 	Action: mainShareDownload,
-	Flags:  append(globalFlags, shareFlagRecursive, shareFlagExpire, shareFlagDownloadHelp),
+	Flags:  append(globalFlags, shareFlagExpire, shareFlagDownloadHelp, shareFlagDownloadRecursive),
 	CustomHelpTemplate: `NAME:
    mc share {{.Name}} - {{.Usage}}
 

--- a/share.go
+++ b/share.go
@@ -66,7 +66,7 @@ func (s shareMesssage) String() string {
 		msg += console.Colorize("Content-type", fmt.Sprintf("Content-Type: %s\n", s.ContentType))
 	}
 
-	// Highlight <FILE> specially. "share upload" sub-commands uses this identifier.
+	// Highlight <FILE> specifically. "share upload" sub-commands use this identifier.
 	shareURL := strings.Replace(s.ShareURL, "<FILE>", console.Colorize("File", "<FILE>"), 1)
 	msg += console.Colorize("Share", fmt.Sprintf("Share: %s\n", shareURL))
 


### PR DESCRIPTION
… that anymore.

- Fixes bug when prefix is available and should be prepended to the key.
- Fixes another bug to avoid doing URL stat for upload, its not needed.

Fixes #1478