### PR TITLE
mirror and cp should print size in --json mode.

### DIFF
--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -82,14 +82,9 @@ func objectDifference(sourceClnt, targetClnt Client, sourceURL, targetURL string
 			}
 
 			if !srcEOF && srcCtnt.Err != nil {
-				switch srcCtnt.Err.ToGoError().(type) {
-				// Handle this specifically for filesystem related errors.
-				case BrokenSymlink, TooManyLevelsSymlink, PathNotFound, PathInsufficientPermission:
+				if isErrIgnored(srcCtnt.Err) {
 					errorIf(srcCtnt.Err.Trace(sourceURL, targetURL), fmt.Sprintf("Failed on '%s'", sourceURL))
-				// Handle these specifically for object storage related errors.
-				case BucketNameEmpty, ObjectMissing, ObjectAlreadyExists, BucketDoesNotExist, BucketInvalid, ObjectOnGlacier:
-					errorIf(srcCtnt.Err.Trace(sourceURL, targetURL), fmt.Sprintf("Failed on '%s'", sourceURL))
-				default:
+				} else {
 					fatalIf(srcCtnt.Err.Trace(sourceURL, targetURL), fmt.Sprintf("Failed on '%s'", sourceURL))
 				}
 				srcCtnt, srcOk = <-srcCh
@@ -97,14 +92,9 @@ func objectDifference(sourceClnt, targetClnt Client, sourceURL, targetURL string
 			}
 
 			if !tgtEOF && tgtCtnt.Err != nil {
-				switch tgtCtnt.Err.ToGoError().(type) {
-				// Handle this specifically for filesystem related errors.
-				case BrokenSymlink, TooManyLevelsSymlink, PathNotFound, PathInsufficientPermission:
+				if isErrIgnored(tgtCtnt.Err) {
 					errorIf(tgtCtnt.Err.Trace(sourceURL, targetURL), fmt.Sprintf("Failed on '%s'", targetURL))
-				// Handle these specifically for object storage related errors.
-				case BucketNameEmpty, ObjectMissing, ObjectAlreadyExists, BucketDoesNotExist, BucketInvalid, ObjectOnGlacier:
-					errorIf(tgtCtnt.Err.Trace(sourceURL, targetURL), fmt.Sprintf("Failed on '%s'", targetURL))
-				default:
+				} else {
 					fatalIf(tgtCtnt.Err.Trace(sourceURL, targetURL), fmt.Sprintf("Failed on '%s'", targetURL))
 				}
 				tgtCtnt, tgtOk = <-tgtCh

--- a/cmd/session-migrate.go
+++ b/cmd/session-migrate.go
@@ -62,7 +62,7 @@ func migrateSessionV7ToV8() {
 		sV8Header.LastCopied = sV7.Header.LastCopied
 		sV8Header.LastRemoved = sV7.Header.LastRemoved
 		sV8Header.TotalBytes = sV7.Header.TotalBytes
-		sV8Header.TotalObjects = sV7.Header.TotalObjects
+		sV8Header.TotalObjects = int64(sV7.Header.TotalObjects)
 
 		// Add insecure flag to the new V8 header
 		sV8Header.GlobalBoolFlags["insecure"] = false

--- a/cmd/session-v8.go
+++ b/cmd/session-v8.go
@@ -48,7 +48,7 @@ type sessionV8Header struct {
 	LastCopied         string            `json:"lastCopied"`
 	LastRemoved        string            `json:"lastRemoved"`
 	TotalBytes         int64             `json:"totalBytes"`
-	TotalObjects       int               `json:"totalObjects"`
+	TotalObjects       int64             `json:"totalObjects"`
 }
 
 // sessionMessage container for session messages

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -24,6 +24,8 @@ type URLs struct {
 	SourceContent *clientContent
 	TargetAlias   string
 	TargetContent *clientContent
+	TotalCount    int64
+	TotalSize     int64
 	Error         *probe.Error `json:"-"`
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -25,7 +25,22 @@ import (
 	"time"
 
 	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minio/pkg/probe"
 )
+
+func isErrIgnored(err *probe.Error) bool {
+	// For all non critical errors we can continue for the remaining files.
+	switch err.ToGoError().(type) {
+	case BrokenSymlink, TooManyLevelsSymlink, PathNotFound, PathInsufficientPermission:
+		return true
+	// Handle these specifically for object storage related errors.
+	case BucketNameEmpty, ObjectMissing, ObjectAlreadyExists:
+		return true
+	case ObjectAlreadyExistsAsDirectory, BucketDoesNotExist, BucketInvalid, ObjectOnGlacier:
+		return true
+	}
+	return false
+}
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 


### PR DESCRIPTION
```sh
mc cp -r --json /usr/bin /tmp | jq .
...
...
{
  "status": "success",
  "source": "/usr/bin/gcm-viewer",
  "target": "/tmp/bin/gcm-viewer",
  "size": 87128,
  "totalCount": 2602,
  "totalSize": 677422730
}
```

This allows scripts to build progress around this data.