### PR TITLE
url: Error out if the aliased URL has host entry.

### DIFF
--- a/typed-errors.go
+++ b/typed-errors.go
@@ -31,6 +31,10 @@ var (
 		return probe.NewError(errors.New("Invalid arguments provided, cannot proceed.")).Untrace()
 	}
 
+	errInvalidAliasedURL = func(URL string) *probe.Error {
+		return probe.NewError(errors.New("Use ‘mc config host add mycloud " + URL + " ...’ to add an alias. Use the alias for S3 operations.")).Untrace()
+	}
+
 	errNoMatchingHost = func(URL string) *probe.Error {
 		return probe.NewError(errors.New("No matching host found for the given URL ‘" + URL + "’.")).Untrace()
 	}

--- a/url.go
+++ b/url.go
@@ -54,6 +54,7 @@ func url2Stat(urlStr string) (client client.Client, content *client.Content, err
 // url2Alias separates alias and path from the URL. Aliased URL is of
 // the form [/]alias/path/to/blah.
 func url2Alias(aliasedURL string) (alias, path string) {
+	// Save aliased url.
 	urlStr := aliasedURL
 
 	// Convert '/' on windows to filepath.Separator.


### PR DESCRIPTION
```
mc ls http://localhost:9000/
```

ends up listing `mc ls /`, This is confusing and should be
treated as an error for filesystem.