### PR TITLE
Do not return S3 empty directories in recursive listing

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1065,6 +1065,10 @@ func (c *s3Client) listRecursiveInRoutine(contentCh chan *clientContent) {
 				}
 				continue
 			}
+			// Ignore S3 empty directories
+			if object.Size == 0 && strings.HasSuffix(object.Key, "/") {
+				continue
+			}
 			content := &clientContent{}
 			url := *c.targetURL
 			// Join bucket and incoming object key.


### PR DESCRIPTION
Recursive listing currently shows empty directories (file with prefix '/' and size equal to zero). I prefered to make this change in client-s3 instead of minio-go since an empty dir is an actual file in S3.

This PR fixes #1716 