### PR TITLE
[Need review] mirror: Delete session data before watching events

### DIFF
--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -165,7 +165,7 @@ func sessionExecute(s *sessionV8) {
 		doCopySession(s)
 	case "mirror":
 		ms := newMirrorSession(s)
-		ms.mirror()
+		doMirrorSession(ms)
 	}
 }
 


### PR DESCRIPTION
When the regular mirroring completes successfully, remove immediately
session file before starting to watch the server.

What's done here, after a successful phase one mirror, indicate that we don't need anymore to save session file when the user presses control-c