### PR TITLE
buildscripts: if `env go version` fails, check `go version`

### DIFF
--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -188,7 +188,11 @@ is_supported_arch() {
 check_deps() {
     check_version "$(env go version 2>/dev/null | sed 's/^.* go\([0-9.]*\).*$/\1/')" "${GO_VERSION}"
     if [ $? -ge 2 ]; then
-        MISSING="${MISSING} golang(>=${GO_VERSION})"
+        # Check again without env command.
+        check_version "$(go version 2>/dev/null | sed 's/^.* go\([0-9.]*\).*$/\1/')" "${GO_VERSION}"
+        if [ $? -ge 2 ]; then
+            MISSING="${MISSING} golang(>=${GO_VERSION})"
+        fi
     fi
 
     check_version "$(env git --version 2>/dev/null | sed -e 's/^.* \([0-9.\].*\).*$/\1/' -e 's/^\([0-9.\]*\).*/\1/g')" "${GIT_VERSION}"


### PR DESCRIPTION
    - $(env go version) fails because of too many symbolic links.
    Check again with $(go version)