### PR TITLE
url: isURLPrefixExists() should use non-recursive mechanism.

### DIFF
--- a/client-fs.go
+++ b/client-fs.go
@@ -44,7 +44,7 @@ const (
 
 var ( // GOOS specific ignore list.
 	ignoreFiles = map[string][]string{
-		"darwin": []string{".DS_Store"},
+		"darwin": {".DS_Store"},
 		// "default": []string{""},
 	}
 )

--- a/client-url.go
+++ b/client-url.go
@@ -216,7 +216,7 @@ func isURLPrefixExists(urlPrefix string, incomplete bool) bool {
 	if err != nil {
 		return false
 	}
-	isRecursive := true
+	isRecursive := false
 	isIncomplete := incomplete
 	for entry := range clnt.List(isRecursive, isIncomplete) {
 		return entry.Err == nil


### PR DESCRIPTION
The reason is to avoid generating recursive requests while
we are only concerned about the top level prefix that if
it exists.