### PR TITLE
clientfs: Fix policy mode calc. in GetAccess()

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -1125,12 +1125,13 @@ func (f *fsClient) GetAccess() (access string, err *probe.Error) {
 	if !st.Mode().IsDir() {
 		return "", probe.NewError(APINotImplemented{API: "GetAccess", APIType: "filesystem"})
 	}
-	switch {
-	case st.Mode() == os.FileMode(0777):
+	// Mask with os.ModePerm to get only inode permissions
+	switch st.Mode() & os.ModePerm {
+	case os.FileMode(0777):
 		return "readwrite", nil
-	case st.Mode() == os.FileMode(0555):
+	case os.FileMode(0555):
 		return "readonly", nil
-	case st.Mode() == os.FileMode(0333):
+	case os.FileMode(0333):
 		return "writeonly", nil
 	}
 	return "none", nil


### PR DESCRIPTION
Masking target directory file mode to be able to perform correct comparaison with policy standard file permissions in FS mode