### PR TITLE
config: Config folder option should be honored.

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,9 +29,6 @@ import (
 // mcCustomConfigDir contains the whole path to config dir. Only access via get/set functions.
 var mcCustomConfigDir string
 
-// mcCustomConfigPath contains the whole path to config file. Only access via get/set functions.
-var mcCustomConfigPath string
-
 // setMcConfigDir - set a custom minio client config folder.
 func setMcConfigDir(configDir string) {
 	mcCustomConfigDir = configDir
@@ -46,13 +43,14 @@ func getMcConfigDir() (string, *probe.Error) {
 	if e != nil {
 		return "", probe.NewError(e)
 	}
+	var configDir string
 	// For windows the path is slightly different
-	switch runtime.GOOS {
-	case "windows":
-		return filepath.Join(homeDir, globalMCConfigWindowsDir), nil
-	default:
-		return filepath.Join(homeDir, globalMCConfigDir), nil
+	if runtime.GOOS == "windows" {
+		configDir = filepath.Join(homeDir, globalMCConfigWindowsDir)
+	} else {
+		configDir = filepath.Join(homeDir, globalMCConfigDir)
 	}
+	return configDir, nil
 }
 
 // mustGetMcConfigDir - construct minio client config folder or fail
@@ -77,8 +75,8 @@ func createMcConfigDir() *probe.Error {
 
 // getMcConfigPath - construct minio client configuration path
 func getMcConfigPath() (string, *probe.Error) {
-	if mcCustomConfigPath != "" {
-		return mcCustomConfigPath, nil
+	if mcCustomConfigDir != "" {
+		return filepath.Join(mcCustomConfigDir, globalMCConfigFile), nil
 	}
 	dir, err := getMcConfigDir()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func commandNotFound(ctx *cli.Context, command string) {
 
 // Check for sane config environment early on and gracefully report.
 func checkConfig() {
+	// Refresh the config once.
+	loadMcConfig = loadMcConfigFactory()
 	// Ensures config file is sane.
 	_, err := loadMcConfig()
 	fatalIf(err.Trace(mustGetMcConfigPath()), "Unable to access configuration file.")

--- a/pkg/httptracer/httptracer.go
+++ b/pkg/httptracer/httptracer.go
@@ -36,6 +36,14 @@ type RoundTripTrace struct {
 	Transport http.RoundTripper // HTTP transport that needs to be intercepted
 }
 
+// CancelRequest implements functinality to cancel an underlying request.
+func (t RoundTripTrace) CancelRequest(req *http.Request) {
+	transport, ok := t.Transport.(*http.Transport)
+	if ok {
+		transport.CancelRequest(req)
+	}
+}
+
 // RoundTrip executes user provided request and response hooks for each HTTP call.
 func (t RoundTripTrace) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	timeStamp := time.Now()


### PR DESCRIPTION
config: Config folder option should be honored.

The fix is to load config factory once again, to avoid looking for stale
scoped global variables. For example ``mcCustomConfigDir``

Fixes #1611