### PR TITLE
cp/mirror: Handle path constructions properly across operating systems.

### DIFF
--- a/cp-main.go
+++ b/cp-main.go
@@ -151,8 +151,8 @@ func doCopy(cpURLs copyURLs, progressReader *progressBar, accountingReader *acco
 
 	var progress io.Reader
 	if globalQuiet || globalJSON {
-		sourcePath := filepath.Join(sourceAlias, sourceURL.Path)
-		targetPath := filepath.Join(targetAlias, targetURL.Path)
+		sourcePath := filepath.ToSlash(filepath.Join(sourceAlias, sourceURL.Path))
+		targetPath := filepath.ToSlash(filepath.Join(targetAlias, targetURL.Path))
 		printMsg(copyMessage{
 			Source: sourcePath,
 			Target: targetPath,

--- a/cp-url.go
+++ b/cp-url.go
@@ -155,7 +155,7 @@ func prepareCopyURLsTypeB(sourceURL string, targetURL string) copyURLs {
 func makeCopyContentTypeB(sourceAlias string, sourceContent *client.Content, targetAlias string, targetURL string) copyURLs {
 	// All OK.. We can proceed. Type B: source is a file, target is a folder and exists.
 	targetURLParse := client.NewURL(targetURL)
-	targetURLParse.Path = filepath.Join(targetURLParse.Path, filepath.Base(sourceContent.URL.Path))
+	targetURLParse.Path = filepath.ToSlash(filepath.Join(targetURLParse.Path, filepath.Base(sourceContent.URL.Path)))
 	return makeCopyContentTypeA(sourceAlias, sourceContent, targetAlias, targetURLParse.String())
 }
 
@@ -200,9 +200,10 @@ func prepareCopyURLsTypeC(sourceURL, targetURL string, isRecursive bool) <-chan 
 func makeCopyContentTypeC(sourceAlias string, sourceURL client.URL, sourceContent *client.Content, targetAlias string, targetURL string) copyURLs {
 	newSourceURL := sourceContent.URL
 	pathSeparatorIndex := strings.LastIndex(sourceURL.Path, string(sourceURL.Separator))
-	newSourceSuffix := newSourceURL.Path
+	newSourceSuffix := filepath.ToSlash(newSourceURL.Path)
 	if pathSeparatorIndex > 1 {
-		newSourceSuffix = strings.TrimPrefix(newSourceURL.Path, sourceURL.Path[:pathSeparatorIndex])
+		sourcePrefix := filepath.ToSlash(sourceURL.Path[:pathSeparatorIndex])
+		newSourceSuffix = strings.TrimPrefix(newSourceSuffix, sourcePrefix)
 	}
 	newTargetURL := urlJoinPath(targetURL, newSourceSuffix)
 	return makeCopyContentTypeA(sourceAlias, sourceContent, targetAlias, newTargetURL)

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -141,8 +141,8 @@ func doMirror(sURLs mirrorURLs, progressReader *progressBar, accountingReader *a
 
 	var progress io.Reader
 	if globalQuiet || globalJSON {
-		sourcePath := filepath.Join(sourceAlias, sourceURL.Path)
-		targetPath := filepath.Join(targetAlias, targetURL.Path)
+		sourcePath := filepath.ToSlash(filepath.Join(sourceAlias, sourceURL.Path))
+		targetPath := filepath.ToSlash(filepath.Join(targetAlias, targetURL.Path))
 		printMsg(mirrorMessage{
 			Source: sourcePath,
 			Target: targetPath,

--- a/pkg/client/url.go
+++ b/pkg/client/url.go
@@ -120,28 +120,12 @@ func NewURL(urlStr string) *URL {
 // JoinURLs join two input urls and returns a url
 func JoinURLs(url1, url2 *URL) *URL {
 	var url1Path, url2Path string
-	url1Path = url1.Path
-	url2Path = url2.Path
-	if runtime.GOOS == "windows" {
-		url1Path = strings.Replace(url1.Path, "\\", "/", -1)
-		url2Path = strings.Replace(url2.Path, "\\", "/", -1)
-	}
-	if url1.Type == Object {
-		if strings.HasSuffix(url1Path, "/") {
-			url1.Path = url1Path + strings.TrimPrefix(url2Path, "/")
-		} else {
-			url1.Path = url1Path + "/" + strings.TrimPrefix(url2Path, "/")
-		}
-	}
-	if url1.Type == Filesystem {
-		if strings.HasSuffix(url1Path, "/") {
-			url1.Path = url1Path + strings.TrimPrefix(url2Path, "/")
-		} else {
-			url1.Path = url1Path + "/" + strings.TrimPrefix(url2Path, "/")
-		}
-		if runtime.GOOS == "windows" {
-			url1.Path = strings.Replace(url1.Path, "/", "\\", -1)
-		}
+	url1Path = filepath.ToSlash(url1.Path)
+	url2Path = filepath.ToSlash(url2.Path)
+	if strings.HasSuffix(url1Path, "/") {
+		url1.Path = url1Path + strings.TrimPrefix(url2Path, "/")
+	} else {
+		url1.Path = url1Path + "/" + strings.TrimPrefix(url2Path, "/")
 	}
 	return url1
 }

--- a/rm-main.go
+++ b/rm-main.go
@@ -177,7 +177,7 @@ func rmAll(targetAlias, targetURL string, isRecursive, isIncomplete, isFake bool
 			continue
 		}
 		// Construct user facing message and path.
-		entryPath := filepath.Join(targetAlias, entry.URL.Path)
+		entryPath := filepath.ToSlash(filepath.Join(targetAlias, entry.URL.Path))
 		printMsg(rmMessage{Status: "success", URL: entryPath})
 	}
 }


### PR DESCRIPTION
  ```
 mc cp -r localhost\testbucket\bin C:\destination
  ```

Following syntax is supposed to copy only 'bin' inside C:\destination.
Due to url construction issues this leads to 'testbucket' instead being
copied as the top level directory.

With this fix the url construction becomes more cross platform friendly.