### PR TITLE
Fix downloading files with exact ranges requested in client FS.

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -246,12 +246,13 @@ func (f *fsClient) Put(reader io.Reader, size int64, contentType string, progres
 				return 0, probe.NewError(e)
 			}
 		}
+
 		// Allocate buffer of 10MiB once.
 		readAtBuffer := make([]byte, 10*1024*1024)
 
 		// Loop through all offsets on incoming io.ReaderAt and write
 		// to the destination.
-		for {
+		for currentOffset < size {
 			readAtSize, re := readerAt.ReadAt(readAtBuffer, currentOffset)
 			if re != nil && re != io.EOF {
 				// For any errors other than io.EOF, we return error


### PR DESCRIPTION
This is due to the fact that ReadAt() will not send io.EOF
when reading past the offset, server instead returns
Range error. Handle the error by only reading until the
requested size.