### PR TITLE
ignore: Add support for `mc` ignore file.

### DIFF
--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -35,7 +35,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	// Create multiple files.
 	objectPath := filepath.Join(root, "object1")
-	fsClient, err := fsNew(objectPath)
+	fsClient, err := fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	data := "hello"
@@ -47,7 +47,7 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(n, Equals, int64(len(data)))
 
 	objectPath = filepath.Join(root, "object2")
-	fsClient, err = fsNew(objectPath)
+	fsClient, err = fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
@@ -55,7 +55,7 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	fsClient, err = fsNew(root)
+	fsClient, err = fsNew(root, []string{})
 	c.Assert(err, IsNil)
 
 	// Verify previously create files and list them.
@@ -73,7 +73,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	// Create another file.
 	objectPath = filepath.Join(root, "test1/newObject1")
-	fsClient, err = fsNew(objectPath)
+	fsClient, err = fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
@@ -81,7 +81,7 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	fsClient, err = fsNew(root)
+	fsClient, err = fsNew(root, []string{})
 	c.Assert(err, IsNil)
 
 	contents = nil
@@ -97,7 +97,7 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(len(contents), Equals, 1)
 	c.Assert(contents[0].Type.IsDir(), Equals, true)
 
-	fsClient, err = fsNew(root)
+	fsClient, err = fsNew(root, []string{})
 	c.Assert(err, IsNil)
 
 	contents = nil
@@ -131,7 +131,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	// Create an ignored file and list to verify if its ignored.
 	objectPath = filepath.Join(root, "test1/.DS_Store")
-	fsClient, err = fsNew(objectPath)
+	fsClient, err = fsNew(objectPath, []string{"*.DS_Store"})
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
@@ -139,7 +139,7 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	fsClient, err = fsNew(root)
+	fsClient, err = fsNew(root, []string{})
 	c.Assert(err, IsNil)
 
 	contents = nil
@@ -183,7 +183,7 @@ func (s *TestSuite) TestPutBucket(c *C) {
 	defer os.RemoveAll(root)
 
 	bucketPath := filepath.Join(root, "bucket")
-	fsClient, err := fsNew(bucketPath)
+	fsClient, err := fsNew(bucketPath, []string{})
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1")
 	c.Assert(err, IsNil)
@@ -197,7 +197,7 @@ func (s *TestSuite) TestStatBucket(c *C) {
 
 	bucketPath := filepath.Join(root, "bucket")
 
-	fsClient, err := fsNew(bucketPath)
+	fsClient, err := fsNew(bucketPath, []string{})
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1")
 	c.Assert(err, IsNil)
@@ -212,7 +212,7 @@ func (s *TestSuite) TestBucketACLFails(c *C) {
 	defer os.RemoveAll(root)
 
 	bucketPath := filepath.Join(root, "bucket")
-	fsClient, err := fsNew(bucketPath)
+	fsClient, err := fsNew(bucketPath, []string{})
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1")
 	c.Assert(err, IsNil)
@@ -234,7 +234,7 @@ func (s *TestSuite) TestPut(c *C) {
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
-	fsClient, err := fsNew(objectPath)
+	fsClient, err := fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	data := "hello"
@@ -252,7 +252,7 @@ func (s *TestSuite) TestGet(c *C) {
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
-	fsClient, err := fsNew(objectPath)
+	fsClient, err := fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	data := "hello"
@@ -278,7 +278,7 @@ func (s *TestSuite) TestGetRange(c *C) {
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
-	fsClient, err := fsNew(objectPath)
+	fsClient, err := fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	data := "hello world"
@@ -307,7 +307,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
-	fsClient, err := fsNew(objectPath)
+	fsClient, err := fsNew(objectPath, []string{})
 	c.Assert(err, IsNil)
 
 	data := "hello"
@@ -329,9 +329,9 @@ func (s *TestSuite) TestCopy(c *C) {
 	defer os.RemoveAll(root)
 	sourcePath := filepath.Join(root, "source")
 	targetPath := filepath.Join(root, "target")
-	fsClientTarget, err := fsNew(targetPath)
+	fsClientTarget, err := fsNew(targetPath, []string{})
 	c.Assert(err, IsNil)
-	fsClientSource, err := fsNew(sourcePath)
+	fsClientSource, err := fsNew(sourcePath, []string{})
 	c.Assert(err, IsNil)
 
 	data := "hello world"

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -117,9 +117,8 @@ func copySourceStreamFromAlias(alias string, urlStr string, source string, size 
 func newClientFromAlias(alias string, urlStr string) (Client, *probe.Error) {
 	hostCfg := mustGetHostConfig(alias)
 	if hostCfg == nil {
-		// No matching host config. So we treat it like a
-		// filesystem.
-		fsClient, err := fsNew(urlStr)
+		// No matching host config. So we treat it like a filesystem.
+		fsClient, err := fsNew(urlStr, globalIgnoredFiles)
 		if err != nil {
 			return nil, err.Trace(alias, urlStr)
 		}

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -35,6 +35,7 @@ const (
 	globalMCConfigDir        = ".mc/"
 	globalMCConfigWindowsDir = "mc\\"
 	globalMCConfigFile       = "config.json"
+	globalMCIgnoreFile       = "mcignore"
 	globalMCCertsDir         = "certs"
 	globalMCCAsDir           = "CAs"
 
@@ -61,6 +62,9 @@ var (
 var (
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool
+
+	// List of ignored files populated if `${HOME}/.mc/mcignore` is present.
+	globalIgnoredFiles []string
 )
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.

--- a/cmd/ignore.go
+++ b/cmd/ignore.go
@@ -1,0 +1,76 @@
+/*
+ * Minio Client (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/minio/minio/pkg/probe"
+)
+
+// getIgnoreFile - return the full path of ignore file.
+func getIgnoreFile() (string, *probe.Error) {
+	p, err := getMcConfigDir()
+	if err != nil {
+		return "", err.Trace()
+	}
+	return filepath.Join(p, globalMCIgnoreFile), nil
+}
+
+// mustGetIgnoreFile - return the full path of
+func mustGetIgnoreFile() string {
+	file, err := getIgnoreFile()
+	fatalIf(err.Trace(), "Unable to determine ignore file.")
+	return file
+}
+
+// isIgnoreFileExists - verify if certs directory exists.
+func isIgnoreFileExists() bool {
+	ignoreFile, err := getIgnoreFile()
+	fatalIf(err.Trace(), "Unable to determine ignore file.")
+	if _, e := os.Stat(ignoreFile); e != nil {
+		return false
+	}
+	return true
+}
+
+// createIgnoreFile - create minio client ignore file.
+func createIgnoreFile() *probe.Error {
+	file, err := getIgnoreFile()
+	if err != nil {
+		return err.Trace()
+	}
+	if e := ioutil.WriteFile(file, []byte(""), 0600); e != nil {
+		return probe.NewError(e)
+	}
+	return nil
+}
+
+// Loads the list of ignored files.
+func loadIgnoredFiles() {
+	ignoreFile := mustGetIgnoreFile()
+	file, e := os.Open(ignoreFile)
+	fatalIf(probe.NewError(e).Trace(), "Unable to open "+ignoreFile)
+	scan := bufio.NewScanner(file)
+	for scan.Scan() {
+		globalIgnoredFiles = append(globalIgnoredFiles, scan.Text())
+	}
+	fatalIf(probe.NewError(scan.Err()), "Unable to scan through the "+ignoreFile)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -197,8 +197,16 @@ func initMC() {
 		fatalIf(createCAsDir().Trace(), "Unable to create `CAs` folder.")
 	}
 
+	// Check if ignore file exists.
+	if !isIgnoreFileExists() {
+		fatalIf(createIgnoreFile().Trace(), "Unable to create `mcignore` file.")
+	}
+
 	// Load all authority certificates present in CAs dir
 	loadRootCAs()
+
+	// Load list of all ignored files into memory.
+	loadIgnoredFiles()
 }
 
 func registerBefore(ctx *cli.Context) error {

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -168,6 +168,9 @@ func mainWatch(ctx *cli.Context) error {
 		for {
 			select {
 			case <-trapCh:
+				// Signal received we are done.
+				close(wo.done)
+				return
 			case event, ok := <-wo.Events():
 				if !ok {
 					return
@@ -178,7 +181,7 @@ func mainWatch(ctx *cli.Context) error {
 				if !ok {
 					return
 				}
-				fatalIf(err, "Cannot watch on events.")
+				errorIf(err, "Cannot watch on events.")
 				return
 			}
 		}


### PR DESCRIPTION
This patch add support for a file `~/.mc/mcignore`
which lists all the paths and files that needs to be
ignored for filesystem.

The format of this file is similar to `.gitignore`
and uses filepath glob matching to filter the files.

Fixes #1902
Fixes #1903