### PR TITLE
config: Migrate to new version of config '8'

### DIFF
--- a/config-host-main.go
+++ b/config-host-main.go
@@ -58,11 +58,11 @@ FLAGS:
 EXAMPLES:
    1. Add Amazon S3 storage service under "myphotos" alias. For security reasons turn off bash history momentarily.
       $ set +o history
-      $ mc config {{.Name}} add myphotos https://s3.amazonaws.com BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
+      $ mc config {{.Name}} add myphotos https://s3.amazonaws.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
       $ set -o history
 
    2. Add Google Cloud Storage service under "goodisk" alias.
-      $ mc config {{.Name}} add goodisk  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2
+      $ mc config {{.Name}} add goodisk  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2
 
    3. List all hosts.
       $ mc config {{.Name}} list
@@ -217,7 +217,7 @@ func mainConfigHost(ctx *cli.Context) {
 		if strings.TrimSpace(api) == "" {
 			api = "S3v4"
 		}
-		hostCfg := hostConfigV7{
+		hostCfg := hostConfigV8{
 			URL:       url,
 			AccessKey: accessKey,
 			SecretKey: secretKey,
@@ -233,23 +233,23 @@ func mainConfigHost(ctx *cli.Context) {
 }
 
 // addHost - add a host config.
-func addHost(alias string, hostCfgV7 hostConfigV7) {
-	mcCfgV7, err := loadMcConfig()
+func addHost(alias string, hostCfgV8 hostConfigV8) {
+	mcCfgV8, err := loadMcConfig()
 	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config ‘"+mustGetMcConfigPath()+"’.")
 
 	// Add new host.
-	mcCfgV7.Hosts[alias] = hostCfgV7
+	mcCfgV8.Hosts[alias] = hostCfgV8
 
-	err = saveMcConfig(mcCfgV7)
+	err = saveMcConfig(mcCfgV8)
 	fatalIf(err.Trace(alias), "Unable to update hosts in config version ‘"+mustGetMcConfigPath()+"’.")
 
 	printMsg(hostMessage{
 		op:        "add",
 		Alias:     alias,
-		URL:       hostCfgV7.URL,
-		AccessKey: hostCfgV7.AccessKey,
-		SecretKey: hostCfgV7.SecretKey,
-		API:       hostCfgV7.API,
+		URL:       hostCfgV8.URL,
+		AccessKey: hostCfgV8.AccessKey,
+		SecretKey: hostCfgV8.SecretKey,
+		API:       hostCfgV8.API,
 	})
 }
 

--- a/config-old.go
+++ b/config-old.go
@@ -160,5 +160,85 @@ func newConfigV6() *configV6 {
 	return conf
 }
 
-/////////////////// Config V7 ///////////////////
+/////////////////// Config V6 ///////////////////
+// hostConfig configuration of a host - version '7'.
+type hostConfigV7 struct {
+	URL       string `json:"url"`
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
+	API       string `json:"api"`
+}
+
+// configV7 config version.
+type configV7 struct {
+	Version string                  `json:"version"`
+	Hosts   map[string]hostConfigV7 `json:"hosts"`
+}
+
+// newConfigV7 - new config version '7'.
+func newConfigV7() *configV7 {
+	cfg := new(configV7)
+	cfg.Version = globalMCConfigVersion
+	cfg.Hosts = make(map[string]hostConfigV7)
+	return cfg
+}
+
+func (c *configV7) loadDefaults() {
+	// Minio server running locally.
+	c.setHost("local", hostConfigV7{
+		URL:       "http://localhost:9000",
+		AccessKey: "",
+		SecretKey: "",
+		API:       "S3v4",
+	})
+
+	// Amazon S3 cloud storage service.
+	c.setHost("s3", hostConfigV7{
+		URL:       "https://s3.amazonaws.com",
+		AccessKey: defaultAccessKey,
+		SecretKey: defaultSecretKey,
+		API:       "S3v4",
+	})
+
+	// Google cloud storage service.
+	c.setHost("gcs", hostConfigV7{
+		URL:       "https://storage.googleapis.com",
+		AccessKey: defaultAccessKey,
+		SecretKey: defaultSecretKey,
+		API:       "S3v2",
+	})
+
+	// Minio anonymous server for demo.
+	c.setHost("play", hostConfigV7{
+		URL:       "https://play.minio.io:9000",
+		AccessKey: "",
+		SecretKey: "",
+		API:       "S3v4",
+	})
+
+	// Minio demo server with public secret and access keys.
+	c.setHost("player", hostConfigV7{
+		URL:       "https://play.minio.io:9002",
+		AccessKey: "Q3AM3UQ867SPQQA43P2F",
+		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
+		API:       "S3v4",
+	})
+
+	// Minio public download service.
+	c.setHost("dl", hostConfigV7{
+		URL:       "https://dl.minio.io:9000",
+		AccessKey: "",
+		SecretKey: "",
+		API:       "S3v4",
+	})
+}
+
+// SetHost sets host config if not empty.
+func (c *configV7) setHost(alias string, cfg hostConfigV7) {
+	if _, ok := c.Hosts[alias]; !ok {
+		c.Hosts[alias] = cfg
+	}
+}
+
+/////////////////// Config V8 ///////////////////
 // RESERVED FOR FUTURE

--- a/config-v8.go
+++ b/config-v8.go
@@ -30,44 +30,44 @@ const (
 
 var (
 	// set once during first load.
-	cacheCfgV7 *configV7
+	cacheCfgV8 *configV8
 	// All access to mc config file should be synchronized.
 	cfgMutex = &sync.RWMutex{}
 )
 
 // hostConfig configuration of a host.
-type hostConfigV7 struct {
+type hostConfigV8 struct {
 	URL       string `json:"url"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
 	API       string `json:"api"`
 }
 
-// configV7 config version.
-type configV7 struct {
+// configV8 config version.
+type configV8 struct {
 	Version string                  `json:"version"`
-	Hosts   map[string]hostConfigV7 `json:"hosts"`
+	Hosts   map[string]hostConfigV8 `json:"hosts"`
 }
 
-// newConfigV7 - new config version.
-func newConfigV7() *configV7 {
-	cfg := new(configV7)
+// newConfigV8 - new config version.
+func newConfigV8() *configV8 {
+	cfg := new(configV8)
 	cfg.Version = globalMCConfigVersion
-	cfg.Hosts = make(map[string]hostConfigV7)
+	cfg.Hosts = make(map[string]hostConfigV8)
 	return cfg
 }
 
 // SetHost sets host config if not empty.
-func (c *configV7) setHost(alias string, cfg hostConfigV7) {
+func (c *configV8) setHost(alias string, cfg hostConfigV8) {
 	if _, ok := c.Hosts[alias]; !ok {
 		c.Hosts[alias] = cfg
 	}
 }
 
 // load default values for missing entries.
-func (c *configV7) loadDefaults() {
+func (c *configV8) loadDefaults() {
 	// Minio server running locally.
-	c.setHost("local", hostConfigV7{
+	c.setHost("local", hostConfigV8{
 		URL:       "http://localhost:9000",
 		AccessKey: "",
 		SecretKey: "",
@@ -75,7 +75,7 @@ func (c *configV7) loadDefaults() {
 	})
 
 	// Amazon S3 cloud storage service.
-	c.setHost("s3", hostConfigV7{
+	c.setHost("s3", hostConfigV8{
 		URL:       "https://s3.amazonaws.com",
 		AccessKey: defaultAccessKey,
 		SecretKey: defaultSecretKey,
@@ -83,7 +83,7 @@ func (c *configV7) loadDefaults() {
 	})
 
 	// Google cloud storage service.
-	c.setHost("gcs", hostConfigV7{
+	c.setHost("gcs", hostConfigV8{
 		URL:       "https://storage.googleapis.com",
 		AccessKey: defaultAccessKey,
 		SecretKey: defaultSecretKey,
@@ -91,67 +91,51 @@ func (c *configV7) loadDefaults() {
 	})
 
 	// Minio anonymous server for demo.
-	c.setHost("play", hostConfigV7{
+	c.setHost("play", hostConfigV8{
 		URL:       "https://play.minio.io:9000",
-		AccessKey: "",
-		SecretKey: "",
-		API:       "S3v4",
-	})
-
-	// Minio demo server with public secret and access keys.
-	c.setHost("player", hostConfigV7{
-		URL:       "https://play.minio.io:9002",
 		AccessKey: "Q3AM3UQ867SPQQA43P2F",
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",
 	})
-
-	// Minio public download service.
-	c.setHost("dl", hostConfigV7{
-		URL:       "https://dl.minio.io:9000",
-		AccessKey: "",
-		SecretKey: "",
-		API:       "S3v4",
-	})
 }
 
-// loadConfigV7 - loads a new config.
-func loadConfigV7() (*configV7, *probe.Error) {
+// loadConfigV8 - loads a new config.
+func loadConfigV8() (*configV8, *probe.Error) {
 	cfgMutex.RLock()
 	defer cfgMutex.RUnlock()
 
 	// Cached in private global variable.
-	if cacheCfgV7 != nil {
-		return cacheCfgV7, nil
+	if cacheCfgV8 != nil {
+		return cacheCfgV8, nil
 	}
 
 	if !isMcConfigExists() {
 		return nil, errInvalidArgument().Trace()
 	}
 
-	mcCfgV7, err := quick.Load(mustGetMcConfigPath(), newConfigV7())
+	mcCfgV8, err := quick.Load(mustGetMcConfigPath(), newConfigV8())
 	fatalIf(err.Trace(), "Unable to load mc config file ‘"+mustGetMcConfigPath()+"’.")
 
-	cfgV7 := mcCfgV7.Data().(*configV7)
+	cfgV8 := mcCfgV8.Data().(*configV8)
 
 	// cache it.
-	cacheCfgV7 = cfgV7
+	cacheCfgV8 = cfgV8
 
-	return cfgV7, nil
+	return cfgV8, nil
 }
 
-// saveConfigV7 - saves an updated config.
-func saveConfigV7(cfgV7 *configV7) *probe.Error {
+// saveConfigV8 - saves an updated config.
+func saveConfigV8(cfgV8 *configV8) *probe.Error {
 	cfgMutex.Lock()
 	defer cfgMutex.Unlock()
 
-	qs, err := quick.New(cfgV7)
+	qs, err := quick.New(cfgV8)
 	if err != nil {
 		return err.Trace()
 	}
 
 	// update the cache.
-	cacheCfgV7 = cfgV7
+	cacheCfgV8 = cfgV8
 
 	return qs.Save(mustGetMcConfigPath()).Trace(mustGetMcConfigPath())
 }

--- a/config.go
+++ b/config.go
@@ -94,19 +94,19 @@ func mustGetMcConfigPath() string {
 }
 
 // newMcConfig - initializes a new version '6' config.
-func newMcConfig() *configV7 {
-	cfg := newConfigV7()
+func newMcConfig() *configV8 {
+	cfg := newConfigV8()
 	cfg.loadDefaults()
 	return cfg
 }
 
 // loadMcConfigCached - returns loadMcConfig with a closure for config cache.
-func loadMcConfigFactory() func() (*configV7, *probe.Error) {
+func loadMcConfigFactory() func() (*configV8, *probe.Error) {
 	// Load once and cache in a closure.
-	cfgCache, err := loadConfigV7()
+	cfgCache, err := loadConfigV8()
 
 	// loadMcConfig - reads configuration file and returns config.
-	return func() (*configV7, *probe.Error) {
+	return func() (*configV8, *probe.Error) {
 		return cfgCache, err
 	}
 }
@@ -114,7 +114,7 @@ func loadMcConfigFactory() func() (*configV7, *probe.Error) {
 var loadMcConfig = loadMcConfigFactory()
 
 // saveMcConfig - saves configuration file and returns error if any.
-func saveMcConfig(config *configV7) *probe.Error {
+func saveMcConfig(config *configV8) *probe.Error {
 	if config == nil {
 		return errInvalidArgument().Trace()
 	}
@@ -125,7 +125,7 @@ func saveMcConfig(config *configV7) *probe.Error {
 	}
 
 	// Save the config.
-	if err := saveConfigV7(config); err != nil {
+	if err := saveConfigV8(config); err != nil {
 		return err.Trace(mustGetMcConfigPath())
 	}
 
@@ -152,7 +152,7 @@ func isValidAlias(alias string) bool {
 }
 
 // getHostConfig retrieves host specific configuration such as access keys, signature type.
-func getHostConfig(alias string) (*hostConfigV7, *probe.Error) {
+func getHostConfig(alias string) (*hostConfigV8, *probe.Error) {
 	mcCfg, err := loadMcConfig()
 	if err != nil {
 		return nil, err.Trace(alias)
@@ -169,13 +169,13 @@ func getHostConfig(alias string) (*hostConfigV7, *probe.Error) {
 }
 
 // mustGetHostConfig retrieves host specific configuration such as access keys, signature type.
-func mustGetHostConfig(alias string) *hostConfigV7 {
+func mustGetHostConfig(alias string) *hostConfigV8 {
 	hostCfg, _ := getHostConfig(alias)
 	return hostCfg
 }
 
 // expandAlias expands aliased URL if any match is found, returns as is otherwise.
-func expandAlias(aliasedURL string) (alias string, urlStr string, hostCfg *hostConfigV7, err *probe.Error) {
+func expandAlias(aliasedURL string) (alias string, urlStr string, hostCfg *hostConfigV8, err *probe.Error) {
 	// Extract alias from the URL.
 	alias, path := url2Alias(aliasedURL)
 
@@ -187,7 +187,7 @@ func expandAlias(aliasedURL string) (alias string, urlStr string, hostCfg *hostC
 }
 
 // mustExpandAlias expands aliased URL if any match is found, returns as is otherwise.
-func mustExpandAlias(aliasedURL string) (alias string, urlStr string, hostCfg *hostConfigV7) {
+func mustExpandAlias(aliasedURL string) (alias string, urlStr string, hostCfg *hostConfigV8) {
 	alias, urlStr, hostCfg, _ = expandAlias(aliasedURL)
 	return alias, urlStr, hostCfg
 }


### PR DESCRIPTION
This config migration was done with the fact that
play.minio.io:9000 anonymous access has been
removed but instead one has to use access keys from
now on, while server is public will not honor 
anonymous requests anymore.