### PR TITLE
Made session list ignore broken sessions

### DIFF
--- a/session-main.go
+++ b/session-main.go
@@ -90,9 +90,8 @@ func listSessions() *probe.Error {
 		session, err := loadSessionV7(sid)
 		if err != nil {
 			continue // Skip 'broken' session during listing
-		} else {
-			session.Close() // Session close right here.
 		}
+		session.Close() // Session close right here.
 		bySessions = append(bySessions, session)
 	}
 	// sort sessions based on time.
@@ -150,6 +149,8 @@ func clearSession(sid string) {
 
 	session, err := loadSessionV7(sid)
 	if err != nil {
+		// `mc session clear <broken-session-id>` assumes that user is aware that the session is unuseful
+		// and wants the associated session files to be removed
 		removeSessionFile(sid)
 		removeSessionDataFile(sid)
 		printMsg(clearSessionMessage{Status: "forced", SessionID: sid})

--- a/session-main.go
+++ b/session-main.go
@@ -89,9 +89,10 @@ func listSessions() *probe.Error {
 	for _, sid := range getSessionIDs() {
 		session, err := loadSessionV7(sid)
 		if err != nil {
-			return err.Trace(sid)
+			continue // Skip 'broken' session during listing
+		} else {
+			session.Close() // Session close right here.
 		}
-		session.Close() // Session close right here.
 		bySessions = append(bySessions, session)
 	}
 	// sort sessions based on time.
@@ -110,7 +111,15 @@ type clearSessionMessage struct {
 
 // String colorized clear session message.
 func (c clearSessionMessage) String() string {
-	return console.Colorize("ClearSession", "Session ‘"+c.SessionID+"’ cleared successfully.")
+	msg := "Session ‘" + c.SessionID + "’"
+	var colorizedMsg string
+	switch c.Status {
+	case "success":
+		colorizedMsg = console.Colorize("ClearSession", msg+" cleared succesfully.")
+	case "forced":
+		colorizedMsg = console.Colorize("ClearSession", msg+" cleared forcefully.")
+	}
+	return colorizedMsg
 }
 
 // JSON jsonified clear session message.
@@ -140,7 +149,12 @@ func clearSession(sid string) {
 	}
 
 	session, err := loadSessionV7(sid)
-	fatalIf(err.Trace(sid), "Unable to load session ‘"+sid+"’.")
+	if err != nil {
+		removeSessionFile(sid)
+		removeSessionDataFile(sid)
+		printMsg(clearSessionMessage{Status: "forced", SessionID: sid})
+		return
+	}
 
 	if session != nil {
 		fatalIf(session.Delete().Trace(sid), "Unable to load session ‘"+sid+"’.")

--- a/session-v7.go
+++ b/session-v7.go
@@ -138,10 +138,10 @@ func loadSessionV7(sid string) (*sessionV7, *probe.Error) {
 		return nil, err.Trace(sid, s.Header.Version)
 	}
 
-	var e error
 	dataFile, e := os.Open(sessionDataFile)
-	fatalIf(probe.NewError(e), "Unable to open session data file \""+sessionDataFile+"\".")
-
+	if e != nil {
+		return nil, probe.NewError(e)
+	}
 	s.DataFP = &sessionDataFP{false, dataFile}
 
 	return s, nil

--- a/session.go
+++ b/session.go
@@ -116,6 +116,7 @@ func getSessionIDs() (sids []string) {
 	return sids
 }
 
+// removeSessionFile - remove the session file, ending with .json
 func removeSessionFile(sid string) {
 	sessionFile, err := getSessionFile(sid)
 	if err != nil {
@@ -124,6 +125,7 @@ func removeSessionFile(sid string) {
 	os.Remove(sessionFile)
 }
 
+// removeSessionDataFile - remove the session data file, ending with .data
 func removeSessionDataFile(sid string) {
 	dataFile, err := getSessionDataFile(sid)
 	if err != nil {

--- a/session.go
+++ b/session.go
@@ -115,3 +115,19 @@ func getSessionIDs() (sids []string) {
 	}
 	return sids
 }
+
+func removeSessionFile(sid string) {
+	sessionFile, err := getSessionFile(sid)
+	if err != nil {
+		return
+	}
+	os.Remove(sessionFile)
+}
+
+func removeSessionDataFile(sid string) {
+	dataFile, err := getSessionDataFile(sid)
+	if err != nil {
+		return
+	}
+	os.Remove(dataFile)
+}

--- a/session_test.go
+++ b/session_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"os"
 	"regexp"
 
 	. "gopkg.in/check.v1"
@@ -37,9 +38,12 @@ func (s *TestSuite) TestSession(c *C) {
 	session := newSessionV7()
 	c.Assert(session.Header.CommandArgs, IsNil)
 	c.Assert(len(session.SessionID), Equals, 8)
+	_, e := os.Stat(session.DataFP.Name())
+	c.Assert(e, IsNil)
 
 	err = session.Close()
 	c.Assert(err, IsNil)
+	c.Assert(isSessionExists(session.SessionID), Equals, true)
 
 	savedSession, err := loadSessionV7(session.SessionID)
 	c.Assert(err, IsNil)
@@ -50,4 +54,7 @@ func (s *TestSuite) TestSession(c *C) {
 
 	err = savedSession.Delete()
 	c.Assert(err, IsNil)
+	c.Assert(isSessionExists(session.SessionID), Equals, false)
+	_, e = os.Stat(session.DataFP.Name())
+	c.Assert(e, NotNil)
 }


### PR DESCRIPTION
- `mc session list` - skips partial sessions[1]

- `mc session clear all` - doesn't clear partial sessions.
The idea is to prevent the user from clearing all sessions without
realising that there were partial sessions.

When there is one or more partial sessions, clear each one of them individually
as follows,
 `mc session clear <broken-session-id>` - clears the partial sessions.

[1] - partial session - a session with missing `.data` file in the sessions directory.

N B The presence of partial sessions indicate some underlying bug in session mangement
code. This PR provides relief for users in the event of such a bug.

Closes #1723