### PR TITLE
cp/mirror: Use proper paths for windows during copyObject.

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -183,7 +183,8 @@ func doCopy(cpURLs URLs, progressReader *progressBar, accountingReader *accounte
 			// If source/target are object storage their aliases must be the same.
 			if sourceAlias == targetAlias {
 				// Do not include alias inside path for ObjStore -> ObjStore.
-				err := copySourceStreamFromAlias(targetAlias, targetURL.String(), sourceURL.Path, length, progress)
+				sourcePath := filepath.ToSlash(sourceURL.Path)
+				err := copySourceStreamFromAlias(targetAlias, targetURL.String(), sourcePath, length, progress)
 				if err != nil {
 					cpURLs.Error = err.Trace(sourceURL.String())
 					return cpURLs

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -246,7 +246,8 @@ func (ms *mirrorSession) doMirror(sURLs URLs) URLs {
 			if sourceAlias == targetAlias {
 				// If source/target are object storage their aliases must be the same
 				// Do not include alias inside path for ObjStore -> ObjStore.
-				err := copySourceStreamFromAlias(targetAlias, targetURL.String(), sourceURL.Path, length, ms.status)
+				sourcePath := filepath.ToSlash(sourceURL.Path)
+				err := copySourceStreamFromAlias(targetAlias, targetURL.String(), sourcePath, length, ms.status)
 				if err != nil {
 					return sURLs.WithError(err.Trace(sourceURL.String()))
 				}


### PR DESCRIPTION
Fixes #1857