### PR TITLE
In json or quiet we print the full path of the target. Instead with a…

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -149,11 +149,9 @@ func doCopy(cpURLs URLs, progressReader *progressBar, accountingReader *accounte
 
 	var progress io.Reader
 	if globalQuiet || globalJSON {
-		sourcePath := filepath.ToSlash(filepath.Join(sourceAlias, sourceURL.Path))
-		targetPath := filepath.ToSlash(filepath.Join(targetAlias, targetURL.Path))
 		printMsg(copyMessage{
-			Source: sourcePath,
-			Target: targetPath,
+			Source: sourceURL.String(),
+			Target: targetURL.String(),
 		})
 		// Proxy reader to accounting reader only during quiet mode.
 		if globalQuiet || globalJSON {

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -219,12 +219,9 @@ func (ms *mirrorSession) doMirror(sURLs URLs) URLs {
 	length := sURLs.SourceContent.Size
 
 	ms.status.SetCaption(sourceURL.String() + ": ")
-
-	sourcePath := filepath.ToSlash(filepath.Join(sourceAlias, sourceURL.Path))
-	targetPath := filepath.ToSlash(filepath.Join(targetAlias, targetURL.Path))
 	ms.status.PrintMsg(mirrorMessage{
-		Source: sourcePath,
-		Target: targetPath,
+		Source: sourceURL.String(),
+		Target: targetURL.String(),
 	})
 
 	// If source size is <= 5GB and operation is across same server type try to use Copy.


### PR DESCRIPTION
…lias.