### PR TITLE
cat: return err in case s3 object short read

### DIFF
--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -61,7 +61,7 @@ EXAMPLES:
 func pipe(targetURL string) *probe.Error {
 	if targetURL == "" {
 		// When no target is specified, pipe cat's stdin to stdout.
-		return catOut(os.Stdin).Trace()
+		return catOut(os.Stdin, -1).Trace()
 	}
 
 	// Stream from stdin to multiple objects until EOF.


### PR DESCRIPTION
cat inspects the size of the downloaded s3 object when specified to
detect a possible short read