### PR TITLE
Emphasize that subcommands have a help flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ var mcHelpTemplate = `NAME:
   {{.Name}} - {{.Usage}}
 
 USAGE:
-  {{.Name}} {{if .Flags}}[FLAGS] {{end}}COMMAND{{if .Flags}} [COMMAND FLAGS]{{end}} [ARGUMENTS...]
+  {{.Name}} {{if .Flags}}[FLAGS] {{end}}COMMAND{{if .Flags}} [COMMAND FLAGS | -h]{{end}} [ARGUMENTS...]
 
 COMMANDS:
   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}


### PR DESCRIPTION
There is no indication that ls supports --recursive for example, so this patch would be is a simple way to make subcommands flags more visible