### PR TITLE
Vendorize new minio-go code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 - linux
 - osx
 
-osx_image: xcode7.2
+osx_image: xcode7.3
 
 env:
 - ARCH=x86_64

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -86,11 +86,6 @@ func (f *fsClient) GetURL() clientURL {
 	return *f.PathURL
 }
 
-// Unwatch - not implemented for fs, on purpose.
-func (f *fsClient) Unwatch(params watchParams) *probe.Error {
-	return nil
-}
-
 // Watches for all fs events on an input path.
 func (f *fsClient) Watch(params watchParams) (*watchObject, *probe.Error) {
 	eventChan := make(chan Event)

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -336,17 +336,6 @@ func (c *s3Client) ListNotificationConfigs(arn string) ([]notificationConfig, *p
 	return configs, nil
 }
 
-// Unwatch de-registers all bucket notification events for a given accountID.
-func (c *s3Client) Unwatch(params watchParams) *probe.Error {
-	// Extract bucket and object.
-	bucket, _ := c.url2BucketAndObject()
-	if err := isValidBucketName(bucket); err != nil {
-		return err
-	}
-	// Success.
-	return nil
-}
-
 // Start watching on all bucket events for a given account ID.
 func (c *s3Client) Watch(params watchParams) (*watchObject, *probe.Error) {
 	eventChan := make(chan Event)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -61,7 +61,6 @@ type Client interface {
 
 	// Watch events
 	Watch(params watchParams) (*watchObject, *probe.Error)
-	Unwatch(params watchParams) *probe.Error
 
 	// Delete operations
 	Remove(isIncomplete bool, contentCh <-chan *clientContent) (errorCh <-chan *probe.Error)

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -175,8 +175,10 @@ func doDiffMain(firstURL, secondURL string) {
 			fmt.Sprintf("Failed to diff '%s' and '%s'", firstURL, secondURL))
 	}
 
+	watchMode := false
+
 	// Diff first and second urls.
-	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL) {
+	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL, watchMode) {
 		printMsg(diffMsg)
 	}
 }

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -40,15 +40,17 @@ func checkMirrorSyntax(ctx *cli.Context) {
 	tgtURL := URLs[1]
 
 	/****** Generic rules *******/
-	_, srcContent, err := url2Stat(srcURL)
-	// incomplete uploads are not necessary for copy operation, no need to verify for them.
-	isIncomplete := false
-	if err != nil && !isURLPrefixExists(srcURL, isIncomplete) {
-		fatalIf(err.Trace(srcURL), "Unable to stat source ‘"+srcURL+"’.")
-	}
+	if !ctx.Bool("watch") {
+		_, srcContent, err := url2Stat(srcURL)
+		// incomplete uploads are not necessary for copy operation, no need to verify for them.
+		isIncomplete := false
+		if err != nil && !isURLPrefixExists(srcURL, isIncomplete) {
+			errorIf(err.Trace(srcURL), "Unable to stat source ‘"+srcURL+"’.")
+		}
 
-	if err == nil && !srcContent.Type.IsDir() {
-		fatalIf(errInvalidArgument().Trace(srcContent.URL.String(), srcContent.Type.String()), fmt.Sprintf("Source ‘%s’ is not a folder. Only folders are supported by mirror command.", srcURL))
+		if err == nil && !srcContent.Type.IsDir() {
+			fatalIf(errInvalidArgument().Trace(srcContent.URL.String(), srcContent.Type.String()), fmt.Sprintf("Source ‘%s’ is not a folder. Only folders are supported by mirror command.", srcURL))
+		}
 	}
 
 	if len(tgtURL) == 0 && tgtURL == "" {
@@ -64,14 +66,17 @@ func checkMirrorSyntax(ctx *cli.Context) {
 			}
 		}
 	}
-	_, _, err = url2Stat(tgtURL)
+	_, _, err := url2Stat(tgtURL)
 	// we die on any error other than PathNotFound - destination directory need not exist.
-	if _, ok := err.ToGoError().(PathNotFound); !ok {
+	switch err.ToGoError().(type) {
+	case PathNotFound:
+	case ObjectMissing:
+	default:
 		fatalIf(err.Trace(tgtURL), fmt.Sprintf("Unable to stat target ‘%s’.", tgtURL))
 	}
 }
 
-func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, URLsCh chan<- URLs) {
+func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, isWatch bool, URLsCh chan<- URLs) {
 	// source and targets are always directories
 	sourceSeparator := string(newClientURL(sourceURL).Separator)
 	if !strings.HasSuffix(sourceURL, sourceSeparator) {
@@ -101,7 +106,7 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 	}
 
 	// List both source and target, compare and return values through channel.
-	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL) {
+	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL, isWatch) {
 		switch diffMsg.Diff {
 		case differInNone:
 			// No difference, continue.
@@ -165,8 +170,8 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 }
 
 // Prepares urls that need to be copied or removed based on requested options.
-func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool) <-chan URLs {
+func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool, isWatch bool, isRemove bool) <-chan URLs {
 	URLsCh := make(chan URLs)
-	go deltaSourceTarget(sourceURL, targetURL, isForce, isFake, isRemove, URLsCh)
+	go deltaSourceTarget(sourceURL, targetURL, isForce, isFake, isRemove, isWatch, URLsCh)
 	return URLsCh
 }

--- a/cmd/session-v8.go
+++ b/cmd/session-v8.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -357,6 +358,7 @@ func (s *sessionV8) Delete() *probe.Error {
 // Close a session and exit.
 func (s sessionV8) CloseAndDie() {
 	s.Close()
+	fmt.Println(string(debug.Stack()))
 	console.Fatalln("Session safely terminated. To resume session ‘mc session resume " + s.SessionID + "’")
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -28,18 +28,21 @@ import (
 	"github.com/minio/minio/pkg/probe"
 )
 
-func isErrIgnored(err *probe.Error) bool {
+func isErrIgnored(err *probe.Error) (ignored bool) {
 	// For all non critical errors we can continue for the remaining files.
 	switch err.ToGoError().(type) {
+	// Handle these specifically for filesystem related errors.
 	case BrokenSymlink, TooManyLevelsSymlink, PathNotFound, PathInsufficientPermission:
-		return true
+		ignored = true
 	// Handle these specifically for object storage related errors.
 	case BucketNameEmpty, ObjectMissing, ObjectAlreadyExists:
-		return true
+		ignored = true
 	case ObjectAlreadyExistsAsDirectory, BucketDoesNotExist, BucketInvalid, ObjectOnGlacier:
-		return true
+		ignored = true
+	default:
+		ignored = false
 	}
-	return false
+	return ignored
 }
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -172,8 +172,6 @@ func mainWatch(ctx *cli.Context) {
 		for {
 			select {
 			case <-trapCh:
-				s3Client.Unwatch(params)
-				return
 			case event, ok := <-wo.Events():
 				if !ok {
 					return

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -134,18 +134,6 @@ func (w *Watcher) Wait() {
 	w.wg.Wait()
 }
 
-// Unjoin the watcher from client.
-func (w *Watcher) Unjoin(client Client, recursive bool) *probe.Error {
-	err := client.Unwatch(watchParams{
-		recursive: recursive,
-		accountID: fmt.Sprintf("%d", w.sessionStartTime.Unix()),
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Join the watcher with client
 func (w *Watcher) Join(client Client, recursive bool) *probe.Error {
 	wo, err := client.Watch(watchParams{

--- a/vendor/github.com/minio/minio-go/api-put-object.go
+++ b/vendor/github.com/minio/minio-go/api-put-object.go
@@ -103,11 +103,10 @@ func getReaderSize(reader io.Reader) (size int64, err error) {
 			// implement Seekable calls. Ignore them and treat
 			// them like a stream with unknown length.
 			switch st.Name() {
-			case "stdin":
-				fallthrough
-			case "stdout":
-				fallthrough
-			case "stderr":
+			case "stdin", "stdout", "stderr":
+				return
+			// Ignore read/write stream of os.Pipe() which have unknown length too.
+			case "|0", "|1":
 				return
 			}
 			size = st.Size()

--- a/vendor/github.com/minio/minio-go/post-policy.go
+++ b/vendor/github.com/minio/minio-go/post-policy.go
@@ -149,6 +149,24 @@ func (p *PostPolicy) SetContentLengthRange(min, max int64) error {
 	return nil
 }
 
+// SetSuccessStatusAction - Sets the status success code of the object for this policy
+// based upload.
+func (p *PostPolicy) SetSuccessStatusAction(status string) error {
+	if strings.TrimSpace(status) == "" || status == "" {
+		return ErrInvalidArgument("Status is empty")
+	}
+	policyCond := policyCondition{
+		matchType: "eq",
+		condition: "$success_action_status",
+		value:     status,
+	}
+	if err := p.addNewPolicy(policyCond); err != nil {
+		return err
+	}
+	p.formData["success_action_status"] = status
+	return nil
+}
+
 // addNewPolicy - internal helper to validate adding new policies.
 func (p *PostPolicy) addNewPolicy(policyCond policyCondition) error {
 	if policyCond.matchType == "" || policyCond.condition == "" || policyCond.value == "" {

--- a/vendor/github.com/minio/minio-go/retry-continous.go
+++ b/vendor/github.com/minio/minio-go/retry-continous.go
@@ -1,0 +1,52 @@
+package minio
+
+import "time"
+
+// newRetryTimerContinous creates a timer with exponentially increasing delays forever.
+func (c Client) newRetryTimerContinous(unit time.Duration, cap time.Duration, jitter float64, doneCh chan struct{}) <-chan int {
+	attemptCh := make(chan int)
+
+	// normalize jitter to the range [0, 1.0]
+	if jitter < NoJitter {
+		jitter = NoJitter
+	}
+	if jitter > MaxJitter {
+		jitter = MaxJitter
+	}
+
+	// computes the exponential backoff duration according to
+	// https://www.awsarchitectureblog.com/2015/03/backoff.html
+	exponentialBackoffWait := func(attempt int) time.Duration {
+		// 1<<uint(attempt) below could overflow, so limit the value of attempt
+		maxAttempt := 30
+		if attempt > maxAttempt {
+			attempt = maxAttempt
+		}
+		//sleep = random_between(0, min(cap, base * 2 ** attempt))
+		sleep := unit * time.Duration(1<<uint(attempt))
+		if sleep > cap {
+			sleep = cap
+		}
+		if jitter != NoJitter {
+			sleep -= time.Duration(c.random.Float64() * float64(sleep) * jitter)
+		}
+		return sleep
+	}
+
+	go func() {
+		defer close(attemptCh)
+		var nextBackoff int
+		for {
+			select {
+			// Attempts starts.
+			case attemptCh <- nextBackoff:
+				nextBackoff++
+			case <-doneCh:
+				// Stop the routine.
+				return
+			}
+			time.Sleep(exponentialBackoffWait(nextBackoff))
+		}
+	}()
+	return attemptCh
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -49,10 +49,10 @@
 			"revisionTime": "2015-10-24T22:24:27-07:00"
 		},
 		{
-			"checksumSHA1": "jIqpnAmNq8z/T8PTQeVV5T51KNw=",
+			"checksumSHA1": "LOqBhL9Sc2QMob0uT1cwvexNzLQ=",
 			"path": "github.com/minio/minio-go",
-			"revision": "88cd2fcfc8f7dad4c586918348e986cf6095bfad",
-			"revisionTime": "2016-10-31T15:51:08Z"
+			"revision": "0cd90f4c44c5e86f4cf8faf865ae5388df2843fb",
+			"revisionTime": "2016-11-20T22:51:24Z"
 		},
 		{
 			"checksumSHA1": "qTxOBp3GVxCC70ykb7Hxg6UgWwA=",


### PR DESCRIPTION
This fixes #1889 

```sh
mc mirror -w
```

Now runs continous even when the source is not available.
Reconnects indefinitely in a binomially increasing fashion
and also allows jitter so that the retry has a nice
distribution as well.

This allows for 'mc mirror -w' to run continously without
further monitoring.