### PR TITLE
client-s3 Stat() returns proper error in case of an object or dir are…

### DIFF
--- a/client-s3.go
+++ b/client-s3.go
@@ -368,10 +368,11 @@ func (c *s3Client) Stat() (*clientContent, *probe.Error) {
 			objectMetadata.Type = os.FileMode(0664)
 			return objectMetadata, nil
 		}
+		objectMetadata.URL = *c.targetURL
+		objectMetadata.Type = os.ModeDir
+		return objectMetadata, nil
 	}
-	objectMetadata.URL = *c.targetURL
-	objectMetadata.Type = os.ModeDir
-	return objectMetadata, nil
+	return nil, probe.NewError(ObjectMissing{})
 }
 
 func isAmazon(host string) bool {


### PR DESCRIPTION
… not found