### PR TITLE
Rename access cmd to policy and permissions to none, download, upload and both

### DIFF
--- a/access-perms.go
+++ b/access-perms.go
@@ -19,7 +19,7 @@ package main
 // isValidAccessPERM - is provided access perm string supported.
 func (b accessPerms) isValidAccessPERM() bool {
 	switch b {
-	case accessNone, accessReadOnly, accessReadWrite, accessWriteOnly:
+	case accessNone, accessDownload, accessUpload, accessBoth:
 		return true
 	}
 	return false
@@ -28,10 +28,10 @@ func (b accessPerms) isValidAccessPERM() bool {
 // accessPerms - access level.
 type accessPerms string
 
-// different types of Access perm's currently supported by access command.
+// different types of Access perm's currently supported by policy command.
 const (
-	accessNone      = accessPerms("none")
-	accessReadOnly  = accessPerms("readonly")
-	accessReadWrite = accessPerms("readwrite")
-	accessWriteOnly = accessPerms("writeonly")
+	accessNone     = accessPerms("none")
+	accessDownload = accessPerms("download")
+	accessUpload   = accessPerms("upload")
+	accessBoth     = accessPerms("both")
 )

--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func registerApp() *cli.App {
 	registerCmd(mirrorCmd)  // Mirror objects and files from single source to multiple destinations.
 	registerCmd(diffCmd)    // Computer differences between two files or folders.
 	registerCmd(rmCmd)      // Remove a file or bucket
-	registerCmd(accessCmd)  // Set access permissions.
+	registerCmd(policyCmd)  // Set policy permissions.
 	registerCmd(sessionCmd) // Manage sessions for copy and mirror.
 	registerCmd(configCmd)  // Configure minio client.
 	registerCmd(updateCmd)  // Check for new software updates.

--- a/mc_test.go
+++ b/mc_test.go
@@ -50,15 +50,15 @@ func (s *TestSuite) TestValidPERMS(c *C) {
 	perms := accessPerms("none")
 	c.Assert(perms.isValidAccessPERM(), Equals, true)
 	c.Assert(string(perms), Equals, "none")
-	perms = accessPerms("readwrite")
+	perms = accessPerms("both")
 	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "readwrite")
-	perms = accessPerms("readonly")
+	c.Assert(string(perms), Equals, "both")
+	perms = accessPerms("download")
 	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "readonly")
-	perms = accessPerms("writeonly")
+	c.Assert(string(perms), Equals, "download")
+	perms = accessPerms("upload")
 	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "writeonly")
+	c.Assert(string(perms), Equals, "upload")
 }
 
 // Tests valid and invalid secret keys.

--- a/policy-main.go
+++ b/policy-main.go
@@ -26,20 +26,20 @@ import (
 )
 
 var (
-	accessFlags = []cli.Flag{
+	policyFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "help, h",
-			Usage: "Help of access.",
+			Usage: "Help of policy.",
 		},
 	}
 )
 
-// Set public access permissions.
-var accessCmd = cli.Command{
-	Name:   "access",
-	Usage:  "Set public access permissions on bucket or prefix.",
-	Action: mainAccess,
-	Flags:  append(accessFlags, globalFlags...),
+// Set public policy
+var policyCmd = cli.Command{
+	Name:   "policy",
+	Usage:  "Set public policy on bucket or prefix.",
+	Action: mainPolicy,
+	Flags:  append(policyFlags, globalFlags...),
 	CustomHelpTemplate: `Name:
    mc {{.Name}} - {{.Usage}}
 
@@ -48,23 +48,23 @@ USAGE:
    mc {{.Name}} [FLAGS] TARGET
 
 PERMISSION:
-   Allowed permissions are: [none, readonly, readwrite, writeonly].
+   Allowed policies are: [none, download, upload, both].
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
-   1. Set bucket to "readonly" on Amazon S3 cloud storage.
-      $ mc {{.Name}} readonly s3/burningman2011
+   1. Set bucket to "download" on Amazon S3 cloud storage.
+      $ mc {{.Name}} download s3/burningman2011
 
-   2. Set bucket to "readwrite" on Amazon S3 cloud storage.
-      $ mc {{.Name}} readwrite s3/shared
+   2. Set bucket to "both" on Amazon S3 cloud storage.
+      $ mc {{.Name}} both s3/shared
 
-   3. Set bucket to "writeonly" on Amazon S3 cloud storage.
-      $ mc {{.Name}} writeonly s3/incoming
+   3. Set bucket to "upload" on Amazon S3 cloud storage.
+      $ mc {{.Name}} upload s3/incoming
 
-   4. Set a prefix to "readwrite" on Amazon S3 cloud storage.
-      $ mc {{.Name}} readwrite s3/public-commons/images
+   4. Set a prefix to "both" on Amazon S3 cloud storage.
+      $ mc {{.Name}} both s3/public-commons/images
 
    5. Get bucket permissions.
       $ mc {{.Name}} s3/shared
@@ -72,8 +72,8 @@ EXAMPLES:
 `,
 }
 
-// accessMessage is container for access command on bucket success and failure messages.
-type accessMessage struct {
+// policyMessage is container for policy command on bucket success and failure messages.
+type policyMessage struct {
 	Operation string      `json:"operation"`
 	Status    string      `json:"status"`
 	Bucket    string      `json:"bucket"`
@@ -81,44 +81,44 @@ type accessMessage struct {
 }
 
 // String colorized access message.
-func (s accessMessage) String() string {
+func (s policyMessage) String() string {
 	if s.Operation == "set" {
-		return console.Colorize("Access",
+		return console.Colorize("Policy",
 			"Access permission for ‘"+s.Bucket+"’ is set to ‘"+string(s.Perms)+"’")
 	}
 	if s.Operation == "get" {
-		return console.Colorize("Access",
+		return console.Colorize("Policy",
 			"Access permission for ‘"+s.Bucket+"’"+" is ‘"+string(s.Perms)+"’")
 	}
 	// nothing to print
 	return ""
 }
 
-// JSON jsonified access message.
-func (s accessMessage) JSON() string {
-	accessJSONBytes, e := json.Marshal(s)
+// JSON jsonified policy message.
+func (s policyMessage) JSON() string {
+	policyJSONBytes, e := json.Marshal(s)
 	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
 
-	return string(accessJSONBytes)
+	return string(policyJSONBytes)
 }
 
-// checkAccessSyntax check for incoming syntax.
-func checkAccessSyntax(ctx *cli.Context) {
+// checkPolicySyntax check for incoming syntax.
+func checkPolicySyntax(ctx *cli.Context) {
 	if !ctx.Args().Present() {
-		cli.ShowCommandHelpAndExit(ctx, "access", 1) // last argument is exit code.
+		cli.ShowCommandHelpAndExit(ctx, "policy", 1) // last argument is exit code.
 	}
 	if len(ctx.Args()) > 2 {
-		cli.ShowCommandHelpAndExit(ctx, "access", 1) // last argument is exit code.
+		cli.ShowCommandHelpAndExit(ctx, "policy", 1) // last argument is exit code.
 	}
 	if len(ctx.Args()) == 2 {
 		perms := accessPerms(ctx.Args().Get(0))
 		if !perms.isValidAccessPERM() {
 			fatalIf(errDummy().Trace(),
-				"Unrecognized permission ‘"+string(perms)+"’. Allowed values are [none, readonly, readwrite, writeonly].")
+				"Unrecognized permission ‘"+string(perms)+"’. Allowed values are [none, download, upload, both].")
 		}
 	}
 	if len(ctx.Args()) < 1 {
-		cli.ShowCommandHelpAndExit(ctx, "access", 1) // last argument is exit code.
+		cli.ShowCommandHelpAndExit(ctx, "policy", 1) // last argument is exit code.
 	}
 }
 
@@ -128,7 +128,18 @@ func doSetAccess(targetURL string, targetPERMS accessPerms) *probe.Error {
 	if err != nil {
 		return err.Trace(targetURL)
 	}
-	if err = clnt.SetAccess(string(targetPERMS)); err != nil {
+	policy := ""
+	switch targetPERMS {
+	case accessNone:
+		policy = "none"
+	case accessDownload:
+		policy = "readonly"
+	case accessUpload:
+		policy = "writeonly"
+	case accessBoth:
+		policy = "readwrite"
+	}
+	if err = clnt.SetAccess(policy); err != nil {
 		return err.Trace(targetURL, string(targetPERMS))
 	}
 	return nil
@@ -144,18 +155,30 @@ func doGetAccess(targetURL string) (perms accessPerms, err *probe.Error) {
 	if err != nil {
 		return "", err.Trace(targetURL)
 	}
-	return accessPerms(perm), nil
+	var policy accessPerms
+	switch perm {
+	case "none":
+		policy = accessNone
+	case "readonly":
+		policy = accessDownload
+	case "writeonly":
+		policy = accessUpload
+	case "readwrite":
+		policy = accessBoth
+	}
+
+	return policy, nil
 }
 
-func mainAccess(ctx *cli.Context) {
+func mainPolicy(ctx *cli.Context) {
 	// Set global flags from context.
 	setGlobalsFromContext(ctx)
 
-	// check 'access' cli arguments.
-	checkAccessSyntax(ctx)
+	// check 'policy' cli arguments.
+	checkPolicySyntax(ctx)
 
 	// Additional command speific theme customization.
-	console.SetColor("Access", color.New(color.FgGreen, color.Bold))
+	console.SetColor("Policy", color.New(color.FgGreen, color.Bold))
 
 	perms := accessPerms(ctx.Args().First())
 	if perms.isValidAccessPERM() {
@@ -163,8 +186,8 @@ func mainAccess(ctx *cli.Context) {
 		err := doSetAccess(targetURL, perms)
 		// Upon error exit.
 		fatalIf(err.Trace(targetURL, string(perms)),
-			"Unable to set access permission ‘"+string(perms)+"’ for ‘"+targetURL+"’.")
-		printMsg(accessMessage{
+			"Unable to set policy ‘"+string(perms)+"’ for ‘"+targetURL+"’.")
+		printMsg(policyMessage{
 			Status:    "success",
 			Operation: "set",
 			Bucket:    targetURL,
@@ -173,8 +196,8 @@ func mainAccess(ctx *cli.Context) {
 	} else {
 		targetURL := ctx.Args().First()
 		perms, err := doGetAccess(targetURL)
-		fatalIf(err.Trace(targetURL), "Unable to get access permission for ‘"+targetURL+"’.")
-		printMsg(accessMessage{
+		fatalIf(err.Trace(targetURL), "Unable to get policy for ‘"+targetURL+"’.")
+		printMsg(policyMessage{
 			Status:    "success",
 			Operation: "get",
 			Bucket:    targetURL,

--- a/tests/tests/access-test.sh
+++ b/tests/tests/access-test.sh
@@ -2,5 +2,5 @@
 
 server="$1"
 
-mc --json access set readonly "$server/testbucket"
+mc --json access set download "$server/testbucket"
 # TODO: validate output


### PR DESCRIPTION
none, readonly, writeonly, readwrite are kept in lower levels.

Fixes #1752 