### PR TITLE
urlAlias: Handle forward slashes on windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ go:
 - 1.5.2
 - 1.5.3
 
+script:
+- diff -au <(gofmt -d *.go) <(printf "")
+- diff -au <(gofmt -d pkg) <(printf "")
+
 notifications:
   slack:
     secure: McinxQ4R/Yu2r/U8lVsdAIQ195Rf+3/Ku6DViWyqLHsTt5fTnVrSfbIKs8vy0t2A0bRLO6zv2xOSMWjfiimZLPMgMbMqLtTFEzUzB8RZyx2n2xgmL8q3gjXcLA3vkBreaRYCzJzX6DjvrxRfhyOg+BQHpLpACWik3FS/7VIdDCI=

--- a/pkg/client/fs/fs-utils.go
+++ b/pkg/client/fs/fs-utils.go
@@ -30,11 +30,11 @@ func (f byDirName) Len() int { return len(f) }
 func (f byDirName) Less(i, j int) bool {
 	// For directory add an ending separator fortrue lexical order.
 	if f[i].Mode().IsDir() {
-		return f[i].Name()+string(os.PathSeparator) < f[j].Name()
+		return f[i].Name()+string(filepath.Separator) < f[j].Name()
 	}
 	// For directory add an ending separator for true lexical order.
 	if f[j].Mode().IsDir() {
-		return f[i].Name() < f[j].Name()+string(os.PathSeparator)
+		return f[i].Name() < f[j].Name()+string(filepath.Separator)
 	}
 	return f[i].Name() < f[j].Name()
 }
@@ -75,7 +75,7 @@ func readDirNames(dirname string) ([]string, error) {
 func getRealName(info os.FileInfo) string {
 	if info.IsDir() {
 		// Make sure directory has its end separator.
-		return info.Name() + string(os.PathSeparator)
+		return info.Name() + string(filepath.Separator)
 	}
 	return info.Name()
 }

--- a/pkg/client/fs/fs.go
+++ b/pkg/client/fs/fs.go
@@ -535,7 +535,7 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan *client.Content, incomp
 	var filePrefix string
 	pathURL := *f.PathURL
 	visitFS := func(fp string, fi os.FileInfo, e error) error {
-		// If file path ends with os.PathSeparator and equals to root path, skip it.
+		// If file path ends with filepath.Separator and equals to root path, skip it.
 		if strings.HasSuffix(fp, string(pathURL.Separator)) {
 			if fp == dirName {
 				return nil
@@ -688,14 +688,14 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan *client.Content, incomp
 	}
 	// No prefix to be filtered by default.
 	filePrefix = ""
-	// if f.Path ends with os.PathSeparator - assuming it to be a directory and moving on.
+	// if f.Path ends with filepath.Separator - assuming it to be a directory and moving on.
 	if strings.HasSuffix(pathURL.Path, string(pathURL.Separator)) {
 		dirName = pathURL.Path
 	} else {
 		// if not a directory, take base path to navigate through WalkFunc.
 		dirName = filepath.Dir(pathURL.Path)
 		if !strings.HasSuffix(dirName, string(pathURL.Separator)) {
-			// basepath truncates the os.PathSeparator,
+			// basepath truncates the filepath.Separator,
 			// add it deligently useful for trimming file path inside WalkFunc
 			dirName = dirName + string(pathURL.Separator)
 		}

--- a/url.go
+++ b/url.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -52,15 +51,19 @@ func url2Stat(urlStr string) (client client.Client, content *client.Content, err
 	return client, content, nil
 }
 
-// url2Alias separates alias and path from the URL. Aliased URL is of the form [/]alias/path/to/blah. If
+// url2Alias separates alias and path from the URL. Aliased URL is of
+// the form [/]alias/path/to/blah.
 func url2Alias(aliasedURL string) (alias, path string) {
 	urlStr := aliasedURL
 
-	// Remove "/" prefix before alias, if any.
-	urlStr = strings.TrimPrefix(urlStr, string(os.PathSeparator))
+	// Convert '/' on windows to filepath.Separator.
+	urlStr = filepath.FromSlash(urlStr)
 
-	// Remove everything after alias (i.e. after "/").
-	urlParts := strings.SplitN(urlStr, string(os.PathSeparator), 2)
+	// Remove '/' prefix before alias, if any.
+	urlStr = strings.TrimPrefix(urlStr, string(filepath.Separator))
+
+	// Remove everything after alias (i.e. after '/').
+	urlParts := strings.SplitN(urlStr, string(filepath.Separator), 2)
 	if len(urlParts) == 2 {
 		// Convert windows style path separator to Unix style.
 		return urlParts[0], urlParts[1]

--- a/vendor/github.com/minio/minio-go/api-definitions.go
+++ b/vendor/github.com/minio/minio-go/api-definitions.go
@@ -33,10 +33,10 @@ type ObjectInfo struct {
 	// each parts concatenated into one string.
 	ETag string `json:"etag"`
 
-	Key          string `json:"name"`            // Name of the object
+	Key          string    `json:"name"`         // Name of the object
 	LastModified time.Time `json:"lastModified"` // Date and time the object was last modified.
-	Size         int64 `json:"size"`             // Size in bytes of the object.
-	ContentType  string `json:"contentType"`     // A standard MIME type describing the format of the object data.
+	Size         int64     `json:"size"`         // Size in bytes of the object.
+	ContentType  string    `json:"contentType"`  // A standard MIME type describing the format of the object data.
 
 	// Owner name.
 	Owner struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -29,8 +29,8 @@
 		},
 		{
 			"path": "github.com/minio/minio-go",
-			"revision": "da044a0509a9a9e667e8cc838a7313b0a8ba2710",
-			"revisionTime": "2016-01-25T16:31:01-08:00"
+			"revision": "4d50c1ea5864a5740c5e5610f0547eb9a0d5b81f",
+			"revisionTime": "2016-01-27T14:26:51-08:00"
 		},
 		{
 			"path": "github.com/minio/minio-xl/pkg/atomic",


### PR DESCRIPTION
On windows
```
> mc ls s3/ --> Fails
```

Since most of our examples talk about '/', we should handle
this cleanly for windows.