### PR TITLE
config: (tmp fix) move loadConfigV8() inside closure to solve issue #1621

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,7 +111,8 @@ func loadMcConfigFactory() func() (*configV8, *probe.Error) {
 	}
 }
 
-var loadMcConfig = loadMcConfigFactory()
+// loadMcConfig - returns configuration, initialized later.
+var loadMcConfig func() (*configV8, *probe.Error)
 
 // saveMcConfig - saves configuration file and returns error if any.
 func saveMcConfig(config *configV8) *probe.Error {


### PR DESCRIPTION
-Move loadConfigV8() inside closure. This should solve the issue for now.
I was not able to detect the origin of the bug.

This solved the issue.
I guess quick.Load saves new config if earlier config does not exist use config path as key.
So repeated calls to loadConfigV8 will fetch from the cache. I am not completely sure, though.
