### PR TITLE
mirror: Avoid flushing session to disk on each i/o operation.

### DIFF
--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -60,7 +60,6 @@ func (q *Queue) Save(dst io.Writer) error {
 		if err != nil {
 			return err
 		}
-
 		fmt.Fprintln(dst, string(jsonData))
 	}
 


### PR DESCRIPTION
The problem was for each read from statusCh we were writing
to session file again and also syncing to disk. This adds
severe performance problems.

Fixes #1908