### PR TITLE
config: Relax valid access and secret keys.

### DIFF
--- a/config-utils.go
+++ b/config-utils.go
@@ -28,8 +28,8 @@ func isValidSecretKey(secretKey string) bool {
 	if secretKey == "" {
 		return true
 	}
-	regex := regexp.MustCompile(`^.{40}$`)
-	return regex.MatchString(secretKey)
+	regex := regexp.MustCompile(`.{8,40}$`)
+	return regex.MatchString(secretKey) && !strings.ContainsAny(secretKey, "$%^~`!|&*#@")
 }
 
 // isValidAccessKey - validate access key.
@@ -37,8 +37,8 @@ func isValidAccessKey(accessKey string) bool {
 	if accessKey == "" {
 		return true
 	}
-	regex := regexp.MustCompile(`^[A-Z0-9\\-\\.\\_\\~]{20}$`)
-	return regex.MatchString(accessKey)
+	regex := regexp.MustCompile(`.{5,40}$`)
+	return regex.MatchString(accessKey) && !strings.ContainsAny(accessKey, "$%^~`!|&*#@")
 }
 
 // isValidHostURL - validate input host url.

--- a/mc_test.go
+++ b/mc_test.go
@@ -61,6 +61,26 @@ func (s *TestSuite) TestValidPERMS(c *C) {
 	c.Assert(string(perms), Equals, "writeonly")
 }
 
+// Tests valid and invalid secret keys.
+func (s *TestSuite) TestValidSecretKeys(c *C) {
+	c.Assert(isValidSecretKey("password"), Equals, true)
+	c.Assert(isValidSecretKey("BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"), Equals, true)
+
+	c.Assert(isValidSecretKey("aaa"), Equals, false)
+	c.Assert(isValidSecretKey("password%%"), Equals, false)
+}
+
+// Tests valid and invalid access keys.
+func (s *TestSuite) TestValidAccessKeys(c *C) {
+	c.Assert(isValidAccessKey("c67W2-r4MAyAYScRl"), Equals, true)
+	c.Assert(isValidAccessKey("EXOb76bfeb1234562iu679f11588"), Equals, true)
+	c.Assert(isValidAccessKey("BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"), Equals, true)
+	c.Assert(isValidAccessKey("admin"), Equals, true)
+
+	c.Assert(isValidAccessKey("aaa"), Equals, false)
+	c.Assert(isValidAccessKey("$$%%%%%3333"), Equals, false)
+}
+
 func (s *TestSuite) TestInvalidPERMS(c *C) {
 	perms := accessPerms("invalid")
 	c.Assert(perms.isValidAccessPERM(), Equals, false)


### PR DESCRIPTION
Deviating from AWS Standards to support non
AWS Standard keys for Ceph and Exoscale, probably
others.

Fixes #1690