### PR TITLE
ls: fix incomplete listing for specific prefix

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -1042,7 +1042,7 @@ func (f *fsClient) SetAccess(access string) *probe.Error {
 }
 
 // Stat - get metadata from path.
-func (f *fsClient) Stat() (content *clientContent, err *probe.Error) {
+func (f *fsClient) Stat(isIncomplete bool) (content *clientContent, err *probe.Error) {
 	st, err := f.fsStat()
 	if err != nil {
 		return nil, err.Trace(f.PathURL.String())

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -201,7 +201,7 @@ func (s *TestSuite) TestStatBucket(c *C) {
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1")
 	c.Assert(err, IsNil)
-	_, err = fsClient.Stat()
+	_, err = fsClient.Stat(false)
 	c.Assert(err, IsNil)
 }
 
@@ -317,7 +317,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	content, err := fsClient.Stat()
+	content, err := fsClient.Stat(false)
 	c.Assert(err, IsNil)
 	c.Assert(content.Size, Equals, int64(dataLen))
 }

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -182,7 +182,7 @@ func url2Stat(urlStr string) (client Client, content *clientContent, err *probe.
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}
-	content, err = client.Stat()
+	content, err = client.Stat(false)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -27,7 +27,7 @@ import (
 // Client - client interface
 type Client interface {
 	// Common operations
-	Stat() (content *clientContent, err *probe.Error)
+	Stat(isIncomplete bool) (content *clientContent, err *probe.Error)
 	List(recursive, incomplete bool) <-chan *clientContent
 
 	// Bucket operations

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -136,7 +136,7 @@ func mainList(ctx *cli.Context) {
 		fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")
 
 		var st *clientContent
-		if st, err = clnt.Stat(); err != nil {
+		if st, err = clnt.Stat(isIncomplete); err != nil {
 			switch err.ToGoError().(type) {
 			case BucketNameEmpty:
 			// For aliases like ``mc ls s3`` it's acceptable to receive BucketNameEmpty error.

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -428,7 +428,7 @@ func (ms *mirrorSession) watch() {
 						ms.statusCh <- mirrorURL.WithError(err)
 						continue
 					}
-					sourceContent, err := sourceClient.Stat()
+					sourceContent, err := sourceClient.Stat(false)
 					if err != nil {
 						// source doesn't exist anymore
 						ms.statusCh <- mirrorURL.WithError(err)
@@ -442,7 +442,7 @@ func (ms *mirrorSession) watch() {
 					}
 					shouldQueue := false
 					if !isForce {
-						_, err = targetClient.Stat()
+						_, err = targetClient.Stat(false)
 						if err == nil {
 							continue
 						} // doesn't exist
@@ -467,7 +467,7 @@ func (ms *mirrorSession) watch() {
 						ms.statusCh <- mirrorURL.WithError(err)
 						return
 					}
-					_, err = targetClient.Stat()
+					_, err = targetClient.Stat(false)
 					if err == nil {
 						continue
 					} // doesn't exist

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -188,7 +188,7 @@ func rm(targetAlias, targetURL string, isIncomplete, isFake bool, older time.Dur
 
 	// Check whether object is created older than given time only if older is >= one hour.
 	if older >= defaultOlderTime {
-		info, err := clnt.Stat()
+		info, err := clnt.Stat(isIncomplete)
 		if err != nil {
 			return err.Trace(targetURL)
 		}


### PR DESCRIPTION
Previously it was failing like below.

```
$ mc ls --incomplete myminio/mybucket
[2016-09-16 09:48:57 PDT] 576MiB 1.iso

$ mc ls --incomplete myminio/mybucket/1.iso
mc: <ERROR> Unable to initialize target ‘myminio/mybucket/1.iso’. Object key is missing, object key cannot be empty
```

This patch fixes this issue.