### PR TITLE
url: There is no reason to split '?' delimiter.

### DIFF
--- a/client-fs.go
+++ b/client-fs.go
@@ -55,7 +55,7 @@ func fsNew(path string) (Client, *probe.Error) {
 		return nil, probe.NewError(EmptyPath{})
 	}
 	return &fsClient{
-		PathURL: newURL(normalizePath(path)),
+		PathURL: newClientURL(normalizePath(path)),
 	}, nil
 }
 
@@ -435,7 +435,7 @@ func (f *fsClient) listPrefixes(prefix string, contentCh chan<- *clientContent, 
 					}
 				}
 				contentCh <- &clientContent{
-					URL:  *newURL(file),
+					URL:  *newClientURL(file),
 					Time: st.ModTime(),
 					Size: st.Size(),
 					Type: st.Mode(),
@@ -455,7 +455,7 @@ func (f *fsClient) listPrefixes(prefix string, contentCh chan<- *clientContent, 
 				}
 			}
 			contentCh <- &clientContent{
-				URL:  *newURL(file),
+				URL:  *newClientURL(file),
 				Time: fi.ModTime(),
 				Size: fi.Size(),
 				Type: fi.Mode(),
@@ -755,7 +755,7 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan *clientContent, incompl
 				}
 			}
 			contentCh <- &clientContent{
-				URL:  *newURL(fp),
+				URL:  *newClientURL(fp),
 				Time: fi.ModTime(),
 				Size: fi.Size(),
 				Type: fi.Mode(),

--- a/client-s3.go
+++ b/client-s3.go
@@ -50,7 +50,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 	// Return New function.
 	return func(config *Config) (Client, *probe.Error) {
 		// Creates a parsed URL.
-		targetURL := newURL(config.HostURL)
+		targetURL := newClientURL(config.HostURL)
 		// By default enable HTTPs.
 		inSecure := false
 		if targetURL.Scheme == "http" {

--- a/client-url.go
+++ b/client-url.go
@@ -90,10 +90,9 @@ func getHost(authority string) (host string) {
 	return authority
 }
 
-// newURL returns an abstracted URL for filesystems and object storage.
-func newURL(urlStr string) *clientURL {
+// newClientURL returns an abstracted URL for filesystems and object storage.
+func newClientURL(urlStr string) *clientURL {
 	scheme, rest := getScheme(urlStr)
-	rest, _ = splitSpecial(rest, "?", true)
 	if strings.HasPrefix(rest, "//") {
 		// if rest has '//' prefix, skip them
 		var authority string
@@ -115,7 +114,7 @@ func newURL(urlStr string) *clientURL {
 	}
 	return &clientURL{
 		Type:      fileSystem,
-		Path:      urlStr,
+		Path:      rest,
 		Separator: filepath.Separator,
 	}
 }
@@ -172,8 +171,8 @@ func isURLVirtualHostStyle(hostURL string) bool {
 
 // urlJoinPath Join a path to existing URL.
 func urlJoinPath(url1, url2 string) string {
-	u1 := newURL(url1)
-	u2 := newURL(url2)
+	u1 := newClientURL(url1)
+	u2 := newClientURL(url2)
 	return joinURLs(u1, u2).String()
 }
 
@@ -228,7 +227,7 @@ func isURLPrefixExists(urlPrefix string, incomplete bool) bool {
 // guessURLContentType - guess content-type of the URL.
 // on failure just return 'application/octet-stream'.
 func guessURLContentType(urlStr string) string {
-	url := newURL(urlStr)
+	url := newClientURL(urlStr)
 	contentType := mime.TypeByExtension(filepath.Ext(url.Path))
 	if contentType == "" {
 		contentType = "application/octet-stream"

--- a/client-url_test.go
+++ b/client-url_test.go
@@ -18,6 +18,20 @@ package main
 
 import . "gopkg.in/check.v1"
 
+// TestURL - tests url parsing and fields.
+func (s *TestSuite) TestURL(c *C) {
+	urlStr := "foo?.go"
+	url := newClientURL(urlStr)
+	c.Assert(url.Path, Equals, "foo?.go")
+
+	urlStr = "https://s3.amazonaws.com/mybucket/foo?.go"
+	url = newClientURL(urlStr)
+	c.Assert(url.Scheme, Equals, "https")
+	c.Assert(url.Host, Equals, "s3.amazonaws.com")
+	c.Assert(url.Path, Equals, "/mybucket/foo?.go")
+}
+
+// TestURLJoinPath - tests joining two different urls.
 func (s *TestSuite) TestURLJoinPath(c *C) {
 	// Join two URLs
 	url1 := "http://s3.mycompany.io/dev"

--- a/common-methods.go
+++ b/common-methods.go
@@ -29,7 +29,7 @@ import (
 
 // Check if the target URL represents folder. It may or may not exist yet.
 func isTargetURLDir(targetURL string) bool {
-	targetURLParse := newURL(targetURL)
+	targetURLParse := newClientURL(targetURL)
 	_, targetContent, err := url2Stat(targetURL)
 	if err != nil {
 		_, aliasedTargetURL, _ := mustExpandAlias(targetURL)

--- a/config-utils.go
+++ b/config-utils.go
@@ -46,7 +46,7 @@ func isValidHostURL(hostURL string) bool {
 	if strings.TrimSpace(hostURL) == "" {
 		return false
 	}
-	url := newURL(hostURL)
+	url := newClientURL(hostURL)
 	if url.Scheme != "https" && url.Scheme != "http" {
 		return false
 	}

--- a/cp-url-syntax.go
+++ b/cp-url-syntax.go
@@ -39,7 +39,7 @@ func checkCopySyntax(ctx *cli.Context) {
 
 	/****** Generic Invalid Rules *******/
 	// Check if bucket name is passed for URL type arguments.
-	url := newURL(tgtURL)
+	url := newClientURL(tgtURL)
 	if url.Host != "" {
 		// This check is for type URL.
 		if !isURLVirtualHostStyle(url.Host) {

--- a/cp-url.go
+++ b/cp-url.go
@@ -120,7 +120,7 @@ func makeCopyContentTypeA(sourceAlias string, sourceContent *clientContent, targ
 		SourceAlias:   sourceAlias,
 		SourceContent: sourceContent,
 		TargetAlias:   targetAlias,
-		TargetContent: &clientContent{URL: *newURL(targetURL)},
+		TargetContent: &clientContent{URL: *newClientURL(targetURL)},
 	}
 }
 
@@ -153,7 +153,7 @@ func prepareCopyURLsTypeB(sourceURL string, targetURL string) copyURLs {
 // makeCopyContentTypeB - CopyURLs content for copying.
 func makeCopyContentTypeB(sourceAlias string, sourceContent *clientContent, targetAlias string, targetURL string) copyURLs {
 	// All OK.. We can proceed. Type B: source is a file, target is a folder and exists.
-	targetURLParse := newURL(targetURL)
+	targetURLParse := newClientURL(targetURL)
 	targetURLParse.Path = filepath.ToSlash(filepath.Join(targetURLParse.Path, filepath.Base(sourceContent.URL.Path)))
 	return makeCopyContentTypeA(sourceAlias, sourceContent, targetAlias, targetURLParse.String())
 }

--- a/diff-main.go
+++ b/diff-main.go
@@ -148,11 +148,11 @@ func checkDiffSyntax(ctx *cli.Context) {
 // doDiffMain runs the diff.
 func doDiffMain(firstURL, secondURL string) {
 	// Source and targets are always directories
-	sourceSeparator := string(newURL(firstURL).Separator)
+	sourceSeparator := string(newClientURL(firstURL).Separator)
 	if !strings.HasSuffix(firstURL, sourceSeparator) {
 		firstURL = firstURL + sourceSeparator
 	}
-	targetSeparator := string(newURL(secondURL).Separator)
+	targetSeparator := string(newClientURL(secondURL).Separator)
 	if !strings.HasSuffix(secondURL, targetSeparator) {
 		secondURL = secondURL + targetSeparator
 	}

--- a/mirror-url.go
+++ b/mirror-url.go
@@ -74,7 +74,7 @@ func checkMirrorSyntax(ctx *cli.Context) {
 		fatalIf(errInvalidArgument().Trace(), "Invalid target arguments to mirror command.")
 	}
 
-	url := newURL(tgtURL)
+	url := newClientURL(tgtURL)
 	if url.Host != "" {
 		if !isURLVirtualHostStyle(url.Host) {
 			if url.Path == string(url.Separator) {
@@ -92,11 +92,11 @@ func checkMirrorSyntax(ctx *cli.Context) {
 
 func deltaSourceTargets(sourceURL string, targetURL string, isForce bool, isFake bool, mirrorURLsCh chan<- mirrorURLs) {
 	// source and targets are always directories
-	sourceSeparator := string(newURL(sourceURL).Separator)
+	sourceSeparator := string(newClientURL(sourceURL).Separator)
 	if !strings.HasSuffix(sourceURL, sourceSeparator) {
 		sourceURL = sourceURL + sourceSeparator
 	}
-	targetSeparator := string(newURL(targetURL).Separator)
+	targetSeparator := string(newClientURL(targetURL).Separator)
 	if !strings.HasSuffix(targetURL, targetSeparator) {
 		targetURL = targetURL + targetSeparator
 	}
@@ -158,7 +158,7 @@ func deltaSourceTargets(sourceURL string, targetURL string, isForce bool, isFake
 		}
 		// either available only in source or size differs and force is set
 		targetPath := urlJoinPath(targetURL, sourceSuffix)
-		targetContent := &clientContent{URL: *newURL(targetPath)}
+		targetContent := &clientContent{URL: *newClientURL(targetPath)}
 		mirrorURLsCh <- mirrorURLs{
 			SourceAlias:   sourceAlias,
 			SourceContent: sourceContent,

--- a/share-upload-main.go
+++ b/share-upload-main.go
@@ -100,7 +100,7 @@ func checkShareUploadSyntax(ctx *cli.Context) {
 	}
 
 	for _, targetURL := range ctx.Args() {
-		url := newURL(targetURL)
+		url := newClientURL(targetURL)
 		if strings.HasSuffix(targetURL, string(url.Separator)) && !isRecursive {
 			fatalIf(errInvalidArgument().Trace(targetURL),
 				"Use --recursive option to generate curl command for prefixes.")
@@ -110,7 +110,7 @@ func checkShareUploadSyntax(ctx *cli.Context) {
 
 // makeCurlCmd constructs curl command-line.
 func makeCurlCmd(key string, isRecursive bool, uploadInfo map[string]string) string {
-	URL := newURL(key)
+	URL := newClientURL(key)
 	postURL := URL.Scheme + URL.SchemeSeparator + URL.Host + string(URL.Separator)
 	if !isBucketVirtualStyle(URL.Host) {
 		postURL = postURL + uploadInfo["bucket"]


### PR DESCRIPTION
The reasoning is that we are not providing query
params through 'mc' and we don't need to handle it
specially. Since all paths are absolute with only
delimiter of '/' all other characters should be allowed
including '?'.

Fixes #1677