### PR TITLE
Ignore BucketEmpty error for top-level listing

### DIFF
--- a/ls-main.go
+++ b/ls-main.go
@@ -137,8 +137,11 @@ func mainList(ctx *cli.Context) {
 
 		var st *clientContent
 		if st, err = clnt.Stat(); err != nil {
+			switch err.ToGoError().(type) {
+			case BucketNameEmpty:
 			// For aliases like ``mc ls s3`` it's acceptable to receive BucketNameEmpty error.
-			if _, bucketEmpty := err.Cause.(BucketNameEmpty); !bucketEmpty {
+			// Nothing to do.
+			default:
 				fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
 			}
 		} else if st.Type.IsDir() {


### PR DESCRIPTION
This is relevant in the case of non-fs backend like s3, play etc.

Closes #1725 