### PR TITLE
pipe: Avoid double copy of buffers in minio-go

### DIFF
--- a/vendor/github.com/minio/minio-go/API.md
+++ b/vendor/github.com/minio/minio-go/API.md
@@ -157,7 +157,7 @@ __Arguments__
 
 __Example__
 ```go
-err := s3Client.SetBucketPolicy("mybucket", "myprefix", "readwrite")
+err := s3Client.SetBucketPolicy("mybucket", "myprefix", BucketPolicyReadWrite)
 if err != nil {
     fmt.Println(err)
     return

--- a/vendor/github.com/minio/minio-go/api-put-object-file.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-file.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"os"
+	"path/filepath"
 	"sort"
 )
 
@@ -55,6 +57,14 @@ func (c Client) FPutObject(bucketName, objectName, filePath, contentType string)
 	// Check for largest object size allowed.
 	if fileSize > int64(maxMultipartPutObjectSize) {
 		return 0, ErrEntityTooLarge(fileSize, maxMultipartPutObjectSize, bucketName, objectName)
+	}
+
+	// Set contentType based on filepath extension if not given or default
+	// value of "binary/octet-stream" if the extension has no associated type.
+	if contentType == "" {
+		if contentType = mime.TypeByExtension(filepath.Ext(filePath)); contentType == "" {
+			contentType = "application/octet-stream"
+		}
 	}
 
 	// NOTE: Google Cloud Storage multipart Put is not compatible with Amazon S3 APIs.

--- a/vendor/github.com/minio/minio-go/api-put-object-multipart.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-multipart.go
@@ -124,7 +124,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		var reader io.Reader
 		// Update progress reader appropriately to the latest offset
 		// as we read from the source.
-		reader = newHook(bytes.NewReader(tmpBuffer.Bytes()), progress)
+		reader = newHook(tmpBuffer, progress)
 
 		// Verify if part should be uploaded.
 		if shouldUploadPart(objectPart{

--- a/vendor/github.com/minio/minio-go/api-put-object-readat.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-readat.go
@@ -155,7 +155,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 		var reader io.Reader
 		// Update progress reader appropriately to the latest offset
 		// as we read from the source.
-		reader = newHook(bytes.NewReader(tmpBuffer.Bytes()), progress)
+		reader = newHook(tmpBuffer, progress)
 
 		// Proceed to upload the part.
 		var objPart objectPart

--- a/vendor/github.com/minio/minio-go/api.go
+++ b/vendor/github.com/minio/minio-go/api.go
@@ -70,7 +70,7 @@ type Client struct {
 // Global constants.
 const (
 	libraryName    = "minio-go"
-	libraryVersion = "1.0.0"
+	libraryVersion = "1.0.1"
 )
 
 // User Agent should always following the below style.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,8 +39,8 @@
 		},
 		{
 			"path": "github.com/minio/minio-go",
-			"revision": "ec610a695d37f1f04b9516a91857bfca007e3740",
-			"revisionTime": "2016-03-19T15:53:30-07:00"
+			"revision": "5a338968f406d8351e55c0d66cc754613ab9a206",
+			"revisionTime": "2016-03-25T17:35:39-07:00"
 		},
 		{
 			"path": "github.com/minio/minio/pkg/atomic",


### PR DESCRIPTION
Disallows multiple copies being referenced internally leads
to OOM conditions on certain low memory devices and systems.

Fixes #1641