### PR TITLE
cp/mirror use CopyObject API to enable server side copy

### DIFF
--- a/client-fs_test.go
+++ b/client-fs_test.go
@@ -320,3 +320,25 @@ func (s *TestSuite) TestStatObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(content.Size, Equals, int64(dataLen))
 }
+
+// Test copy.
+func (s *TestSuite) TestCopy(c *C) {
+	root, e := ioutil.TempDir(os.TempDir(), "fs-")
+	c.Assert(e, IsNil)
+	defer os.RemoveAll(root)
+	sourcePath := filepath.Join(root, "source")
+	targetPath := filepath.Join(root, "target")
+	fsClientTarget, err := fsNew(targetPath)
+	fsClientSource, err := fsNew(sourcePath)
+	c.Assert(err, IsNil)
+
+	data := "hello world"
+	var reader io.Reader
+	reader = bytes.NewReader([]byte(data))
+	n, err := fsClientSource.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(len(data)))
+
+	err = fsClientTarget.Copy(sourcePath, int64(len(data)), nil)
+	c.Assert(err, IsNil)
+}

--- a/client.go
+++ b/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	// I/O operations
 	Get() (reader io.Reader, err *probe.Error)
 	Put(reader io.Reader, size int64, contentType string, progress io.Reader) (n int64, err *probe.Error)
+	Copy(source string, size int64, progress io.Reader) *probe.Error
 
 	// I/O operations with expiration
 	ShareDownload(expires time.Duration) (string, *probe.Error)

--- a/common-methods.go
+++ b/common-methods.go
@@ -96,6 +96,19 @@ func putTargetStream(urlStr string, reader io.Reader, size int64) (int64, *probe
 	return putTargetStreamFromAlias(alias, urlStrFull, reader, size, nil)
 }
 
+// copyTargetStreamFromAlias copies to URL from source.
+func copySourceStreamFromAlias(alias string, urlStr string, source string, size int64, progress io.Reader) *probe.Error {
+	targetClnt, err := newClientFromAlias(alias, urlStr)
+	if err != nil {
+		return err.Trace(alias, urlStr)
+	}
+	err = targetClnt.Copy(source, size, progress)
+	if err != nil {
+		return err.Trace(alias, urlStr)
+	}
+	return nil
+}
+
 // newClientFromAlias gives a new client interface for matching
 // alias entry in the mc config file. If no matching host config entry
 // is found, fs client is returned.

--- a/mirror-main.go
+++ b/mirror-main.go
@@ -196,7 +196,32 @@ func doMirror(sURLs mirrorURLs, progressReader *progressBar, accountingReader *a
 		sURLs.Error = nil
 		return sURLs
 	}
-
+	// If source size is <= 5GB and operation is across same server type try to use Copy.
+	if length <= fiveGB && (sourceURL.Type == targetURL.Type) {
+		// FS -> FS Copy includes alias in path.
+		if sourceURL.Type == fileSystem {
+			sourcePath := filepath.ToSlash(filepath.Join(sourceAlias, sourceURL.Path))
+			err := copySourceStreamFromAlias(targetAlias, targetURL.String(), sourcePath, length, progress)
+			if err != nil {
+				sURLs.Error = err.Trace(sourceURL.String())
+				return sURLs
+			}
+			sURLs.Error = nil
+			return sURLs
+		}
+		// If source/target are object storage their aliases must be the same
+		if sourceURL.Type == objectStorage && (sourceAlias == targetAlias) {
+			// Do not include alias inside path for ObjStore -> ObjStore.
+			err := copySourceStreamFromAlias(targetAlias, targetURL.String(), sourceURL.Path, length, progress)
+			if err != nil {
+				sURLs.Error = err.Trace(sourceURL.String())
+				return sURLs
+			}
+			sURLs.Error = nil
+			return sURLs
+		}
+	}
+	// Standard GET/PUT for size > 5GB
 	reader, err := getSourceStreamFromAlias(sourceAlias, sourceURL.String())
 	if err != nil {
 		sURLs.Error = err.Trace(sourceURL.String())


### PR DESCRIPTION
Adds:

Copy method to both fs and s3 clients with s3 client using CopyObject API to do both cp and mirror of objects < 5G. 
Test for fs client. 

No test for s3 client included but was manually tested using minio's aws server.