### PR TITLE
ls: ls should ignore error BucketNameEmpty.

### DIFF
--- a/ls-main.go
+++ b/ls-main.go
@@ -96,6 +96,11 @@ func checkListSyntax(ctx *cli.Context) {
 	for _, url := range URLs {
 		_, _, err := url2Stat(url)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
+			// Bucket name empty is a valid error for 'ls myminio',
+			// treat it as such.
+			if _, ok := err.ToGoError().(BucketNameEmpty); ok {
+				continue
+			}
 			fatalIf(err.Trace(url), "Unable to stat ‘"+url+"’.")
 		}
 	}


### PR DESCRIPTION
This is a valid case of 'ls', without this change.

```
$ mc ls localhost
mc: <ERROR> Unable to stat ‘localhost’. Bucket name cannot be empty.
```

What we need to ideally see is if server is not available is
```
$ mc ls localhost
mc: <ERROR> Unable to list folder. Get http://localhost:9000/: dial tcp [::1]:9000: getsockopt: connection refused
```