### PR TITLE
rm: add timebased delete and object list from stdin

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/cheggaaa/pb"
 	"github.com/fatih/color"
@@ -193,7 +194,7 @@ func (ms *mirrorSession) doRemove(sURLs URLs) URLs {
 	isIncomplete := false
 
 	// Remove extraneous file on target.
-	err := rm(targetAlias, targetURL.String(), isIncomplete, isFake)
+	err := rm(targetAlias, targetURL.String(), isIncomplete, isFake, time.Duration(0))
 	if err != nil {
 		return sURLs.WithError(err.Trace(targetAlias, targetURL.String()))
 	}


### PR DESCRIPTION
* Add multi-delete support by taking object list from stdin
* Add support to `rm` to remove objects older than given time

Fixes #1827 #1828