### PR TITLE
mirror/cp/pipe: Preserve metadata while copying s3 to s3.

### DIFF
--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -42,7 +42,9 @@ func (s *TestSuite) TestList(c *C) {
 
 	reader := bytes.NewReader([]byte(data))
 	var n int64
-	n, err = fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err = fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -51,7 +53,9 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
-	n, err = fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err = fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -77,7 +81,9 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
-	n, err = fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err = fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -135,7 +141,9 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
-	n, err = fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err = fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -240,7 +248,9 @@ func (s *TestSuite) TestPut(c *C) {
 	data := "hello"
 	reader := bytes.NewReader([]byte(data))
 	var n int64
-	n, err = fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err = fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 }
@@ -258,11 +268,13 @@ func (s *TestSuite) TestGet(c *C) {
 	data := "hello"
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
-	n, err := fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err := fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, err = fsClient.Get()
+	reader, _, err = fsClient.Get()
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	_, e = io.Copy(&results, reader)
@@ -284,11 +296,13 @@ func (s *TestSuite) TestGetRange(c *C) {
 	data := "hello world"
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
-	n, err := fsClient.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err := fsClient.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, err = fsClient.Get()
+	reader, _, err = fsClient.Get()
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	buf := make([]byte, 5)
@@ -313,7 +327,9 @@ func (s *TestSuite) TestStatObject(c *C) {
 	data := "hello"
 	dataLen := len(data)
 	reader := bytes.NewReader([]byte(data))
-	n, err := fsClient.Put(reader, int64(dataLen), "application/octet-stream", nil)
+	n, err := fsClient.Put(reader, int64(dataLen), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -337,7 +353,9 @@ func (s *TestSuite) TestCopy(c *C) {
 	data := "hello world"
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
-	n, err := fsClientSource.Put(reader, int64(len(data)), "application/octet-stream", nil)
+	n, err := fsClientSource.Put(reader, int64(len(data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -224,11 +224,13 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 
 	var reader io.Reader
 	reader = bytes.NewReader(object.data)
-	n, err := s3c.Put(reader, int64(len(object.data)), "application/octet-stream", nil)
+	n, err := s3c.Put(reader, int64(len(object.data)), map[string][]string{
+		"Content-Type": []string{"application/octet-stream"},
+	}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(object.data)))
 
-	reader, err = s3c.Get()
+	reader, _, err = s3c.Get()
 	c.Assert(err, IsNil)
 	var buffer bytes.Buffer
 	{

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -51,9 +51,11 @@ type Client interface {
 	SetAccess(access string) *probe.Error
 
 	// I/O operations
-	Get() (reader io.Reader, err *probe.Error)
-	Put(reader io.Reader, size int64, contentType string, progress io.Reader) (n int64, err *probe.Error)
 	Copy(source string, size int64, progress io.Reader) *probe.Error
+
+	// I/O operations with metadata.
+	Get() (reader io.Reader, metadata map[string][]string, err *probe.Error)
+	Put(reader io.Reader, size int64, metadata map[string][]string, progress io.Reader) (n int64, err *probe.Error)
 
 	// I/O operations with expiration
 	ShareDownload(expires time.Duration) (string, *probe.Error)

--- a/vendor/github.com/minio/minio-go/api-datatypes.go
+++ b/vendor/github.com/minio/minio-go/api-datatypes.go
@@ -16,7 +16,10 @@
 
 package minio
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // BucketInfo container for bucket metadata.
 type BucketInfo struct {
@@ -37,6 +40,10 @@ type ObjectInfo struct {
 	LastModified time.Time `json:"lastModified"` // Date and time the object was last modified.
 	Size         int64     `json:"size"`         // Size in bytes of the object.
 	ContentType  string    `json:"contentType"`  // A standard MIME type describing the format of the object data.
+
+	// Collection of additional metadata on the object.
+	// eg: x-amz-meta-*, content-encoding etc.
+	Metadata http.Header `json:"metadata"`
 
 	// Owner name.
 	Owner struct {

--- a/vendor/github.com/minio/minio-go/api-presigned.go
+++ b/vendor/github.com/minio/minio-go/api-presigned.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"net/url"
 	"time"
+
+	"github.com/minio/minio-go/pkg/s3signer"
 )
 
 // supportedGetReqParams - supported request parameters for GET presigned request.
@@ -133,7 +135,7 @@ func (c Client) PresignedPostPolicy(p *PostPolicy) (u *url.URL, formData map[str
 			p.formData["AWSAccessKeyId"] = c.accessKeyID
 		}
 		// Sign the policy.
-		p.formData["signature"] = postPresignSignatureV2(policyBase64, c.secretAccessKey)
+		p.formData["signature"] = s3signer.PostPresignSignatureV2(policyBase64, c.secretAccessKey)
 		return u, p.formData, nil
 	}
 
@@ -156,7 +158,7 @@ func (c Client) PresignedPostPolicy(p *PostPolicy) (u *url.URL, formData map[str
 	}
 
 	// Add a credential policy.
-	credential := getCredential(c.accessKeyID, location, t)
+	credential := s3signer.GetCredential(c.accessKeyID, location, t)
 	if err = p.addNewPolicy(policyCondition{
 		matchType: "eq",
 		condition: "$x-amz-credential",
@@ -172,6 +174,6 @@ func (c Client) PresignedPostPolicy(p *PostPolicy) (u *url.URL, formData map[str
 	p.formData["x-amz-algorithm"] = signV4Algorithm
 	p.formData["x-amz-credential"] = credential
 	p.formData["x-amz-date"] = t.Format(iso8601DateFormat)
-	p.formData["x-amz-signature"] = postPresignSignatureV4(policyBase64, t, c.secretAccessKey, location)
+	p.formData["x-amz-signature"] = s3signer.PostPresignSignatureV4(policyBase64, t, c.secretAccessKey, location)
 	return u, p.formData, nil
 }

--- a/vendor/github.com/minio/minio-go/api-put-object-multipart.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-multipart.go
@@ -45,11 +45,11 @@ import (
 // If we exhaust all the known types, code proceeds to use stream as
 // is where each part is re-downloaded, checksummed and verified
 // before upload.
-func (c Client) putObjectMultipart(bucketName, objectName string, reader io.Reader, size int64, contentType string, progress io.Reader) (n int64, err error) {
+func (c Client) putObjectMultipart(bucketName, objectName string, reader io.Reader, size int64, metaData map[string][]string, progress io.Reader) (n int64, err error) {
 	if size > 0 && size > minPartSize {
 		// Verify if reader is *os.File, then use file system functionalities.
 		if isFile(reader) {
-			return c.putObjectMultipartFromFile(bucketName, objectName, reader.(*os.File), size, contentType, progress)
+			return c.putObjectMultipartFromFile(bucketName, objectName, reader.(*os.File), size, metaData, progress)
 		}
 		// Verify if reader is *minio.Object or io.ReaderAt.
 		// NOTE: Verification of object is kept for a specific purpose
@@ -58,17 +58,17 @@ func (c Client) putObjectMultipart(bucketName, objectName string, reader io.Read
 		// and such a functionality is used in the subsequent code
 		// path.
 		if isObject(reader) || isReadAt(reader) {
-			return c.putObjectMultipartFromReadAt(bucketName, objectName, reader.(io.ReaderAt), size, contentType, progress)
+			return c.putObjectMultipartFromReadAt(bucketName, objectName, reader.(io.ReaderAt), size, metaData, progress)
 		}
 	}
 	// For any other data size and reader type we do generic multipart
 	// approach by staging data in temporary files and uploading them.
-	return c.putObjectMultipartStream(bucketName, objectName, reader, size, contentType, progress)
+	return c.putObjectMultipartStream(bucketName, objectName, reader, size, metaData, progress)
 }
 
 // putObjectStream uploads files bigger than 5MiB, and also supports
 // special case where size is unknown i.e '-1'.
-func (c Client) putObjectMultipartStream(bucketName, objectName string, reader io.Reader, size int64, contentType string, progress io.Reader) (n int64, err error) {
+func (c Client) putObjectMultipartStream(bucketName, objectName string, reader io.Reader, size int64, metaData map[string][]string, progress io.Reader) (n int64, err error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -84,7 +84,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 	var complMultipartUpload completeMultipartUpload
 
 	// Get the upload id of a previously partially uploaded object or initiate a new multipart upload
-	uploadID, partsInfo, err := c.getMpartUploadSession(bucketName, objectName, contentType)
+	uploadID, partsInfo, err := c.getMpartUploadSession(bucketName, objectName, metaData)
 	if err != nil {
 		return 0, err
 	}
@@ -199,7 +199,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 }
 
 // initiateMultipartUpload - Initiates a multipart upload and returns an upload ID.
-func (c Client) initiateMultipartUpload(bucketName, objectName, contentType string) (initiateMultipartUploadResult, error) {
+func (c Client) initiateMultipartUpload(bucketName, objectName string, metaData map[string][]string) (initiateMultipartUploadResult, error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
 		return initiateMultipartUploadResult{}, err
@@ -212,13 +212,18 @@ func (c Client) initiateMultipartUpload(bucketName, objectName, contentType stri
 	urlValues := make(url.Values)
 	urlValues.Set("uploads", "")
 
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-
 	// Set ContentType header.
 	customHeader := make(http.Header)
-	customHeader.Set("Content-Type", contentType)
+	for k, v := range metaData {
+		if len(v) > 0 {
+			customHeader.Set(k, v[0])
+		}
+	}
+
+	// Set a default content-type header if the latter is not provided
+	if v, ok := metaData["Content-Type"]; !ok || len(v) == 0 {
+		customHeader.Set("Content-Type", "application/octet-stream")
+	}
 
 	reqMetadata := requestMetadata{
 		bucketName:   bucketName,

--- a/vendor/github.com/minio/minio-go/api-put-object-readat.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-readat.go
@@ -63,7 +63,7 @@ func shouldUploadPartReadAt(objPart objectPart, uploadReq uploadPartReq) bool {
 // temporary files for staging all the data, these temporary files are
 // cleaned automatically when the caller i.e http client closes the
 // stream after uploading all the contents successfully.
-func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, reader io.ReaderAt, size int64, contentType string, progress io.Reader) (n int64, err error) {
+func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, reader io.ReaderAt, size int64, metaData map[string][]string, progress io.Reader) (n int64, err error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -73,7 +73,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 	}
 
 	// Get the upload id of a previously partially uploaded object or initiate a new multipart upload
-	uploadID, partsInfo, err := c.getMpartUploadSession(bucketName, objectName, contentType)
+	uploadID, partsInfo, err := c.getMpartUploadSession(bucketName, objectName, metaData)
 	if err != nil {
 		return 0, err
 	}

--- a/vendor/github.com/minio/minio-go/api-put-object.go
+++ b/vendor/github.com/minio/minio-go/api-put-object.go
@@ -150,7 +150,7 @@ func (c Client) PutObject(bucketName, objectName string, reader io.Reader, conte
 
 // putObjectNoChecksum special function used Google Cloud Storage. This special function
 // is used for Google Cloud Storage since Google's multipart API is not S3 compatible.
-func (c Client) putObjectNoChecksum(bucketName, objectName string, reader io.Reader, size int64, contentType string, progress io.Reader) (n int64, err error) {
+func (c Client) putObjectNoChecksum(bucketName, objectName string, reader io.Reader, size int64, metaData map[string][]string, progress io.Reader) (n int64, err error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -168,7 +168,7 @@ func (c Client) putObjectNoChecksum(bucketName, objectName string, reader io.Rea
 
 	// This function does not calculate sha256 and md5sum for payload.
 	// Execute put object.
-	st, err := c.putObjectDo(bucketName, objectName, readSeeker, nil, nil, size, contentType)
+	st, err := c.putObjectDo(bucketName, objectName, readSeeker, nil, nil, size, metaData)
 	if err != nil {
 		return 0, err
 	}
@@ -180,7 +180,7 @@ func (c Client) putObjectNoChecksum(bucketName, objectName string, reader io.Rea
 
 // putObjectSingle is a special function for uploading single put object request.
 // This special function is used as a fallback when multipart upload fails.
-func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader, size int64, contentType string, progress io.Reader) (n int64, err error) {
+func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader, size int64, metaData map[string][]string, progress io.Reader) (n int64, err error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -236,7 +236,7 @@ func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader,
 		}
 	}
 	// Execute put object.
-	st, err := c.putObjectDo(bucketName, objectName, reader, hashSums["md5"], hashSums["sha256"], size, contentType)
+	st, err := c.putObjectDo(bucketName, objectName, reader, hashSums["md5"], hashSums["sha256"], size, metaData)
 	if err != nil {
 		return 0, err
 	}
@@ -254,7 +254,7 @@ func (c Client) putObjectSingle(bucketName, objectName string, reader io.Reader,
 
 // putObjectDo - executes the put object http operation.
 // NOTE: You must have WRITE permissions on a bucket to add an object to it.
-func (c Client) putObjectDo(bucketName, objectName string, reader io.Reader, md5Sum []byte, sha256Sum []byte, size int64, contentType string) (ObjectInfo, error) {
+func (c Client) putObjectDo(bucketName, objectName string, reader io.Reader, md5Sum []byte, sha256Sum []byte, size int64, metaData map[string][]string) (ObjectInfo, error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
 		return ObjectInfo{}, err
@@ -271,13 +271,20 @@ func (c Client) putObjectDo(bucketName, objectName string, reader io.Reader, md5
 		return ObjectInfo{}, ErrEntityTooLarge(size, maxSinglePutObjectSize, bucketName, objectName)
 	}
 
-	if strings.TrimSpace(contentType) == "" {
-		contentType = "application/octet-stream"
-	}
-
 	// Set headers.
 	customHeader := make(http.Header)
-	customHeader.Set("Content-Type", contentType)
+
+	// Set metadata to headers
+	for k, v := range metaData {
+		if len(v) > 0 {
+			customHeader.Set(k, v[0])
+		}
+	}
+
+	// If Content-Type is not provided, set the default application/octet-stream one
+	if v, ok := metaData["Content-Type"]; !ok || len(v) == 0 {
+		customHeader.Set("Content-Type", "application/octet-stream")
+	}
 
 	// Populate request metadata.
 	reqMetadata := requestMetadata{
@@ -302,13 +309,13 @@ func (c Client) putObjectDo(bucketName, objectName string, reader io.Reader, md5
 		}
 	}
 
-	var metadata ObjectInfo
+	var objInfo ObjectInfo
 	// Trim off the odd double quotes from ETag in the beginning and end.
-	metadata.ETag = strings.TrimPrefix(resp.Header.Get("ETag"), "\"")
-	metadata.ETag = strings.TrimSuffix(metadata.ETag, "\"")
+	objInfo.ETag = strings.TrimPrefix(resp.Header.Get("ETag"), "\"")
+	objInfo.ETag = strings.TrimSuffix(objInfo.ETag, "\"")
 	// A success here means data was written to server successfully.
-	metadata.Size = size
+	objInfo.Size = size
 
 	// Return here.
-	return metadata, nil
+	return objInfo, nil
 }

--- a/vendor/github.com/minio/minio-go/bucket-cache.go
+++ b/vendor/github.com/minio/minio-go/bucket-cache.go
@@ -23,6 +23,8 @@ import (
 	"path"
 	"strings"
 	"sync"
+
+	"github.com/minio/minio-go/pkg/s3signer"
 )
 
 // bucketLocationCache - Provides simple mechanism to hold bucket
@@ -160,10 +162,7 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 	urlValues.Set("location", "")
 
 	// Set get bucket location always as path style.
-	targetURL, err := url.Parse(c.endpointURL)
-	if err != nil {
-		return nil, err
-	}
+	targetURL := c.endpointURL
 	targetURL.Path = path.Join(bucketName, "") + "/"
 	targetURL.RawQuery = urlValues.Encode()
 
@@ -189,9 +188,9 @@ func (c Client) getBucketLocationRequest(bucketName string) (*http.Request, erro
 
 	// Sign the request.
 	if c.signature.isV4() {
-		req = signV4(*req, c.accessKeyID, c.secretAccessKey, "us-east-1")
+		req = s3signer.SignV4(*req, c.accessKeyID, c.secretAccessKey, "us-east-1")
 	} else if c.signature.isV2() {
-		req = signV2(*req, c.accessKeyID, c.secretAccessKey)
+		req = s3signer.SignV2(*req, c.accessKeyID, c.secretAccessKey)
 	}
 	return req, nil
 }

--- a/vendor/github.com/minio/minio-go/constants.go
+++ b/vendor/github.com/minio/minio-go/constants.go
@@ -44,3 +44,9 @@ const optimalReadBufferSize = 1024 * 1024 * 5
 // unsignedPayload - value to be set to X-Amz-Content-Sha256 header when
 // we don't want to sign the request payload
 const unsignedPayload = "UNSIGNED-PAYLOAD"
+
+// Signature related constants.
+const (
+	signV4Algorithm   = "AWS4-HMAC-SHA256"
+	iso8601DateFormat = "20060102T150405Z"
+)

--- a/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v2.go
+++ b/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v2.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package minio
+package s3signer
 
 import (
 	"bytes"
@@ -58,9 +58,9 @@ func encodeURL2Path(u *url.URL) (path string) {
 	return
 }
 
-// preSignV2 - presign the request in following style.
+// PreSignV2 - presign the request in following style.
 // https://${S3_BUCKET}.s3.amazonaws.com/${S3_OBJECT}?AWSAccessKeyId=${S3_ACCESS_KEY}&Expires=${TIMESTAMP}&Signature=${SIGNATURE}.
-func preSignV2(req http.Request, accessKeyID, secretAccessKey string, expires int64) *http.Request {
+func PreSignV2(req http.Request, accessKeyID, secretAccessKey string, expires int64) *http.Request {
 	// Presign is not needed for anonymous credentials.
 	if accessKeyID == "" || secretAccessKey == "" {
 		return &req
@@ -104,9 +104,9 @@ func preSignV2(req http.Request, accessKeyID, secretAccessKey string, expires in
 	return &req
 }
 
-// postPresignSignatureV2 - presigned signature for PostPolicy
+// PostPresignSignatureV2 - presigned signature for PostPolicy
 // request.
-func postPresignSignatureV2(policyBase64, secretAccessKey string) string {
+func PostPresignSignatureV2(policyBase64, secretAccessKey string) string {
 	hm := hmac.New(sha1.New, []byte(secretAccessKey))
 	hm.Write([]byte(policyBase64))
 	signature := base64.StdEncoding.EncodeToString(hm.Sum(nil))
@@ -129,8 +129,8 @@ func postPresignSignatureV2(policyBase64, secretAccessKey string) string {
 //
 // CanonicalizedProtocolHeaders = <described below>
 
-// signV2 sign the request before Do() (AWS Signature Version 2).
-func signV2(req http.Request, accessKeyID, secretAccessKey string) *http.Request {
+// SignV2 sign the request before Do() (AWS Signature Version 2).
+func SignV2(req http.Request, accessKeyID, secretAccessKey string) *http.Request {
 	// Signature calculation is not needed for anonymous credentials.
 	if accessKeyID == "" || secretAccessKey == "" {
 		return &req

--- a/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v4.go
+++ b/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v4.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package minio
+package s3signer
 
 import (
 	"bytes"
@@ -101,8 +101,8 @@ func getScope(location string, t time.Time) string {
 	return scope
 }
 
-// getCredential generate a credential string.
-func getCredential(accessKeyID, location string, t time.Time) string {
+// GetCredential generate a credential string.
+func GetCredential(accessKeyID, location string, t time.Time) string {
 	scope := getScope(location, t)
 	return accessKeyID + "/" + scope
 }
@@ -202,9 +202,9 @@ func getStringToSignV4(t time.Time, location, canonicalRequest string) string {
 	return stringToSign
 }
 
-// preSignV4 presign the request, in accordance with
+// PreSignV4 presign the request, in accordance with
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html.
-func preSignV4(req http.Request, accessKeyID, secretAccessKey, location string, expires int64) *http.Request {
+func PreSignV4(req http.Request, accessKeyID, secretAccessKey, location string, expires int64) *http.Request {
 	// Presign is not needed for anonymous credentials.
 	if accessKeyID == "" || secretAccessKey == "" {
 		return &req
@@ -214,7 +214,7 @@ func preSignV4(req http.Request, accessKeyID, secretAccessKey, location string, 
 	t := time.Now().UTC()
 
 	// Get credential string.
-	credential := getCredential(accessKeyID, location, t)
+	credential := GetCredential(accessKeyID, location, t)
 
 	// Get all signed headers.
 	signedHeaders := getSignedHeaders(req)
@@ -246,9 +246,9 @@ func preSignV4(req http.Request, accessKeyID, secretAccessKey, location string, 
 	return &req
 }
 
-// postPresignSignatureV4 - presigned signature for PostPolicy
+// PostPresignSignatureV4 - presigned signature for PostPolicy
 // requests.
-func postPresignSignatureV4(policyBase64 string, t time.Time, secretAccessKey, location string) string {
+func PostPresignSignatureV4(policyBase64 string, t time.Time, secretAccessKey, location string) string {
 	// Get signining key.
 	signingkey := getSigningKey(secretAccessKey, location, t)
 	// Calculate signature.
@@ -256,9 +256,9 @@ func postPresignSignatureV4(policyBase64 string, t time.Time, secretAccessKey, l
 	return signature
 }
 
-// signV4 sign the request before Do(), in accordance with
+// SignV4 sign the request before Do(), in accordance with
 // http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
-func signV4(req http.Request, accessKeyID, secretAccessKey, location string) *http.Request {
+func SignV4(req http.Request, accessKeyID, secretAccessKey, location string) *http.Request {
 	// Signature calculation is not needed for anonymous credentials.
 	if accessKeyID == "" || secretAccessKey == "" {
 		return &req
@@ -280,7 +280,7 @@ func signV4(req http.Request, accessKeyID, secretAccessKey, location string) *ht
 	signingKey := getSigningKey(secretAccessKey, location, t)
 
 	// Get credential string.
-	credential := getCredential(accessKeyID, location, t)
+	credential := GetCredential(accessKeyID, location, t)
 
 	// Get all signed headers.
 	signedHeaders := getSignedHeaders(req)

--- a/vendor/github.com/minio/minio-go/pkg/s3signer/utils.go
+++ b/vendor/github.com/minio/minio-go/pkg/s3signer/utils.go
@@ -1,0 +1,118 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package s3signer
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+// unsignedPayload - value to be set to X-Amz-Content-Sha256 header when
+const unsignedPayload = "UNSIGNED-PAYLOAD"
+
+// sum256 calculate sha256 sum for an input byte array.
+func sum256(data []byte) []byte {
+	hash := sha256.New()
+	hash.Write(data)
+	return hash.Sum(nil)
+}
+
+// sumHMAC calculate hmac between two input byte array.
+func sumHMAC(key []byte, data []byte) []byte {
+	hash := hmac.New(sha256.New, key)
+	hash.Write(data)
+	return hash.Sum(nil)
+}
+
+//expects ascii encoded strings - from output of urlEncodePath
+func percentEncodeSlash(s string) string {
+	return strings.Replace(s, "/", "%2F", -1)
+}
+
+// queryEncode - encodes query values in their URL encoded form. In
+// addition to the percent encoding performed by urlEncodePath() used
+// here, it also percent encodes '/' (forward slash)
+func queryEncode(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := v[k]
+		prefix := percentEncodeSlash(urlEncodePath(k)) + "="
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			buf.WriteString(percentEncodeSlash(urlEncodePath(v)))
+		}
+	}
+	return buf.String()
+}
+
+// urlEncodePath encode the strings from UTF-8 byte representations to HTML hex escape sequences
+//
+// This is necessary since regular url.Parse() and url.Encode() functions do not support UTF-8
+// non english characters cannot be parsed due to the nature in which url.Encode() is written
+//
+// This function on the other hand is a direct replacement for url.Encode() technique to support
+// pretty much every UTF-8 character.
+func urlEncodePath(pathName string) string {
+	// if object matches reserved string, no need to encode them
+	reservedNames := regexp.MustCompile("^[a-zA-Z0-9-_.~/]+$")
+	if reservedNames.MatchString(pathName) {
+		return pathName
+	}
+	var encodedPathname string
+	for _, s := range pathName {
+		if 'A' <= s && s <= 'Z' || 'a' <= s && s <= 'z' || '0' <= s && s <= '9' { // §2.3 Unreserved characters (mark)
+			encodedPathname = encodedPathname + string(s)
+			continue
+		}
+		switch s {
+		case '-', '_', '.', '~', '/': // §2.3 Unreserved characters (mark)
+			encodedPathname = encodedPathname + string(s)
+			continue
+		default:
+			len := utf8.RuneLen(s)
+			if len < 0 {
+				// if utf8 cannot convert return the same string as is
+				return pathName
+			}
+			u := make([]byte, len)
+			utf8.EncodeRune(u, s)
+			for _, r := range u {
+				hex := hex.EncodeToString([]byte{r})
+				encodedPathname = encodedPathname + "%" + strings.ToUpper(hex)
+			}
+		}
+	}
+	return encodedPathname
+}

--- a/vendor/github.com/minio/minio-go/s3-endpoints.go
+++ b/vendor/github.com/minio/minio-go/s3-endpoints.go
@@ -23,6 +23,7 @@ var awsS3EndpointMap = map[string]string{
 	"us-east-2":      "s3-us-east-2.amazonaws.com",
 	"us-west-2":      "s3-us-west-2.amazonaws.com",
 	"us-west-1":      "s3-us-west-1.amazonaws.com",
+	"ca-central-1":   "s3.ca-central-1.amazonaws.com",
 	"eu-west-1":      "s3-eu-west-1.amazonaws.com",
 	"eu-central-1":   "s3-eu-central-1.amazonaws.com",
 	"ap-south-1":     "s3-ap-south-1.amazonaws.com",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -50,16 +50,22 @@
 			"revisionTime": "2015-10-24T22:24:27-07:00"
 		},
 		{
-			"checksumSHA1": "pZ8dP8DPhCsSmAeZPUvbUYLfd8o=",
+			"checksumSHA1": "/057xLXT+4oqAvucT+iHwDqYOok=",
 			"path": "github.com/minio/minio-go",
-			"revision": "95231ceb23b6b961f00ff14f68a155a76afe49a9",
-			"revisionTime": "2016-11-27T19:47:22Z"
+			"revision": "d02caa62b9e1034f93a82d41da806651a666c5a3",
+			"revisionTime": "2016-12-14T00:10:05Z"
 		},
 		{
 			"checksumSHA1": "qTxOBp3GVxCC70ykb7Hxg6UgWwA=",
 			"path": "github.com/minio/minio-go/pkg/policy",
 			"revision": "583c261267bc1022bb3e046c7d01c49d3f56edaa",
 			"revisionTime": "2016-09-03T08:42:23Z"
+		},
+		{
+			"checksumSHA1": "l95EyvF0yFAItXsXYqsZ6g7yGy4=",
+			"path": "github.com/minio/minio-go/pkg/s3signer",
+			"revision": "d02caa62b9e1034f93a82d41da806651a666c5a3",
+			"revisionTime": "2016-12-14T00:10:05Z"
 		},
 		{
 			"checksumSHA1": "A8QOw1aWwc+RtjGozY0XeS5varo=",


### PR DESCRIPTION
Fixes #1923