### PR TITLE
stat: Print proper error messages when bucket name is empty.

### DIFF
--- a/client-errors.go
+++ b/client-errors.go
@@ -56,6 +56,15 @@ func (e BucketNameEmpty) Error() string {
 	return "Bucket name cannot be empty."
 }
 
+// BucketInvalid - bucket name invalid.
+type BucketInvalid struct {
+	Bucket string
+}
+
+func (e BucketInvalid) Error() string {
+	return "Bucket name " + e.Bucket + " not valid."
+}
+
 // ObjectAlreadyExists - typed return for MethodNotAllowed
 type ObjectAlreadyExists struct {
 	Object string

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -309,17 +309,9 @@ func doMirrorSession(session *sessionV6) {
 					// remaining files.
 					switch sURLs.Error.ToGoError().(type) {
 					// Handle this specifically for filesystem related errors.
-					case BrokenSymlink:
+					case BrokenSymlink, TooManyLevelsSymlink, PathNotFound, PathInsufficientPermission:
 						continue
-					case TooManyLevelsSymlink:
-						continue
-					case PathNotFound:
-						continue
-					case PathInsufficientPermission:
-						continue
-					case ObjectAlreadyExists:
-						continue
-					case BucketDoesNotExist:
+					case BucketNameEmpty, ObjectMissing, ObjectAlreadyExists, BucketDoesNotExist, BucketInvalid:
 						continue
 					}
 					// For critical errors we should exit. Session

--- a/mirror-url.go
+++ b/mirror-url.go
@@ -86,7 +86,7 @@ func checkMirrorSyntax(ctx *cli.Context) {
 	_, _, err = url2Stat(tgtURL)
 	// we die on any error other than PathNotFound - destination directory need not exist.
 	if _, ok := err.ToGoError().(PathNotFound); !ok {
-		fatalIf(err.Trace(tgtURL), fmt.Sprintf("Unable to stat %s", tgtURL))
+		fatalIf(err.Trace(tgtURL), fmt.Sprintf("Unable to stat target ‘%s’.", tgtURL))
 	}
 }
 


### PR DESCRIPTION
Handle cases for situations for all commands where target bucket
name is not specified, indicate proper errors in this situation.

Fixes #1629