### PR TITLE
flags: use IsSet to fetch for cli flags

### DIFF
--- a/cmd/admin-lock-clear.go
+++ b/cmd/admin-lock-clear.go
@@ -40,6 +40,7 @@ var (
 var adminLockClearCmd = cli.Command{
 	Name:   "clear",
 	Usage:  "Clear locks hold in a given Minio server",
+	Before: setGlobalsFromContext,
 	Action: mainAdminLockClear,
 	Flags:  append(adminLockClearFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
@@ -104,7 +105,6 @@ func checkAdminLockClearSyntax(ctx *cli.Context) {
 
 func mainAdminLockClear(ctx *cli.Context) error {
 
-	setGlobalsFromContext(ctx)
 	checkAdminLockClearSyntax(ctx)
 
 	// Get the alias parameter from cli

--- a/cmd/admin-lock-list.go
+++ b/cmd/admin-lock-list.go
@@ -41,6 +41,7 @@ var adminLockListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "Get the list of locks hold in a given Minio server",
 	Action: mainAdminLockList,
+	Before: setGlobalsFromContext,
 	Flags:  append(adminLockListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc admin lock {{.Name}} - {{.Usage}}
@@ -104,7 +105,6 @@ func checkAdminLockListSyntax(ctx *cli.Context) {
 
 func mainAdminLockList(ctx *cli.Context) error {
 
-	setGlobalsFromContext(ctx)
 	checkAdminLockListSyntax(ctx)
 
 	// Get the alias parameter from cli

--- a/cmd/admin-lock.go
+++ b/cmd/admin-lock.go
@@ -26,6 +26,7 @@ var adminLockCmd = cli.Command{
 	Name:   "lock",
 	Usage:  "Control locks in servers.",
 	Action: mainAdminLock,
+	Before: setGlobalsFromContext,
 	Flags:  append(adminLockFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		adminLockListCmd,
@@ -48,8 +49,6 @@ COMMANDS:
 
 // mainAdminLock is the handle for "mc admin lock" command.
 func mainAdminLock(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -26,6 +26,7 @@ var adminCmd = cli.Command{
 	Name:   "admin",
 	Usage:  "Manage Minio servers.",
 	Action: mainAdmin,
+	Before: setGlobalsFromContext,
 	Flags:  append(adminFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		adminServiceCmd,
@@ -48,8 +49,6 @@ COMMANDS:
 
 // mainAdmin is the handle for "mc admin" command.
 func mainAdmin(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -29,6 +29,7 @@ var adminServiceRestartCmd = cli.Command{
 	Name:   "restart",
 	Usage:  "Restart a minio server",
 	Action: mainAdminServiceRestart,
+	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
    mc admin service {{.Name}} - {{.Usage}}
@@ -72,8 +73,6 @@ func checkAdminServiceRestartSyntax(ctx *cli.Context) {
 }
 
 func mainAdminServiceRestart(ctx *cli.Context) error {
-	// Set global values from context.
-	setGlobalsFromContext(ctx)
 
 	// Validate serivce restart syntax.
 	checkAdminServiceRestartSyntax(ctx)

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -36,6 +36,7 @@ var adminServiceStatusCmd = cli.Command{
 	Name:   "status",
 	Usage:  "Get the status of a Minio server",
 	Action: mainAdminServiceStatus,
+	Before: setGlobalsFromContext,
 	Flags:  append(adminServiceStatusFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc admin service {{.Name}} - {{.Usage}}
@@ -114,8 +115,6 @@ func checkAdminServiceStatusSyntax(ctx *cli.Context) {
 }
 
 func mainAdminServiceStatus(ctx *cli.Context) error {
-	// Set global values.
-	setGlobalsFromContext(ctx)
 
 	// Validate serivce status syntax.
 	checkAdminServiceStatusSyntax(ctx)

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -22,6 +22,7 @@ var adminServiceCmd = cli.Command{
 	Name:   "service",
 	Usage:  "Control servers.",
 	Action: mainAdminService,
+	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminServiceRestartCmd,
@@ -44,8 +45,6 @@ COMMANDS:
 
 // mainAdmin is the handle for "mc admin service" command.
 func mainAdminService(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -37,6 +37,7 @@ var catCmd = cli.Command{
 	Name:   "cat",
 	Usage:  "Display file and object contents.",
 	Action: mainCat,
+	Before: setGlobalsFromContext,
 	Flags:  append(catFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -134,8 +135,6 @@ func catOut(r io.Reader, size int64) *probe.Error {
 
 // mainCat is the main entry point for cat command.
 func mainCat(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'cat' cli arguments.
 	checkCatSyntax(ctx)

--- a/cmd/config-host-main.go
+++ b/cmd/config-host-main.go
@@ -37,6 +37,7 @@ var configHostCmd = cli.Command{
 	Usage:  "List, modify and remove hosts in configuration file.",
 	Flags:  append(configHostFlags, globalFlags...),
 	Action: mainConfigHost,
+	Before: setGlobalsFromContext,
 	CustomHelpTemplate: `NAME:
    mc config {{.Name}} - {{.Usage}}
 
@@ -187,8 +188,6 @@ func checkConfigHostRemoveSyntax(ctx *cli.Context) {
 }
 
 func mainConfigHost(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'config host' cli arguments.
 	checkConfigHostSyntax(ctx)

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -37,6 +37,7 @@ var configCmd = cli.Command{
 	Name:   "config",
 	Usage:  "Manage mc configuration file.",
 	Action: mainConfig,
+	Before: setGlobalsFromContext,
 	Flags:  append(configFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		configHostCmd,
@@ -58,8 +59,6 @@ COMMANDS:
 
 // mainConfig is the handle for "mc config" command. provides sub-commands which write configuration data in json format to config file.
 func mainConfig(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -49,6 +49,7 @@ var cpCmd = cli.Command{
 	Name:   "cp",
 	Usage:  "Copy files and objects.",
 	Action: mainCopy,
+	Before: setGlobalsFromContext,
 	Flags:  append(cpFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -353,8 +354,6 @@ func doCopySession(session *sessionV8) {
 
 // mainCopy is the entry point for cp command.
 func mainCopy(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'copy' cli arguments.
 	checkCopySyntax(ctx)

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -38,6 +38,7 @@ var diffCmd = cli.Command{
 	Usage:       "Show differences between two folders or buckets.",
 	Description: "Diff only lists missing objects or objects with size differences. It *DOES NOT* compare contents. i.e. Objects of same name and size, but differ in contents are not noticed.",
 	Action:      mainDiff,
+	Before:      setGlobalsFromContext,
 	Flags:       append(diffFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -180,8 +181,6 @@ func doDiffMain(firstURL, secondURL string) error {
 
 // mainDiff main for 'diff'.
 func mainDiff(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'diff' cli arguments.
 	checkDiffSyntax(ctx)

--- a/cmd/events-add.go
+++ b/cmd/events-add.go
@@ -48,6 +48,7 @@ var eventsAddCmd = cli.Command{
 	Name:   "add",
 	Usage:  "Add a new bucket notification.",
 	Action: mainEventsAdd,
+	Before: setGlobalsFromContext,
 	Flags:  append(eventsAddFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc events {{.Name}} - {{.Usage}}
@@ -98,7 +99,6 @@ func (u eventsAddMessage) String() string {
 func mainEventsAdd(ctx *cli.Context) error {
 	console.SetColor("Events", color.New(color.FgGreen, color.Bold))
 
-	setGlobalsFromContext(ctx)
 	checkEventsAddSyntax(ctx)
 
 	args := ctx.Args()

--- a/cmd/events-list.go
+++ b/cmd/events-list.go
@@ -34,6 +34,7 @@ var eventsListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "List bucket notifications.",
 	Action: mainEventsList,
+	Before: setGlobalsFromContext,
 	Flags:  append(eventsListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc events {{.Name}} - {{.Usage}}
@@ -99,7 +100,6 @@ func mainEventsList(ctx *cli.Context) error {
 	console.SetColor("Events", color.New(color.FgCyan, color.Bold))
 	console.SetColor("Filter", color.New(color.Bold))
 
-	setGlobalsFromContext(ctx)
 	checkEventsListSyntax(ctx)
 
 	args := ctx.Args()

--- a/cmd/events-main.go
+++ b/cmd/events-main.go
@@ -26,6 +26,7 @@ var eventsCmd = cli.Command{
 	Name:   "events",
 	Usage:  "Manage object notifications.",
 	Action: mainEvents,
+	Before: setGlobalsFromContext,
 	Flags:  append(eventsFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		eventsAddCmd,
@@ -49,8 +50,6 @@ COMMANDS:
 
 // mainEvents is the handle for "mc events" command.
 func mainEvents(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())

--- a/cmd/events-remove.go
+++ b/cmd/events-remove.go
@@ -39,6 +39,7 @@ var eventsRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "Remove a bucket notification. With '--force' can remove all bucket notifications.",
 	Action: mainEventsRemove,
+	Before: setGlobalsFromContext,
 	Flags:  append(eventsRemoveFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc events {{.Name}} - {{.Usage}}
@@ -89,7 +90,6 @@ func (u eventsRemoveMessage) String() string {
 func mainEventsRemove(ctx *cli.Context) error {
 	console.SetColor("Events", color.New(color.FgGreen, color.Bold))
 
-	setGlobalsFromContext(ctx)
 	checkEventsRemoveSyntax(ctx)
 
 	args := ctx.Args()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -87,11 +87,12 @@ func setGlobals(quiet, debug, json, noColor, insecure bool) {
 }
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
-func setGlobalsFromContext(ctx *cli.Context) {
-	quiet := ctx.Bool("quiet") || ctx.GlobalBool("quiet")
-	debug := ctx.Bool("debug") || ctx.GlobalBool("debug")
-	json := ctx.Bool("json") || ctx.GlobalBool("json")
-	noColor := ctx.Bool("no-color") || ctx.GlobalBool("no-color")
-	insecure := ctx.Bool("insecure") || ctx.GlobalBool("insecure")
+func setGlobalsFromContext(ctx *cli.Context) error {
+	quiet := ctx.IsSet("quiet")
+	debug := ctx.IsSet("debug")
+	json := ctx.IsSet("json")
+	noColor := ctx.IsSet("no-color")
+	insecure := ctx.IsSet("insecure")
 	setGlobals(quiet, debug, json, noColor, insecure)
+	return nil
 }

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -43,6 +43,7 @@ var lsCmd = cli.Command{
 	Name:   "ls",
 	Usage:  "List files and folders.",
 	Action: mainList,
+	Before: setGlobalsFromContext,
 	Flags:  append(lsFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -109,9 +110,6 @@ func mainList(ctx *cli.Context) error {
 	console.SetColor("Dir", color.New(color.FgCyan, color.Bold))
 	console.SetColor("Size", color.New(color.FgYellow))
 	console.SetColor("Time", color.New(color.FgGreen))
-
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'ls' cli arguments.
 	checkListSyntax(ctx)

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -40,6 +40,7 @@ var mbCmd = cli.Command{
 	Name:   "mb",
 	Usage:  "Make a bucket or a folder.",
 	Action: mainMakeBucket,
+	Before: setGlobalsFromContext,
 	Flags:  append(mbFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -97,8 +98,6 @@ func checkMakeBucketSyntax(ctx *cli.Context) {
 
 // mainMakeBucket is entry point for mb command.
 func mainMakeBucket(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'mb' cli arguments.
 	checkMakeBucketSyntax(ctx)

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -60,6 +60,7 @@ var mirrorCmd = cli.Command{
 	Name:   "mirror",
 	Usage:  "Mirror buckets and folders.",
 	Action: mainMirror,
+	Before: setGlobalsFromContext,
 	Flags:  append(mirrorFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -702,8 +703,6 @@ func newMirrorSession(session *sessionV8) *mirrorSession {
 
 // Main entry point for mirror command.
 func mainMirror(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'mirror' cli arguments.
 	checkMirrorSyntax(ctx)

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -33,6 +33,7 @@ var pipeCmd = cli.Command{
 	Name:   "pipe",
 	Usage:  "Redirect STDIN to an object or file or STDOUT.",
 	Action: mainPipe,
+	Before: setGlobalsFromContext,
 	Flags:  append(pipeFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -88,8 +89,6 @@ func checkPipeSyntax(ctx *cli.Context) {
 
 // mainPipe is the main entry point for pipe command.
 func mainPipe(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// validate pipe input arguments.
 	checkPipeSyntax(ctx)

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -41,6 +41,7 @@ var policyCmd = cli.Command{
 	Name:   "policy",
 	Usage:  "Manage anonymous access to objects.",
 	Action: mainPolicy,
+	Before: setGlobalsFromContext,
 	Flags:  append(policyFlags, globalFlags...),
 	CustomHelpTemplate: `Name:
    mc {{.Name}} - {{.Usage}}
@@ -381,8 +382,6 @@ func runPolicyCmd(ctx *cli.Context) {
 }
 
 func mainPolicy(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'policy' cli arguments.
 	checkPolicySyntax(ctx)

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -67,6 +67,7 @@ var rmCmd = cli.Command{
 	Name:   "rm",
 	Usage:  "Remove files and objects.",
 	Action: mainRm,
+	Before: setGlobalsFromContext,
 	Flags:  append(rmFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -264,8 +265,6 @@ func removeRecursive(url string, isIncomplete bool, isFake bool, older int) erro
 
 // main for rm command.
 func mainRm(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'rm' cli arguments.
 	checkRmSyntax(ctx)

--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -39,6 +39,7 @@ var sessionCmd = cli.Command{
 	Usage:  "Manage saved sessions for cp and mirror commands.",
 	Action: mainSession,
 	Flags:  append(sessionFlags, globalFlags...),
+	Before: setGlobalsFromContext,
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
 
@@ -206,8 +207,6 @@ func findClosestSessions(session string) []string {
 }
 
 func mainSession(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check 'session' cli arguments.
 	checkSessionSyntax(ctx)

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -38,6 +38,7 @@ var shareDownload = cli.Command{
 	Name:   "download",
 	Usage:  "Generate URLs for download access.",
 	Action: mainShareDownload,
+	Before: setGlobalsFromContext,
 	Flags:  append(shareDownloadFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc share {{.Name}} - {{.Usage}}
@@ -152,8 +153,6 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 
 // main for share download.
 func mainShareDownload(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check input arguments.
 	checkShareDownloadSyntax(ctx)

--- a/cmd/share-list-main.go
+++ b/cmd/share-list-main.go
@@ -33,6 +33,7 @@ var shareList = cli.Command{
 	Name:   "list",
 	Usage:  "List previously shared objects and folders.",
 	Action: mainShareList,
+	Before: setGlobalsFromContext,
 	Flags:  append(shareListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc share {{.Name}} COMMAND - {{.Usage}}
@@ -101,8 +102,6 @@ func doShareList(cmd string) *probe.Error {
 
 // main entry point for share list.
 func mainShareList(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// validate command-line args.
 	checkShareListSyntax(ctx)

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -34,6 +34,7 @@ var shareCmd = cli.Command{
 	Name:   "share",
 	Usage:  "Generate URL for sharing.",
 	Action: mainShare,
+	Before: setGlobalsFromContext,
 	Flags:  append(shareFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		shareDownload,
@@ -73,8 +74,6 @@ func migrateShare() {
 
 // mainShare - main handler for mc share command.
 func mainShare(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -41,6 +41,7 @@ var shareUpload = cli.Command{
 	Name:   "upload",
 	Usage:  "Generate ‘curl’ command to upload objects without requiring access/secret keys.",
 	Action: mainShareUpload,
+	Before: setGlobalsFromContext,
 	Flags:  append(shareUploadFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc share {{.Name}} - {{.Usage}}
@@ -175,8 +176,6 @@ func doShareUploadURL(objectURL string, isRecursive bool, expiry time.Duration, 
 
 // main for share upload command.
 func mainShareUpload(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// check input arguments.
 	checkShareUploadSyntax(ctx)

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -46,6 +46,7 @@ var updateCmd = cli.Command{
 	Name:   "update",
 	Usage:  "Check for new mc update.",
 	Action: mainUpdate,
+	Before: setGlobalsFromContext,
 	Flags:  append(updateFlags, globalFlags...),
 	CustomHelpTemplate: `Name:
    mc {{.Name}} - {{.Usage}}
@@ -213,8 +214,6 @@ func getReleaseUpdate(updateURL string) (updateMsg updateMessage, errMsg string,
 
 // main entry point for update command.
 func mainUpdate(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// Additional command speific theme customization.
 	console.SetColor("Update", color.New(color.FgGreen, color.Bold))

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -35,6 +35,7 @@ var versionCmd = cli.Command{
 	Name:   "version",
 	Usage:  "Print version info.",
 	Action: mainVersion,
+	Before: setGlobalsFromContext,
 	Flags:  append(versionFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -75,8 +76,6 @@ func (v versionMessage) JSON() string {
 }
 
 func mainVersion(ctx *cli.Context) error {
-	// Set global flags from context.
-	setGlobalsFromContext(ctx)
 
 	// Additional command speific theme customization.
 	console.SetColor("Version", color.New(color.FgGreen, color.Bold))

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -58,6 +58,7 @@ var watchCmd = cli.Command{
 	Name:   "watch",
 	Usage:  "Watch for files and objects events.",
 	Action: mainWatch,
+	Before: setGlobalsFromContext,
 	Flags:  append(watchFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    mc {{.Name}} - {{.Usage}}
@@ -124,7 +125,6 @@ func mainWatch(ctx *cli.Context) error {
 	console.SetColor("EventType", color.New(color.FgCyan, color.Bold))
 	console.SetColor("ObjectName", color.New(color.Bold))
 
-	setGlobalsFromContext(ctx)
 	checkWatchSyntax(ctx)
 
 	args := ctx.Args()


### PR DESCRIPTION
cli package fails to search for global flags when we use many level of subcommands. This PR uses context.IsSet() instead.


This is a **workaround**, we probably can wait for fixes for this instead https://github.com/urfave/cli/issues/585

Fixes #1962 