### PR TITLE
cp/diff/mirror: Cleanup code and deprecate unnecessary flags.

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -170,10 +170,8 @@ func doDiffMain(firstURL, secondURL string) error {
 			fmt.Sprintf("Failed to diff '%s' and '%s'", firstURL, secondURL))
 	}
 
-	watchMode := false
-
 	// Diff first and second urls.
-	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL, watchMode) {
+	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL) {
 		printMsg(diffMsg)
 	}
 

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -50,7 +50,7 @@ func (d differType) String() string {
 
 // objectDifference function finds the difference between all objects
 // recursively in sorted order from source and target.
-func objectDifference(sourceClnt, targetClnt Client, sourceURL, targetURL string, watchMode bool) (diffCh chan diffMessage) {
+func objectDifference(sourceClnt, targetClnt Client, sourceURL, targetURL string) (diffCh chan diffMessage) {
 	var (
 		srcEOF, tgtEOF       bool
 		srcOk, tgtOk         bool
@@ -77,10 +77,8 @@ func objectDifference(sourceClnt, targetClnt Client, sourceURL, targetURL string
 
 			// No objects from source AND target: Finish
 			if srcEOF && tgtEOF {
-				if !watchMode {
-					close(diffCh)
-					break
-				}
+				close(diffCh)
+				break
 			}
 
 			if !srcEOF && srcCtnt.Err != nil {

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -47,6 +47,9 @@ const (
 
 	// Global error exit status.
 	globalErrorExitStatus = 1
+
+	// Maximum size for a single PUT operation.
+	globalMaximumPutSize = 5 * 1024 * 1024 * 1024 // 5GiB.
 )
 
 var (

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -76,7 +76,7 @@ func checkMirrorSyntax(ctx *cli.Context) {
 	}
 }
 
-func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, isWatch bool, URLsCh chan<- URLs) {
+func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, URLsCh chan<- URLs) {
 	// source and targets are always directories
 	sourceSeparator := string(newClientURL(sourceURL).Separator)
 	if !strings.HasSuffix(sourceURL, sourceSeparator) {
@@ -106,7 +106,7 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 	}
 
 	// List both source and target, compare and return values through channel.
-	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL, isWatch) {
+	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL) {
 		switch diffMsg.Diff {
 		case differInNone:
 			// No difference, continue.
@@ -170,8 +170,8 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 }
 
 // Prepares urls that need to be copied or removed based on requested options.
-func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool, isWatch bool, isRemove bool) <-chan URLs {
+func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool) <-chan URLs {
 	URLsCh := make(chan URLs)
-	go deltaSourceTarget(sourceURL, targetURL, isForce, isFake, isRemove, isWatch, URLsCh)
+	go deltaSourceTarget(sourceURL, targetURL, isForce, isFake, isRemove, URLsCh)
 	return URLsCh
 }


### PR DESCRIPTION
This fix also fixes an apparent crash found in diff.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4bdc07]

goroutine 84 [running]:
panic(0x810ea0, 0xc4200120e0)
        /home/builder/.gimme/versions/go1.7.3.linux.amd64/src/runtime/panic.go:500 +0x1a1
github.com/minio/mc/cmd.objectDifference.func1(0xc4200880a8, 0xc42042ee56, 0xc420315ec0, 0xc4200880b0, 0xc42042ee57, 0xc420315f20, 0xc42042ee54, 0xc42042ee55, 0xc420315501, 0xc4200880a0, ...)
        /home/builder/mygo/src/github.com/minio/mc/cmd/difference.go:109 +0x197
created by github.com/minio/mc/cmd.objectDifference
        /home/builder/mygo/src/github.com/minio/mc/cmd/difference.go:180 +0x2f5
```