### PR TITLE
session: Signal trap shouldn't panic, close the Notify handler.

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -38,6 +38,9 @@ func signalTrap(sig ...os.Signal) <-chan bool {
 		// Wait for the signal.
 		<-sigCh
 
+		// Once signal has been received stop signal Notify handler.
+		signal.Stop(sigCh)
+
 		// Notify the caller.
 		trapCh <- true
 	}(trapCh)


### PR DESCRIPTION
Avoid executing Notify handler again when two SIGINTS are
received which can occur when 'mc' is busy copying a largefile.

Fixes #1710