### PR TITLE
help: Use {{.HelpName}} in help/examples template

### DIFF
--- a/cmd/admin-heal-list.go
+++ b/cmd/admin-heal-list.go
@@ -45,20 +45,20 @@ var adminHealListCmd = cli.Command{
 	Action: mainAdminHealList,
 	Flags:  append(adminHealListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc admin heal {{.Name}} - {{.Usage}}
+  {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc admin heal {{.Name}} ALIAS/BUCKET/PREFIX
+   {{.HelpName}} ALIAS/BUCKET/PREFIX
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
-
 EXAMPLES:
     1. List objects than need to be healed related to 'testbucket' in a Minio server represented by its alias 'play'.
-       $ mc admin heal {{.Name}} play/testbucket/
+       $ {{.HelpName}} play/testbucket/
+
     2. Recursively list objects than need to be healed.
-       $ mc admin heal {{.Name}} --recursive play/
+       $ {{.HelpName}} --recursive play/
 
 `,
 }

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -52,10 +52,10 @@ var adminHealCmd = cli.Command{
 		adminHealListCmd,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}
@@ -64,14 +64,15 @@ FLAGS:
 COMMANDS:
    {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
-
 EXAMPLES:
     1. Heal 'testbucket' in a Minio server represented by its alias 'play'.
-       $ mc admin {{.Name}} play/testbucket/
+       $ {{.HelpName}} play/testbucket/
+
     2. Heal all objects under 'dir' prefix 
-       $ mc admin {{.Name}} --recursive play/testbucket/dir/
+       $ {{.HelpName}} --recursive play/testbucket/dir/
+
     3. Issue a fake heal operation to see what the server could report
-       $ mc admin {{.Name}} --fake play/testbucket/dir/
+       $ {{.HelpName}} --fake play/testbucket/dir/
 
 `,
 }

--- a/cmd/admin-lock-clear.go
+++ b/cmd/admin-lock-clear.go
@@ -44,24 +44,23 @@ var adminLockClearCmd = cli.Command{
 	Action: mainAdminLockClear,
 	Flags:  append(adminLockClearFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc admin lock {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc admin lock {{.Name}} ALIAS/BUCKET/PREFIX
+   {{.HelpName}} ALIAS/BUCKET/PREFIX
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
-
 EXAMPLES:
     1. Clear all locks hold by 'testbucket' in a Minio server represented by its alias 'play'.
-       $ mc admin lock {{.Name}} play/testbucket
+       $ {{.HelpName}} play/testbucket
 
     2. Clear all 'testbucket' locks that are older than 15 minutes.
-       $ mc admin lock {{.Name}} --duration 15m play/testbucket/
+       $ {{.HelpName}} --duration 15m play/testbucket/
 
     3. Clear all locks hold by all objects under 'dir' prefix
-       $ mc admin lock {{.Name}} play/testbucket/dir/
+       $ {{.HelpName}} play/testbucket/dir/
 
 `,
 }

--- a/cmd/admin-lock-list.go
+++ b/cmd/admin-lock-list.go
@@ -44,24 +44,23 @@ var adminLockListCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(adminLockListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc admin lock {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc admin lock {{.Name}} ALIAS/BUCKET/PREFIX
+   {{.HelpName}} ALIAS/BUCKET/PREFIX
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
-
 EXAMPLES:
     1. List hold locks related to testbucket in a Minio server represented by its alias 'play'.
-       $ mc admin lock {{.Name}} play/testbucket/
+       $ {{.HelpName}} play/testbucket/
 
     2. List locks that are hold for more than 15 minutes.
-       $ mc admin lock {{.Name}} --duration 15m play/testbucket/
+       $ {{.HelpName}} --duration 15m play/testbucket/
 
     3. List locks hold by all objects under dir prefix
-       $ mc admin lock {{.Name}} play/testbucket/dir/
+       $ {{.HelpName}} play/testbucket/dir/
 
 `,
 }

--- a/cmd/admin-lock.go
+++ b/cmd/admin-lock.go
@@ -33,10 +33,10 @@ var adminLockCmd = cli.Command{
 		adminLockClearCmd,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -35,10 +35,10 @@ var adminCmd = cli.Command{
 		adminHealCmd,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/admin-password.go
+++ b/cmd/admin-password.go
@@ -31,17 +31,18 @@ var adminPasswordCmd = cli.Command{
 	Action: mainAdminPassword,
 	Flags:  append(adminPasswordFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc admin {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc admin {{.Name}} ALIAS ACCESS_KEY SECRET_KEY
+   {{.HelpName}} ALIAS ACCESS_KEY SECRET_KEY
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Set new credentials of a Minio server represented by its alias 'play'.
-       $ mc admin {{.Name}} play/ minio minio123
+       $ {{.HelpName}} play/ minio minio123
+
 `,
 }
 

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -32,17 +32,18 @@ var adminServiceRestartCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
-   mc admin service {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc admin service {{.Name}} ALIAS
+   {{.HelpName}} ALIAS
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Restart a Minio server represented by its alias 'play'.
-       $ mc admin service {{.Name}} play/
+       $ {{.HelpName}} play/
+
 `,
 }
 

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -40,17 +40,18 @@ var adminServiceStatusCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(adminServiceStatusFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc admin service {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc admin service {{.Name}} ALIAS
+   {{.HelpName}} ALIAS
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Get storage information of a Minio server represented by its alias 'play'.
-       $ mc admin service {{.Name}} play/
+       $ {{.HelpName}} play/
+
 `,
 }
 

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -29,10 +29,10 @@ var adminServiceCmd = cli.Command{
 		adminServiceStatusCmd,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -40,23 +40,23 @@ var catCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(catFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] SOURCE [SOURCE...]
+   {{.HelpName}} [FLAGS] SOURCE [SOURCE...]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Stream an object from Amazon S3 cloud storage to mplayer standard input.
-      $ mc {{.Name}} s3/ferenginar/klingon_opera_aktuh_maylotah.ogg | mplayer -
+      $ {{.HelpName}} s3/ferenginar/klingon_opera_aktuh_maylotah.ogg | mplayer -
 
    2. Concantenate contents of file1.txt and stdin to standard output.
-      $ mc {{.Name}} file1.txt - > file.txt
+      $ {{.HelpName}} file1.txt - > file.txt
 
    3. Concantenate multiple files to one.
-      $ mc {{.Name}} part.* > complete.img
+      $ {{.HelpName}} part.* > complete.img
 
 `,
 }

--- a/cmd/config-host-main.go
+++ b/cmd/config-host-main.go
@@ -39,10 +39,10 @@ var configHostCmd = cli.Command{
 	Action: mainConfigHost,
 	Before: setGlobalsFromContext,
 	CustomHelpTemplate: `NAME:
-   mc config {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc config {{.Name}} OPERATION
+   {{.HelpName}} OPERATION
 
 OPERATION:
    add ALIAS URL ACCESS-KEY SECRET-KEY [API]
@@ -55,21 +55,22 @@ FLAGS:
 EXAMPLES:
    1. Add Amazon S3 storage service under "myphotos" alias. For security reasons turn off bash history momentarily.
       $ set +o history
-      $ mc config {{.Name}} add myphotos https://s3.amazonaws.com \
+      $ {{.HelpName}} add myphotos https://s3.amazonaws.com \
                   BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
       $ set -o history
 
    2. Add Amazon S3 accelerated storage service under "accel" alias. For security reasons turn off bash history momentarily.
       $ set +o history
-      $ mc config {{.Name}} add accel https://s3-accelerate.amazonaws.com \
+      $ {{.HelpName}} add accel https://s3-accelerate.amazonaws.com \
                   BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
       $ set -o history
 
    3. List all hosts.
-      $ mc config {{.Name}} list
+      $ {{.HelpName}} list
 
    4. Remove "goodisk" config.
-      $ mc config {{.Name}} remove goodisk
+      $ {{.HelpName}} remove goodisk
+
 `,
 }
 

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -43,10 +43,10 @@ var configCmd = cli.Command{
 		configHostCmd,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -52,32 +52,33 @@ var cpCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(cpFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] SOURCE [SOURCE...] TARGET
+   {{.HelpName}} [FLAGS] SOURCE [SOURCE...] TARGET
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Copy a list of objects from local file system to Amazon S3 cloud storage.
-      $ mc {{.Name}} Music/*.ogg s3/jukebox/
+      $ {{.HelpName}} Music/*.ogg s3/jukebox/
 
    2. Copy a folder recursively from Minio cloud storage to Amazon S3 cloud storage.
-      $ mc {{.Name}} --recursive play/mybucket/burningman2011/ s3/mybucket/
+      $ {{.HelpName}} --recursive play/mybucket/burningman2011/ s3/mybucket/
 
    3. Copy multiple local folders recursively to Minio cloud storage.
-      $ mc {{.Name}} --recursive backup/2014/ backup/2015/ play/archive/
+      $ {{.HelpName}} --recursive backup/2014/ backup/2015/ play/archive/
 
    4. Copy a bucket recursively from aliased Amazon S3 cloud storage to local filesystem on Windows.
-      $ mc {{.Name}} --recursive s3\documents\2014\ C:\Backups\2014
+      $ {{.HelpName}} --recursive s3\documents\2014\ C:\Backups\2014
 
    5. Copy an object with name containing unicode characters to Amazon S3 cloud storage.
-      $ mc {{.Name}} 本語 s3/andoria/
+      $ {{.HelpName}} 本語 s3/andoria/
 
    6. Copy a local folder with space separated characters to Amazon S3 cloud storage.
-      $ mc {{.Name}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
+      $ {{.HelpName}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
+
 `,
 }
 

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -54,10 +54,11 @@ DESCRIPTION:
 
 EXAMPLES:
    1. Compare a local folder with a folder on Amazon S3 cloud storage.
-      $ mc {{.Name}} ~/Photos s3/MyBucket/Photos
+      $ {{.HelpName}} ~/Photos s3/MyBucket/Photos
 
    2. Compare two different folders on a local filesystem.
-      $ mc {{.Name}} ~/Photos /Media/Backup/Photos
+      $ {{.HelpName}} ~/Photos /Media/Backup/Photos
+
 `,
 }
 

--- a/cmd/events-add.go
+++ b/cmd/events-add.go
@@ -51,19 +51,21 @@ var eventsAddCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(eventsAddFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc events {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc events {{.Name}} ALIAS/BUCKET ARN [FLAGS]
+   {{.HelpName}} ALIAS/BUCKET ARN [FLAGS]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Enable bucket notification with a specific arn
-     $ mc events {{.Name}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+
    2. Enable bucket notification with filters parameters
-     $ mc events {{.Name}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue --events put,delete --prefix photos/ --suffix .jpg
+     $ {{.HelpName}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue --events put,delete --prefix photos/ --suffix .jpg
+
 `,
 }
 

--- a/cmd/events-list.go
+++ b/cmd/events-list.go
@@ -37,19 +37,21 @@ var eventsListCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(eventsListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc events {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc events {{.Name}} ALIAS/BUCKET ARN [FLAGS]
+   {{.HelpName}} ALIAS/BUCKET ARN [FLAGS]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. List notification configurations associated to a specific arn
-     $ mc events {{.Name}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+
    2. List all notification configurations
-     $ mc events {{.Name}} s3/mybucket
+     $ {{.HelpName}} s3/mybucket
+
 `,
 }
 

--- a/cmd/events-main.go
+++ b/cmd/events-main.go
@@ -34,10 +34,10 @@ var eventsCmd = cli.Command{
 		eventsListCmd,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/events-remove.go
+++ b/cmd/events-remove.go
@@ -42,19 +42,21 @@ var eventsRemoveCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(eventsRemoveFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc events {{.Name}} - {{.Usage}}
+  {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc events {{.Name}} ALIAS/BUCKET [ARN] [FLAGS]
+   {{.HelpName}} ALIAS/BUCKET [ARN] [FLAGS]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Remove bucket notification associated to a specific arn
-     $ mc events {{.Name}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+
    2. Remove all bucket notifications. --force flag is mandatory here
-     $ mc events {{.Name}} myminio/mybucket --force
+     $ {{.HelpName}} myminio/mybucket --force
+
 `,
 }
 

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -46,32 +46,33 @@ var lsCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(lsFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] TARGET [TARGET ...]
+   {{.HelpName}} [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. List buckets on Amazon S3 cloud storage.
-      $ mc {{.Name}} s3
+      $ {{.HelpName}} s3
 
    2. List buckets and all its contents from Amazon S3 cloud storage recursively.
-      $ mc {{.Name}} --recursive s3
+      $ {{.HelpName}} --recursive s3
 
    3. List all contents of mybucket on Amazon S3 cloud storage.
-      $ mc {{.Name}} s3/mybucket/
+      $ {{.HelpName}} s3/mybucket/
 
    4. List all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.
-      $ mc {{.Name}} s3\mybucket\
+      $ {{.HelpName}} s3\mybucket\
 
    5. List files recursively on a local filesystem on Microsoft Windows.
-      $ mc {{.Name}} --recursive C:\Users\Worf\
+      $ {{.HelpName}} --recursive C:\Users\Worf\
 
    6. List incomplete (previously failed) uploads of objects on Amazon S3. 
-      $ mc {{.Name}} --incomplete s3/mybucket
+      $ {{.HelpName}} --incomplete s3/mybucket
+
 `,
 }
 

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -43,29 +43,30 @@ var mbCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(mbFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] TARGET [TARGET...]
+   {{.HelpName}} [FLAGS] TARGET [TARGET...]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Create a bucket on Amazon S3 cloud storage.
-      $ mc {{.Name}} s3/mynewbucket
+      $ {{.HelpName}} s3/mynewbucket
 
    2. Create a new bucket on Google Cloud Storage.
-      $ mc {{.Name}} gcs/miniocloud
+      $ {{.HelpName}} gcs/miniocloud
 
    4. Create a new bucket on Amazon S3 cloud storage in region ‘us-west-2’.
-      $ mc {{.Name}} --region=us-west-2 s3/myregionbucket
+      $ {{.HelpName}} --region=us-west-2 s3/myregionbucket
 
    5. Create a new directory including its missing parents (equivalent to ‘mkdir -p’).
-      $ mc {{.Name}} /tmp/this/new/dir1
+      $ {{.HelpName}} /tmp/this/new/dir1
 
    6. Create multiple directories including its missing parents (behavior similar to ‘mkdir -p’).
-      $ mc {{.Name}} /mnt/sdb/mydisk /mnt/sdc/mydisk /mnt/sdd/mydisk
+      $ {{.HelpName}} /mnt/sdb/mydisk /mnt/sdc/mydisk /mnt/sdd/mydisk
+
 `,
 }
 

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -63,34 +63,35 @@ var mirrorCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(mirrorFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] SOURCE TARGET
+   {{.HelpName}} [FLAGS] SOURCE TARGET
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Mirror a bucket recursively from Minio cloud storage to a bucket on Amazon S3 cloud storage.
-      $ mc {{.Name}} play/photos/2014 s3/backup-photos
+      $ {{.HelpName}} play/photos/2014 s3/backup-photos
 
    2. Mirror a local folder recursively to Amazon S3 cloud storage.
-      $ mc {{.Name}} backup/ s3/archive
+      $ {{.HelpName}} backup/ s3/archive
 
    3. Mirror a bucket from aliased Amazon S3 cloud storage to a folder on Windows.
-      $ mc {{.Name}} s3\documents\2014\ C:\backup\2014
+      $ {{.HelpName}} s3\documents\2014\ C:\backup\2014
 
    4. Mirror a bucket from aliased Amazon S3 cloud storage to a local folder use '--force' to overwrite destination.
-      $ mc {{.Name}} --force s3/miniocloud miniocloud-backup
+      $ {{.HelpName}} --force s3/miniocloud miniocloud-backup
 
    5. Mirror a bucket from Minio cloud storage to a bucket on Amazon S3 cloud storage and remove any extraneous
       files on Amazon S3 cloud storage. NOTE: '--remove' is only supported with '--force'.
-      $ mc {{.Name}} --force --remove play/photos/2014 s3/backup-photos/2014
+      $ {{.HelpName}} --force --remove play/photos/2014 s3/backup-photos/2014
 
    6. Continuously mirror a local folder recursively to Minio cloud storage. '--watch' continuously watches for
       new objects and uploads them.
-      $ mc {{.Name}} --force --remove --watch /var/lib/backups play/backups
+      $ {{.HelpName}} --force --remove --watch /var/lib/backups play/backups
+
 `,
 }
 

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -36,26 +36,27 @@ var pipeCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(pipeFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] [TARGET]
+   {{.HelpName}} [FLAGS] [TARGET]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Write contents of stdin to a file on local filesystem.
-      $ mc {{.Name}} /tmp/hello-world.go
+      $ {{.HelpName}} /tmp/hello-world.go
 
    2. Write contents of stdin to an object on Amazon S3 cloud storage.
-      $ mc {{.Name}} s3/personalbuck/meeting-notes.txt
+      $ {{.HelpName}} s3/personalbuck/meeting-notes.txt
 
    3. Copy an ISO image to an object on Amazon S3 cloud storage.
-      $ cat debian-8.2.iso | mc {{.Name}} s3/ferenginar/gnuos.iso
+      $ cat debian-8.2.iso | {{.HelpName}} s3/ferenginar/gnuos.iso
 
    4. Stream MySQL database dump to Amazon S3 directly.
-      $ mysqldump -u root -p ******* accountsdb | mc {{.Name}} s3/ferenginar/backups/accountsdb-oct-9-2015.sql
+      $ mysqldump -u root -p ******* accountsdb | {{.HelpName}} s3/ferenginar/backups/accountsdb-oct-9-2015.sql
+
 `,
 }
 

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -44,11 +44,11 @@ var policyCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(policyFlags, globalFlags...),
 	CustomHelpTemplate: `Name:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] PERMISSION TARGET
-   mc {{.Name}} [FLAGS] TARGET
+   {{.HelpName}} [FLAGS] PERMISSION TARGET
+   {{.HelpName}} [FLAGS] TARGET
 
 PERMISSION:
    Allowed policies are: [none, download, upload, public].
@@ -58,25 +58,25 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. Set bucket to "download" on Amazon S3 cloud storage.
-      $ mc {{.Name}} download s3/burningman2011
+      $ {{.HelpName}} download s3/burningman2011
 
    2. Set bucket to "public" on Amazon S3 cloud storage.
-      $ mc {{.Name}} public s3/shared
+      $ {{.HelpName}} public s3/shared
 
    3. Set bucket to "upload" on Amazon S3 cloud storage.
-      $ mc {{.Name}} upload s3/incoming
+      $ {{.HelpName}} upload s3/incoming
 
    4. Set a prefix to "public" on Amazon S3 cloud storage.
-      $ mc {{.Name}} public s3/public-commons/images
+      $ {{.HelpName}} public s3/public-commons/images
 
    5. Get bucket permissions.
-      $ mc {{.Name}} s3/shared
+      $ {{.HelpName}} s3/shared
 
    6. List policies set to a specified bucket.
-      $ mc {{.Name}} list s3/shared
+      $ {{.HelpName}} list s3/shared
 
    7. List public object URLs recursively.
-      $ mc {{.Name}} --recursive links s3/shared/
+      $ {{.HelpName}} --recursive links s3/shared/
 
 `,
 }

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -70,29 +70,30 @@ var rmCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(rmFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+  {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] TARGET [TARGET ...]
+  {{.HelpName}} [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Remove a file.
-      $ mc {{.Name}} 1999/old-backup.tgz
+      $ {{.HelpName}} 1999/old-backup.tgz
 
    2. Remove all objects recursively.
-      $ mc {{.Name}} --recursive s3/jazz-songs/louis/
+      $ {{.HelpName}} --recursive s3/jazz-songs/louis/
 
    3. Remove all objects older than '90' days.
-      $ mc {{.Name}} --recursive --older-than=90 s3/jazz-songs/louis/
+      $ {{.HelpName}} --recursive --older-than=90 s3/jazz-songs/louis/
 
    4. Remove all objects read from STDIN.
-      $ mc {{.Name}} --force --stdin
+      $ {{.HelpName}} --force --stdin
 
    5. Drop all incomplete uploads on 'jazz-songs' bucket.
-      $ mc {{.Name}} --incomplete --recursive s3/jazz-songs/
+      $ {{.HelpName}} --incomplete --recursive s3/jazz-songs/
+
 `,
 }
 

--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -42,10 +42,10 @@ var sessionCmd = cli.Command{
 	Flags:  append(sessionFlags, globalFlags...),
 	Before: setGlobalsFromContext,
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] OPERATION [ARG]
+   {{.HelpName}} [FLAGS] OPERATION [ARG]
 
 OPERATION:
    resume   Resume a previously saved session.
@@ -60,16 +60,17 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. List sessions.
-      $ mc {{.Name}} list
+      $ {{.HelpName}} list
 
    2. Resume session.
-      $ mc {{.Name}} resume ygVIpSJs
+      $ {{.HelpName}} resume ygVIpSJs
 
    3. Clear session.
-      $ mc {{.Name}} clear ygVIpSJs
+      $ {{.HelpName}} clear ygVIpSJs
 
    4. Clear all sessions.
-      $ mc {{.Name}} clear all
+      $ {{.HelpName}} clear all
+
 `,
 }
 

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -41,26 +41,27 @@ var shareDownload = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(shareDownloadFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc share {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc share {{.Name}} [OPTIONS] TARGET [TARGET...]
+   {{.HelpName}} [OPTIONS] TARGET [TARGET...]
 
 OPTIONS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Share this object with 7 days default expiry.
-      $ mc share {{.Name}} s3/backup/2006-Mar-1/backup.tar.gz
+      $ {{.HelpName}} s3/backup/2006-Mar-1/backup.tar.gz
 
    2. Share this object with 10 minutes expiry.
-      $ mc share {{.Name}} --expire=10m s3/backup/2006-Mar-1/backup.tar.gz
+      $ {{.HelpName}} --expire=10m s3/backup/2006-Mar-1/backup.tar.gz
 
    3. Share all objects under this folder with 5 days expiry.
-      $ mc share {{.Name}} --expire=120h s3/backup/
+      $ {{.HelpName}} --expire=120h s3/backup/
 
    4. Share all objects under this folder and all its sub-folders with 5 days expiry.
-      $ mc share {{.Name}} --recursive --expire=120h s3/backup/
+      $ {{.HelpName}} --recursive --expire=120h s3/backup/
+
 `,
 }
 

--- a/cmd/share-list-main.go
+++ b/cmd/share-list-main.go
@@ -36,20 +36,21 @@ var shareList = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(shareListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc share {{.Name}} COMMAND - {{.Usage}}
+   {{.HelpName}} COMMAND - {{.Usage}}
 
 COMMAND:
    upload:   list previously shared access to uploads.
    download: list previously shared access to downloads.
 
 USAGE:
-   mc share {{.Name}}
+   {{.HelpName}}
 
 EXAMPLES:
    1. List previously shared downloads, that haven't expired yet.
-       $ mc share {{.Name}} download
+       $ {{.HelpName}} download
    2. List previously shared uploads, that haven't expired yet.
-       $ mc share {{.Name}} upload
+       $ {{.HelpName}} upload
+
 `,
 }
 

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -42,10 +42,10 @@ var shareCmd = cli.Command{
 		shareList,
 	},
 	CustomHelpTemplate: `NAME:
-   {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   {{.Name}} [FLAGS] COMMAND
+   {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -44,26 +44,27 @@ var shareUpload = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(shareUploadFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc share {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc share {{.Name}} [OPTIONS] TARGET [TARGET...]
+   {{.HelpName}} [OPTIONS] TARGET [TARGET...]
 
 OPTIONS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Generate a curl command to allow upload access for a single object. Command expires in 7 days (default).
-      $ mc share {{.Name}} s3/backup/2006-Mar-1/backup.tar.gz
+      $ {{.HelpName}} s3/backup/2006-Mar-1/backup.tar.gz
 
    2. Generate a curl command to allow upload access to a folder. Command expires in 120 hours.
-      $ mc share {{.Name}} --expire=120h s3/backup/2007-Mar-2/
+      $ {{.HelpName}} --expire=120h s3/backup/2007-Mar-2/
 
    3. Generate a curl command to allow upload access of only '.png' images to a folder. Command expires in 2 hours.
-      $ mc share {{.Name}} --expire=2h --content-type=image/png s3/backup/2007-Mar-2/
+      $ {{.HelpName}} --expire=2h --content-type=image/png s3/backup/2007-Mar-2/
 
    4. Generate a curl command to allow upload access to any objects matching the key prefix 'backup/'. Command expires in 2 hours.
-      $ mc share {{.Name}} --recursive --expire=2h s3/backup/2007-Mar-2/backup/
+      $ {{.HelpName}} --recursive --expire=2h s3/backup/2007-Mar-2/backup/
+
 `,
 }
 

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -49,20 +49,21 @@ var updateCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(updateFlags, globalFlags...),
 	CustomHelpTemplate: `Name:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS]
+   {{.HelpName}} [FLAGS]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Check for any new official release.
-      $ mc {{.Name}}
+      $ {{.HelpName}}
 
    2. Check for any new experimental release.
-      $ mc {{.Name}} --experimental
+      $ {{.HelpName}} --experimental
+
 `,
 }
 

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -38,10 +38,10 @@ var versionCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(versionFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS]
+   {{.HelpName}} [FLAGS]
 
 FLAGS:
   {{range .Flags}}{{.}}

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -61,29 +61,30 @@ var watchCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  append(watchFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS]
+   {{.HelpName}} [FLAGS]
 
 FLAGS:
   {{range .Flags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Watch new S3 operations on a minio server
-      $ mc {{.Name}} play/testbucket
+      $ {{.HelpName}} play/testbucket
 
    2. Watch new events for a specific prefix "output/"  on minio server.
-      $ mc {{.Name}} play/testbucket --prefix "output/"
+      $ {{.HelpName}} play/testbucket --prefix "output/"
 
    3. Watch new events for a specific suffix ".jpg" on minio server.
-      $ mc {{.Name}} play/testbucket --suffix ".jpg"
+      $ {{.HelpName}} play/testbucket --suffix ".jpg"
 
    4. Watch new events on a specific prefix and suffix on minio server.
-      $ mc {{.Name}} play/testbucket --suffix ".jpg" --prefix "photos/"
+      $ {{.HelpName}} play/testbucket --suffix ".jpg" --prefix "photos/"
 
    5. Watch for events on local directory.
-      $ mc {{.Name}} /usr/share
+      $ {{.HelpName}} /usr/share
+
 `,
 }
 


### PR DESCRIPTION
It is easier to use {{.HelpName}} in help text template to print
the mc binary name plus the whole command hierarchy (binary name +
command + subcommand, etc..)

Fixes #2011 