### PR TITLE
progressBar: Finish progress bar if total is greater than 0

### DIFF
--- a/cp-main.go
+++ b/cp-main.go
@@ -356,9 +356,10 @@ func doCopySession(session *sessionV6) {
 	wg.Wait()
 
 	if !globalQuiet && !globalJSON {
-		progressReader.ProgressBar.Finish()
-	}
-	if globalQuiet {
+		if progressReader.ProgressBar.Total > 0 {
+			progressReader.ProgressBar.Finish()
+		}
+	} else {
 		accntStat := accntReader.Stat()
 		cpStatMessage := copyStatMessage{
 			Total:       accntStat.Total,

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -339,7 +339,9 @@ func doMirrorSession(session *sessionV6) {
 	wg.Wait()
 
 	if !globalQuiet && !globalJSON {
-		progressReader.ProgressBar.Finish()
+		if progressReader.ProgressBar.Total > 0 {
+			progressReader.ProgressBar.Finish()
+		}
 	} else {
 		accntStat := accntReader.Stat()
 		mrStatMessage := mirrorStatMessage{


### PR DESCRIPTION
In case of 'mc mirror' => mc prints an erroneous progress bar
with 0bytes.

```
mc mirror /usr/local/Cellar/go/1.5.3/libexec play/test123/libexec
0 B / ?  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▓  0.00 % 0
```

This patch fixes #1592