### PR TITLE
Fix ls error msg

### DIFF
--- a/pkg/client/fs/fs-common.go
+++ b/pkg/client/fs/fs-common.go
@@ -62,11 +62,11 @@ func (f *fsClient) fsStat() (os.FileInfo, *probe.Error) {
 	if e != nil {
 		if os.IsPermission(e) {
 			if runtime.GOOS == "windows" {
-				return f.handleWindowsSymlinks(fpath)
+				return f.handleWindowsSymlinks(f.PathURL.Path)
 			}
-			return nil, probe.NewError(client.PathInsufficientPermission{Path: fpath})
+			return nil, probe.NewError(client.PathInsufficientPermission{Path: f.PathURL.Path})
 		}
-		err := f.toClientError(e, fpath)
+		err := f.toClientError(e, f.PathURL.Path)
 		return nil, err.Trace(fpath)
 	}
 	st, e := os.Stat(fpath)


### PR DESCRIPTION
Not documented, but according to this https://github.com/golang/go/blob/master/src/path/filepath/symlink.go#L100, EvalSymlinks always returns an empty string if there is an error.

This patch will fix this minor ls error msg
$ mc ls /path_not_found
mc: <ERROR> Unable to stat ‘/path_not_found’. Requested file `` not found

So it will be shown correctly
$ mc ls /path_not_found
mc: <ERROR> Unable to stat ‘/path_not_found’. Requested file `/path_not_found` not found

Not sure about how this patch affects this line f.handleWindowsSymlinks(f.PathURL.Path), but I am pretty sure that it wasn't working at all before now
