### PR TITLE
build: Now builds for all platforms and builds into 'release/experimental' directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ cover.out
 mc
 *~
 *.test
+release
+experimental

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -38,4 +38,4 @@ $
 
 `mc` doesn't follow semantic versioning style, `mc` instead uses the release date and time as the release versions.
 
-`make release` will install new released binary into your `GOPATH`
+`make release` will generate new binary into `release` directory.

--- a/build-constants.go
+++ b/build-constants.go
@@ -18,11 +18,11 @@ package main
 
 var (
 	// mcVersion - version time.RFC3339.
-	mcVersion = "UNOFFICIAL.GOGET"
+	mcVersion = "DEVELOPMENT.GOGET"
 	// mcReleaseTag - release tag in TAG.%Y-%m-%dT%H-%M-%SZ.
-	mcReleaseTag = "UNOFFICIAL.GOGET"
+	mcReleaseTag = "DEVELOPMENT.GOGET"
 	// mcCommitID - latest commit id.
-	mcCommitID = "UNOFFICIAL.GOGET"
+	mcCommitID = "DEVELOPMENT.GOGET"
 	// mcShortCommitID - first 12 characters from mcCommitID.
 	mcShortCommitID = mcCommitID[:12]
 )

--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Save release LDFLAGS
+LDFLAGS=$(go run buildscripts/gen-ldflags.go)
+
+# Extract of release tag
+release_tag=$(echo $LDFLAGS | awk {'print $4'} | cut -f2 -d=)
+
+# Extract release string.
+release_str=$(echo $MC_RELEASE | tr '[:upper:]' '[:lower:]')
+
+# List of supported architectures
+SUPPORTED_OSARCH='linux/386 linux/amd64 linux/arm windows/386 windows/amd64 darwin/amd64'
+
+# Builds.
+echo "Executing $release_str builds."
+for osarch in ${SUPPORTED_OSARCH}; do
+    os=$(echo $osarch | cut -f1 -d'/')
+    arch=$(echo $osarch | cut -f2 -d'/')
+    package=$(go list -f '{{.ImportPath}}')
+    echo -n "-->"
+    printf "%15s:%s\n" "${osarch}" "${package}"
+    GOOS=$os GOARCH=$arch go build --ldflags "${LDFLAGS}" -o $release_str/$os-$arch/$(basename $package).$release_tag
+done
+
+

--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -37,7 +37,7 @@ func genLDFlags(version string) string {
 
 // genReleaseTag prints release tag to the console for easy git tagging.
 func releaseTag(version string) string {
-	relPrefix := "UNOFFICIAL"
+	relPrefix := "DEVELOPMENT"
 	if prefix := os.Getenv("MC_RELEASE"); prefix != "" {
 		relPrefix = prefix
 	}

--- a/pipe-main.go
+++ b/pipe-main.go
@@ -55,7 +55,7 @@ EXAMPLES:
    2. Write contents of stdin to an object on Amazon S3 cloud storage.
       $ mc {{.Name}} s3/personalbuck/meeting-notes.txt
 
-   3. Copy an ISO image to an object on Amazon S3 cloud storage and Google Cloud Storage simultaneously.
+   3. Copy an ISO image to an object on Amazon S3 cloud storage.
       $ cat debian-8.2.iso | mc {{.Name}} s3/ferenginar/gnuos.iso
 
    4. Stream MySQL database dump to Amazon S3 directly.

--- a/release.cmd
+++ b/release.cmd
@@ -1,5 +1,0 @@
-SET MC_RELEASE=OFFICIAL
-SET GO15VENDOREXPERIMENT=1
-go run buildscripts/gen-ldflags.go > temp.txt
-SET /p LDFLAGS=<temp.txt
-go build -ldflags="%LDFLAGS%" -o %GOPATH%\bin\mc.exe

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-echo -n "Making official release binaries.. "
-export MC_RELEASE=OFFICIAL
-make 1>/dev/null
-echo "Binaries built at ${GOPATH}/bin/mc"

--- a/update-main.go
+++ b/update-main.go
@@ -144,7 +144,7 @@ func getReleaseUpdate(updateURL string) {
 	data, e := http.Get(newUpdateURL)
 	fatalIf(probe.NewError(e), "Unable to read from update URL ‘"+newUpdateURL+"’.")
 
-	if mcVersion == "UNOFFICIAL.GOGET" {
+	if strings.HasPrefix(mcVersion, "DEVELOPMENT.GOGET") {
 		fatalIf(errDummy().Trace(newUpdateURL),
 			"Update mechanism is not supported for ‘go get’ based binary builds.  Please download official releases from https://minio.io/#minio")
 	}

--- a/vendor/github.com/minio/minio/pkg/user/user.go
+++ b/vendor/github.com/minio/minio/pkg/user/user.go
@@ -39,14 +39,16 @@ func Current() (*user.User, error) {
 		}
 		return &user.User{Uid: "0", Gid: "0", Username: "root", Name: "root", HomeDir: wd}, nil
 	}
-	if runtime.GOARCH == "386" && runtime.GOOS == "linux" {
-		return &user.User{
-			Uid:      strconv.Itoa(os.Getuid()),
-			Gid:      strconv.Itoa(os.Getgid()),
-			Username: os.Getenv("USER"),
-			Name:     os.Getenv("USER"),
-			HomeDir:  os.Getenv("HOME"),
-		}, nil
+	if runtime.GOARCH == "386" {
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			return &user.User{
+				Uid:      strconv.Itoa(os.Getuid()),
+				Gid:      strconv.Itoa(os.Getgid()),
+				Username: os.Getenv("USER"),
+				Name:     os.Getenv("USER"),
+				HomeDir:  os.Getenv("HOME"),
+			}, nil
+		}
 	}
 	user, e := user.Current()
 	if e != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -49,8 +49,8 @@
 		},
 		{
 			"path": "github.com/minio/minio/pkg/user",
-			"revision": "71876688282283e8af374bd8592c7d33c547df4d",
-			"revisionTime": "2015-12-07T14:59:57-08:00"
+			"revision": "4e328d7b2cdec323820ad90c83dcc0dffa7900f7",
+			"revisionTime": "2016-02-08T01:59:02-08:00"
 		},
 		{
 			"path": "github.com/minio/pb",


### PR DESCRIPTION
Two Makefile options are

- make release
- make experimental

Currently supported OS and arch -

- linux/386
- linux/amd64
- linux/arm
- windows/386
- windows/amd64
- darwin/amd64