### PR TITLE
share: Move to --recursive instead of --starts-with for consistency.

### DIFF
--- a/pkg/client/s3/s3.go
+++ b/pkg/client/s3/s3.go
@@ -127,7 +127,7 @@ func (c *s3Client) ShareDownload(expires time.Duration) (string, *probe.Error) {
 }
 
 // ShareUpload - get data for presigned post http form upload.
-func (c *s3Client) ShareUpload(startsWith bool, expires time.Duration, contentType string) (map[string]string, *probe.Error) {
+func (c *s3Client) ShareUpload(isRecursive bool, expires time.Duration, contentType string) (map[string]string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	p := minio.NewPostPolicy()
 	if err := p.SetExpires(time.Now().UTC().Add(expires)); err != nil {
@@ -140,15 +140,13 @@ func (c *s3Client) ShareUpload(startsWith bool, expires time.Duration, contentTy
 	if err := p.SetBucket(bucket); err != nil {
 		return nil, probe.NewError(err)
 	}
-	if object != "" {
-		if startsWith {
-			if err := p.SetKeyStartsWith(object); err != nil {
-				return nil, probe.NewError(err)
-			}
-		} else {
-			if err := p.SetKey(object); err != nil {
-				return nil, probe.NewError(err)
-			}
+	if isRecursive {
+		if err := p.SetKeyStartsWith(object); err != nil {
+			return nil, probe.NewError(err)
+		}
+	} else {
+		if err := p.SetKey(object); err != nil {
+			return nil, probe.NewError(err)
 		}
 	}
 	m, err := c.api.PresignedPostPolicy(p)

--- a/share.go
+++ b/share.go
@@ -68,6 +68,9 @@ func (s shareMesssage) String() string {
 
 	// Highlight <FILE> specifically. "share upload" sub-commands use this identifier.
 	shareURL := strings.Replace(s.ShareURL, "<FILE>", console.Colorize("File", "<FILE>"), 1)
+	// Highlight <KEY> specifically for recursive operation.
+	shareURL = strings.Replace(shareURL, "<NAME>", console.Colorize("File", "<NAME>"), 1)
+
 	msg += console.Colorize("Share", fmt.Sprintf("Share: %s\n", shareURL))
 
 	return msg


### PR DESCRIPTION
- if URL ends with "/" and no --recursive option exit properly.
- if recursive is given no matter what key is specified it is regarded
  as prefix.
- if no recursive option and no "/" suffix is provided is treated as
  exact object name.