### PR TITLE
fix regex comparator for GOROOT

### DIFF
--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -134,7 +134,7 @@ check_golang_env() {
         new_go_binary_path=$(readlink ${go_binary_path})
     fi
 
-    if [[ !"$(dirname ${new_go_binary_path})" =~ *"${GOROOT%%*(/)}"* ]] ; then
+    if [[ ! "$(dirname ${new_go_binary_path})" =~ "${GOROOT}"* ]] ; then
         echo "The go binary found in your PATH configuration does not belong to the Go installation pointed by your GOROOT environment," \
             "please refer to Go installation document"
         echo "https://github.com/minio/mc/blob/master/INSTALLGO.md#install-go-13"


### PR DESCRIPTION
Noticed this fails on bash 4.3.42, but actually the syntax that fails here was too inclusive to begin with.

I think we want GOPATH to be inclusive on the right, and not inclusive on the left. With a GOROOT of /usr/lib/go, a go binary from /usr/lib/go/bin/go is good, but from /foo/bar/baz/usr/lib/go would be bad.

bash 4.3.42:
[[ ! /usr/lib/go/bin =~ */usr/lib/go/bin* ]] returns 1
[[ ! /usr/lib/go/bin =~ /usr/lib/go/bin* ]] returns 0
[[ ! /usr/lib/go/bin =~ */usr/lib/go* ]] returns 1
[[ ! /usr/lib/go/bin =~ /usr/lib/go* ]] returns 0

bash 4.3.11
[[ ! /usr/lib/go/bin =~ */usr/lib/go/bin* ]] returns 0
[[ ! /usr/lib/go/bin =~ /usr/lib/go/bin* ]] returns 0
[[ ! /usr/lib/go/bin =~ */usr/lib/go* ]] returns 0
[[ ! /usr/lib/go/bin =~ /usr/lib/go* ]] returns 0

With this change, both versions return 0 in all cases.