### PR TITLE
tests: add tests for 'mc cat' and 'mc config host'

### DIFF
--- a/tests/tests/cat-test.sh
+++ b/tests/tests/cat-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+
+# Testing mc cat
+# 1. Pass a variable as stdin
+# 2. Assert result returned by mc cat is the same
+# 3. Repeat the same for mc pipe with no arguments
+# 4. Take a random string to test for non existant files
+
+dummy_string="asdasd"
+
+cat_result=`mc cat <<< $dummy_string`
+if [ "$cat_result" == "$dummy_string" ]; then
+    echo "mc cat STDIN Test Passed"
+else
+    echo "mc cat STDIN Test Failed"
+fi
+
+pipe_result=`mc pipe <<< $dummy_string`
+if [ "$pipe_result" == "$dummy_string" ]; then
+    echo "mc pipe STDIN Test Passed"
+else
+    echo "mc pipe STDIN Test Failed"
+fi
+
+random_string="asd.jasd"
+
+cat_json_result=`mc cat --json $random_string`
+if [[ "$cat_json_result" == *"\"status\":\"error\""* ]]
+then
+    echo "mc cat Non-Existent File Test Passed"
+else
+    echo "mc cat Non-Existent File Test Failed"
+fi

--- a/tests/tests/config-host-test.sh
+++ b/tests/tests/config-host-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+# Testing mc config  hosts
+# 1. Get number of previous hosts
+# 2. Add a host
+# 3. Assert the increase in number of hosts by one.
+# 4. Delete the new host
+
+
+initial_count=`mc config host list | wc -l`
+add_test_result=`mc config --json host add testdisk  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2`
+final_count=`mc config host list | wc -l`
+remove_test_result=`mc config host remove testdisk`
+
+if [ "$add_test_result" == "Added ‘testdisk’ successfully." ]; then
+    echo "mc config host add Test Passed";
+else
+    echo "mc config host add Test Failed";
+fi
+
+if [ $((initial_count + 1)) -ne $final_count ]; then
+    echo "mc config host list Test Failed";
+else
+    echo "mc config host list Test Passed";
+fi
+
+if [ "$remove_test_result" == "Removed ‘testdisk’ successfully." ]; then
+    echo "mc config host remove Test Passed";
+else
+    echo "mc config host remove Test Failed";
+fi


### PR DESCRIPTION
@harshavardhana I have written tests for 'mc cat' and 'mc pipe'. In test-minio.sh, it validates using test_script's stdout.
How do I integrate these to test-minio.sh?

I have not written tests for the 5th condition in #1530. Needs more clarity on what cases it should succeed except network failure.