### PR TITLE
admin: Set 5 min timeout for header response

### DIFF
--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -83,6 +83,7 @@ func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 				}).DialContext,
 				MaxIdleConns:          100,
 				IdleConnTimeout:       90 * time.Second,
+				ResponseHeaderTimeout: 5 * time.Minute,
 				TLSHandshakeTimeout:   10 * time.Second,
 				ExpectContinueTimeout: 1 * time.Second,
 				TLSClientConfig:       tlsConfig,
@@ -94,9 +95,6 @@ func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 
 			// Set custom transport.
 			api.SetCustomTransport(transport)
-
-			// Set client timeout
-			api.SetTimeout(30 * time.Second)
 
 			// Set app info.
 			api.SetAppInfo(config.AppName, config.AppVersion)


### PR DESCRIPTION
For admin management API requests, we set 5 min as default value