### PR TITLE
mirror: Implement --fake option.

### DIFF
--- a/mirror-main.go
+++ b/mirror-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015 Minio, Inc.
+ * Minio Client, (C) 2015, 2016 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,10 @@ var (
 			Name:  "force",
 			Usage: "Force overwrite of an existing target(s).",
 		},
+		cli.BoolFlag{
+			Name:  "fake",
+			Usage: "Perform a fake mirror operation.",
+		},
 	}
 )
 
@@ -71,6 +75,13 @@ EXAMPLES:
 
    3. Mirror a bucket from aliased Amazon S3 cloud storage to a folder on Windows.
       $ mc {{.Name}} s3\documents\2014\ C:\backup\2014
+
+   4. Mirror a bucket from aliased Amazon S3 cloud storage to a local folder use '--force' to overwrite destination.
+      $ mc {{.Name}} --force s3/miniocloud miniocloud-backup
+
+   5. Fake mirror a bucket from Minio cloud storage to a bucket on Amazon S3 cloud storage.
+      $ mc {{.Name}} --fake play/photos/2014 s3/backup-photos/2014
+
 `,
 }
 
@@ -172,7 +183,7 @@ func doMirrorFake(sURLs mirrorURLs, progressReader *progressBar) mirrorURLs {
 }
 
 // doPrepareMirrorURLs scans the source URL and prepares a list of objects for mirroring.
-func doPrepareMirrorURLs(session *sessionV6, isForce bool, trapCh <-chan bool) {
+func doPrepareMirrorURLs(session *sessionV6, isForce bool, isFake bool, trapCh <-chan bool) {
 	sourceURL := session.Header.CommandArgs[0] // first one is source.
 	targetURL := session.Header.CommandArgs[1]
 	var totalBytes int64
@@ -186,7 +197,7 @@ func doPrepareMirrorURLs(session *sessionV6, isForce bool, trapCh <-chan bool) {
 		scanBar = scanBarFactory()
 	}
 
-	URLsCh := prepareMirrorURLs(sourceURL, targetURL, isForce)
+	URLsCh := prepareMirrorURLs(sourceURL, targetURL, isForce, isFake)
 	done := false
 	for done == false {
 		select {
@@ -235,10 +246,13 @@ func doPrepareMirrorURLs(session *sessionV6, isForce bool, trapCh <-chan bool) {
 // Session'fied mirror command.
 func doMirrorSession(session *sessionV6) {
 	isForce := session.Header.CommandBoolFlags["force"]
+	isFake := session.Header.CommandBoolFlags["fake"]
+
+	// Initialize signal trap.
 	trapCh := signalTrap(os.Interrupt, syscall.SIGTERM)
 
 	if !session.HasData() {
-		doPrepareMirrorURLs(session, isForce, trapCh)
+		doPrepareMirrorURLs(session, isForce, isFake, trapCh)
 	}
 
 	// Enable accounting reader by default.
@@ -318,7 +332,7 @@ func doMirrorSession(session *sessionV6) {
 		}
 	}()
 
-	// Loop through all urls.
+	// Loop through all urls and mirror.
 	for urlScanner.Scan() {
 		var sURLs mirrorURLs
 		// Unmarshal copyURLs from each line.
@@ -327,7 +341,13 @@ func doMirrorSession(session *sessionV6) {
 		if isCopied(sURLs.SourceContent.URL.String()) {
 			statusCh <- doMirrorFake(sURLs, progressReader)
 		} else {
-			statusCh <- doMirror(sURLs, progressReader, accntReader)
+			// Mirror is initiated if its not a fake run.
+			if !isFake {
+				statusCh <- doMirror(sURLs, progressReader, accntReader)
+			} else {
+				// fake Mirror is initiated if its a fake run.
+				statusCh <- doMirrorFake(sURLs, progressReader)
+			}
 		}
 	}
 
@@ -374,7 +394,9 @@ func mainMirror(ctx *cli.Context) {
 
 	// Set command flags from context.
 	isForce := ctx.Bool("force")
+	isFake := ctx.Bool("fake")
 	session.Header.CommandBoolFlags["force"] = isForce
+	session.Header.CommandBoolFlags["fake"] = isFake
 
 	// extract URLs.
 	session.Header.CommandArgs = ctx.Args()

--- a/mirror-url.go
+++ b/mirror-url.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * Minio Client (C) 2015, 2016 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func checkMirrorSyntax(ctx *cli.Context) {
 	}
 }
 
-func deltaSourceTargets(sourceURL string, targetURL string, isForce bool, mirrorURLsCh chan<- mirrorURLs) {
+func deltaSourceTargets(sourceURL string, targetURL string, isForce bool, isFake bool, mirrorURLsCh chan<- mirrorURLs) {
 	// source and targets are always directories
 	sourceSeparator := string(newURL(sourceURL).Separator)
 	if !strings.HasSuffix(sourceURL, sourceSeparator) {
@@ -143,8 +143,8 @@ func deltaSourceTargets(sourceURL string, targetURL string, isForce bool, mirror
 			mirrorURLsCh <- mirrorURLs{Error: errInvalidTarget(suffix)}
 			continue
 		}
-		if differ == differSize && !isForce {
-			// size differs and force not set
+		if differ == differSize && !isForce && !isFake {
+			// Size differs and force not set
 			mirrorURLsCh <- mirrorURLs{Error: errOverWriteNotAllowed(sourceContent.URL.String())}
 			continue
 		}
@@ -160,8 +160,8 @@ func deltaSourceTargets(sourceURL string, targetURL string, isForce bool, mirror
 	}
 }
 
-func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool) <-chan mirrorURLs {
+func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool) <-chan mirrorURLs {
 	mirrorURLsCh := make(chan mirrorURLs)
-	go deltaSourceTargets(sourceURL, targetURL, isForce, mirrorURLsCh)
+	go deltaSourceTargets(sourceURL, targetURL, isForce, isFake, mirrorURLsCh)
 	return mirrorURLsCh
 }


### PR DESCRIPTION
This option helps users verify what operation 'mirror'
is going to perform without it. It also allows for scripts
to validate what files will be copied etc.

#1628