### PR TITLE
ls: list objects inside a directory when this latter is passed without a trailing separtor

### DIFF
--- a/ls-main.go
+++ b/ls-main.go
@@ -135,6 +135,15 @@ func mainList(ctx *cli.Context) {
 		clnt, err := newClient(targetURL)
 		fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
 
+		st, err := clnt.Stat()
+		fatalIf(err.Trace(targetURL), "Unable to stat target ‘"+targetURL+"’.")
+
+		if st.Type.IsDir() {
+			targetURL = targetURL + string(clnt.GetURL().Separator)
+			clnt, err = newClient(targetURL)
+			fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
+		}
+
 		err = doList(clnt, isRecursive, isIncomplete)
 		if err != nil {
 			errorIf(err.Trace(clnt.GetURL().String()), "Unable to list target ‘"+clnt.GetURL().String()+"’.")


### PR DESCRIPTION
The difference between fs/s3 is better to be handled at top level or at a specific level, could we discuss a better change if any?