### PR TITLE
Avoid printing hidden flags and commands with custom help.

### DIFF
--- a/cmd/admin-heal-list.go
+++ b/cmd/admin-heal-list.go
@@ -51,7 +51,7 @@ USAGE:
    {{.HelpName}} ALIAS/BUCKET/PREFIX
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
     1. List objects than need to be healed related to 'testbucket' in a Minio server represented by its alias 'play'.

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -58,11 +58,11 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 EXAMPLES:
     1. Heal 'testbucket' in a Minio server represented by its alias 'play'.

--- a/cmd/admin-lock-clear.go
+++ b/cmd/admin-lock-clear.go
@@ -50,7 +50,7 @@ USAGE:
    {{.HelpName}} ALIAS/BUCKET/PREFIX
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Clear all locks hold by 'testbucket' in a Minio server represented by its alias 'play'.

--- a/cmd/admin-lock-list.go
+++ b/cmd/admin-lock-list.go
@@ -50,7 +50,7 @@ USAGE:
    {{.HelpName}} ALIAS/BUCKET/PREFIX
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
     1. List hold locks related to testbucket in a Minio server represented by its alias 'play'.

--- a/cmd/admin-lock.go
+++ b/cmd/admin-lock.go
@@ -39,10 +39,10 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 `,
 }

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -41,10 +41,10 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 `,
 }

--- a/cmd/admin-password.go
+++ b/cmd/admin-password.go
@@ -37,7 +37,7 @@ USAGE:
    {{.HelpName}} ALIAS ACCESS_KEY SECRET_KEY
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Set new credentials of a Minio server represented by its alias 'play'.

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -38,7 +38,7 @@ USAGE:
    {{.HelpName}} ALIAS
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Restart a Minio server represented by its alias 'play'.

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -46,7 +46,7 @@ USAGE:
    {{.HelpName}} ALIAS
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
     1. Get storage information of a Minio server represented by its alias 'play'.

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -35,10 +35,10 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 `,
 }

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -46,7 +46,7 @@ USAGE:
    {{.HelpName}} [FLAGS] SOURCE [SOURCE...]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Stream an object from Amazon S3 cloud storage to mplayer standard input.

--- a/cmd/config-host-main.go
+++ b/cmd/config-host-main.go
@@ -50,7 +50,7 @@ OPERATION:
    list
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Add Amazon S3 storage service under "myphotos" alias. For security reasons turn off bash history momentarily.

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -49,10 +49,10 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 `,
 }

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -58,7 +58,7 @@ USAGE:
    {{.HelpName}} [FLAGS] SOURCE [SOURCE...] TARGET
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Copy a list of objects from local file system to Amazon S3 cloud storage.

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -47,7 +47,7 @@ USAGE:
    mc {{.Name}} [FLAGS] FIRST SECOND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 DESCRIPTION:
    {{.Description}}

--- a/cmd/events-add.go
+++ b/cmd/events-add.go
@@ -57,7 +57,7 @@ USAGE:
    {{.HelpName}} ALIAS/BUCKET ARN [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Enable bucket notification with a specific arn

--- a/cmd/events-list.go
+++ b/cmd/events-list.go
@@ -43,7 +43,7 @@ USAGE:
    {{.HelpName}} ALIAS/BUCKET ARN [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. List notification configurations associated to a specific arn

--- a/cmd/events-main.go
+++ b/cmd/events-main.go
@@ -40,10 +40,10 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 `,
 }

--- a/cmd/events-remove.go
+++ b/cmd/events-remove.go
@@ -48,7 +48,7 @@ USAGE:
    {{.HelpName}} ALIAS/BUCKET [ARN] [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Remove bucket notification associated to a specific arn

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -52,7 +52,7 @@ USAGE:
    {{.HelpName}} [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. List buckets on Amazon S3 cloud storage.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,13 +43,13 @@ var mcHelpTemplate = `NAME:
   {{.Name}} - {{.Usage}}
 
 USAGE:
-  {{.Name}} {{if .Flags}}[FLAGS] {{end}}COMMAND{{if .Flags}} [COMMAND FLAGS | -h]{{end}} [ARGUMENTS...]
+  {{.Name}} {{if .VisibleFlags}}[FLAGS] {{end}}COMMAND{{if .VisibleFlags}} [COMMAND FLAGS | -h]{{end}} [ARGUMENTS...]
 
 COMMANDS:
-  {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
-  {{end}}{{if .Flags}}
+  {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+  {{end}}{{if .VisibleFlags}}
 GLOBAL FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 VERSION:
   ` + Version +

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -49,7 +49,7 @@ USAGE:
    {{.HelpName}} [FLAGS] TARGET [TARGET...]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Create a bucket on Amazon S3 cloud storage.

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -78,7 +78,7 @@ USAGE:
    {{.HelpName}} [FLAGS] SOURCE TARGET
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Mirror a bucket recursively from Minio cloud storage to a bucket on Amazon S3 cloud storage.

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -42,7 +42,7 @@ USAGE:
    {{.HelpName}} [FLAGS] [TARGET]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Write contents of stdin to a file on local filesystem.

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -54,7 +54,7 @@ PERMISSION:
    Allowed policies are: [none, download, upload, public].
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Set bucket to "download" on Amazon S3 cloud storage.

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -76,7 +76,7 @@ USAGE:
   {{.HelpName}} [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Remove a file.

--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -56,7 +56,7 @@ SESSION-ID:
    SESSION - Session can either be $SESSION-ID or "all".
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. List sessions.

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -47,7 +47,7 @@ USAGE:
    {{.HelpName}} [OPTIONS] TARGET [TARGET...]
 
 OPTIONS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Share this object with 7 days default expiry.

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -48,10 +48,10 @@ USAGE:
    {{.HelpName}} [FLAGS] COMMAND
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 COMMANDS:
-   {{range .Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{range .VisibleCommands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
    {{end}}
 `,
 }

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -50,7 +50,7 @@ USAGE:
    {{.HelpName}} [OPTIONS] TARGET [TARGET...]
 
 OPTIONS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Generate a curl command to allow upload access for a single object. Command expires in 7 days (default).

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -55,7 +55,7 @@ USAGE:
    {{.HelpName}} [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Check for any new official release.

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -44,7 +44,7 @@ USAGE:
    {{.HelpName}} [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 `,
 }

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -67,7 +67,7 @@ USAGE:
    {{.HelpName}} [FLAGS]
 
 FLAGS:
-  {{range .Flags}}{{.}}
+  {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
    1. Watch new S3 operations on a minio server


### PR DESCRIPTION
Always use .VisibleFlags and .VisibleCommands in templates
to avoid printing hidden flags and commands in the help
template.