### PR TITLE
Rename mc to minioc

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,8 +4,8 @@
 
 ## Steps to reproduce the behaviour
 
-## mc version
-- (paste output of `mc version`)
+## minioc version
+- (paste output of `minioc version`)
 
 ## System information
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 cover.out
-./mc
+./minioc
 *~
 *.test
 release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
-### Setup your mc Github Repository
-Fork [mc upstream](https://github.com/minio/mc/fork) source repository to your own personal repository.
+### Setup your minioc Github Repository
+Fork [minioc upstream](https://github.com/minio/minioc/fork) source repository to your own personal repository.
 ```sh
 $ mkdir -p $GOPATH/src/github.com/minio
 $ cd $GOPATH/src/github.com/minio
-$ git clone https://github.com/$USER_ID/mc
-$ cd mc
+$ git clone https://github.com/$USER_ID/minioc
+$ cd minioc
 $ make
-$ mc --help
+$ minioc --help
 ```
 
 ###  Developer Guidelines
 
-``mc`` welcomes your contribution. To make the process as seamless as possible, we ask for the following:
+``minioc`` welcomes your contribution. To make the process as seamless as possible, we ask for the following:
 
 * Go ahead and fork the project and make your changes. We encourage pull requests to discuss code changes.
     - Fork it
@@ -20,12 +20,12 @@ $ mc --help
     - Push to the branch (git push origin my-new-feature)
     - Create new Pull Request
 
-* If you have additional dependencies for ``mc``, ``mc`` manages its dependencies using [govendor](https://github.com/kardianos/govendor)
+* If you have additional dependencies for ``minioc``, ``minioc`` manages its dependencies using [govendor](https://github.com/kardianos/govendor)
     - Run `go get foo/bar`
     - Edit your code to import foo/bar
     - Run `make pkg-add PKG=foo/bar` from top-level folder
 
-* If you have dependencies which needs to be removed from ``mc``
+* If you have dependencies which needs to be removed from ``minioc``
     - Edit your code to not import foo/bar
     - Run `make pkg-remove PKG=foo/bar` from top-level folder
 
@@ -36,5 +36,5 @@ $ mc --help
     - Make sure `make build` completes.
 
 * Read [Effective Go](https://github.com/golang/go/wiki/CodeReviewComments) article from Golang project
-    - `mc` project is conformant with Golang style
+    - `minioc` project is conformant with Golang style
     - if you happen to observe offending code, please feel free to send a pull request

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN \
 	rm -rf /go/pkg /go/src && \
 	apk del git
 
-ENTRYPOINT ["mc"]
+ENTRYPOINT ["minioc"]

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ fmt:
 lint:
 	@echo "Running $@:"
 	@$(GOPATH)/bin/golint .
-	@$(GOPATH)/bin/golint github.com/minio/mc/cmd...
-	@$(GOPATH)/bin/golint github.com/minio/mc/pkg...
+	@$(GOPATH)/bin/golint github.com/minio/minioc/cmd...
+	@$(GOPATH)/bin/golint github.com/minio/minioc/pkg...
 
 cyclo:
 	@echo "Running $@:"
@@ -54,13 +54,13 @@ build: getdeps verifiers
 
 test: getdeps verifiers
 	@echo "Running all testing:"
-	@go test $(GOFLAGS) github.com/minio/mc/cmd...
-	@go test $(GOFLAGS) github.com/minio/mc/pkg...
+	@go test $(GOFLAGS) github.com/minio/minioc/cmd...
+	@go test $(GOFLAGS) github.com/minio/minioc/pkg...
 
 gomake-all: build
-	@echo "Installing mc:"
-	@go build --ldflags "$(LDFLAGS)" -o $(GOPATH)/bin/mc
-	@mkdir -p $(HOME)/.mc
+	@echo "Installing minioc:"
+	@go build --ldflags "$(LDFLAGS)" -o $(GOPATH)/bin/minioc
+	@mkdir -p $(HOME)/.minioc
 
 coverage: getdeps verifiers
 	@echo "Running all coverage:"
@@ -90,13 +90,13 @@ all-tests: test
 	#@./tests/test-minio.sh
 
 release: verifiers
-	@MC_RELEASE=RELEASE ./buildscripts/build.sh
+	@MINIOC_RELEASE=RELEASE ./buildscripts/build.sh
 
 experimental: verifiers
-	@MC_RELEASE=EXPERIMENTAL ./buildscripts/build.sh
+	@MINIOC_RELEASE=EXPERIMENTAL ./buildscripts/build.sh
 
 clean:
 	@rm -f cover.out
-	@rm -f mc
+	@rm -f minioc
 	@find . -name '*.test' | xargs rm -fv
 	@rm -fr release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minio Client Quickstart Guide [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 
-Minio Client (mc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
+Minio Client (minioc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
 
 ```
 
@@ -26,23 +26,23 @@ version       Print version.
 ## Docker Container
 ### Stable
 ```
-docker pull minio/mc
-docker run minio/mc ls play
+docker pull minio/minioc
+docker run minio/minioc ls play
 ```
 
 ### Edge
 ```
-docker pull minio/mc:edge
-docker run minio/mc ls play
+docker pull minio/minioc:edge
+docker run minio/minioc ls play
 ```
 
 ## macOS
 ### Homebrew
-Install mc packages using [Homebrew](http://brew.sh/)
+Install minioc packages using [Homebrew](http://brew.sh/)
 
 ```sh
-brew install minio-mc
-mc --help
+brew install minio-minioc
+minioc --help
 
 ```
 
@@ -50,14 +50,14 @@ mc --help
 ### Binary Download
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc|
-||32-bit Intel|https://dl.minio.io/client/mc/release/linux-386/mc|
-||32-bit ARM|https://dl.minio.io/client/mc/release/linux-arm/mc|
+|GNU/Linux|64-bit Intel|https://dl.minio.io/client/minioc/release/linux-amd64/minioc|
+||32-bit Intel|https://dl.minio.io/client/minioc/release/linux-386/minioc|
+||32-bit ARM|https://dl.minio.io/client/minioc/release/linux-arm/minioc|
 
 ```sh
 
-chmod +x mc
-./mc --help
+chmod +x minioc
+./minioc --help
 
 ```
 
@@ -65,12 +65,12 @@ chmod +x mc
 ### Binary Download
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|Microsoft Windows|64-bit|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe|
-||32-bit|https://dl.minio.io/client/mc/release/windows-386/mc.exe |
+|Microsoft Windows|64-bit|https://dl.minio.io/client/minioc/release/windows-amd64/minioc.exe|
+||32-bit|https://dl.minio.io/client/minioc/release/windows-386/minioc.exe |
 
 ```sh
 
-mc.exe --help
+minioc.exe --help
 
 ```
 
@@ -78,12 +78,12 @@ mc.exe --help
 ### Binary Download
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|FreeBSD|64-bit|https://dl.minio.io/client/mc/release/freebsd-amd64/mc|
+|FreeBSD|64-bit|https://dl.minio.io/client/minioc/release/freebsd-amd64/minioc|
 
 ```sh
 
-chmod 755 mc
-./mc --help
+chmod 755 minioc
+./minioc --help
 
 ```
 
@@ -92,30 +92,30 @@ chmod 755 mc
 
 ```sh
 
-go get -u github.com/minio/mc
-mc --help
+go get -u github.com/minio/minioc
+minioc --help
 
 ```
 
 ## Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://minio.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `minioc update` command does not support update notifications for source based installations. Please download official releases from https://minio.io/downloads/#minio-client.
 
 If you do not have a working Golang environment, please follow [How to install Golang](https://docs.minio.io/docs/how-to-install-golang).
 
 ```sh
 
-go get -u github.com/minio/mc
+go get -u github.com/minio/minioc
 
 ```
 
 ## Add a Cloud Storage Service
-If you are planning to use `mc` only on POSIX compatible filesystems, you may skip this step and proceed to [everyday use](#everyday-use).
+If you are planning to use `minioc` only on POSIX compatible filesystems, you may skip this step and proceed to [everyday use](#everyday-use).
 
-To add one or more Amazon S3 compatible hosts, please follow the instructions below. `mc` stores all its configuration information in ``~/.mc/config.json`` file.
+To add one or more Amazon S3 compatible hosts, please follow the instructions below. `minioc` stores all its configuration information in ``~/.minioc/config.json`` file.
 
 ```sh
 
-mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY> <API-SIGNATURE>
+minioc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY> <API-SIGNATURE>
 
 ```
 
@@ -126,7 +126,7 @@ Minio server displays URL, access and secret keys.
 
 ```sh
 
-mc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
+minioc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
 
 ```
 
@@ -135,7 +135,7 @@ Get your AccessKeyID and SecretAccessKey by following [AWS Credentials Guide](ht
 
 ```sh
 
-mc config host add s3 https://s3.amazonaws.com BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
+minioc config host add s3 https://s3.amazonaws.com BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
 
 ```
 
@@ -144,14 +144,14 @@ Get your AccessKeyID and SecretAccessKey by following [Google Credentials Guide]
 
 ```sh
 
-mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2
+minioc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2
 
 ```
 
 NOTE: Google Cloud Storage only supports Legacy Signature Version 2, so you have to pick - S3v2
 
 ## Test Your Setup
-`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`minioc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
@@ -159,7 +159,7 @@ List all buckets from https://play.minio.io:9000
 
 ```sh
 
-mc ls play
+minioc ls play
 [2016-03-22 19:47:48 PDT]     0B my-bucketname/
 [2016-03-22 22:01:07 PDT]     0B mytestbucket/
 [2016-03-22 20:04:39 PDT]     0B mybucketname/
@@ -173,11 +173,11 @@ You may add shell aliases to override your common Unix tools.
 
 ```sh
 
-alias ls='mc ls'
-alias cp='mc cp'
-alias cat='mc cat'
-alias mkdir='mc mb'
-alias pipe='mc pipe'
+alias ls='minioc ls'
+alias cp='minioc cp'
+alias cat='minioc cat'
+alias mkdir='minioc mb'
+alias pipe='minioc pipe'
 
 ```
 
@@ -187,5 +187,5 @@ alias pipe='mc pipe'
 - [The Minio documentation website](https://docs.minio.io)
 
 ## Contribute to Minio Project
-Please follow Minio [Contributor's Guide](https://github.com/minio/mc/blob/master/CONTRIBUTING.md)
+Please follow Minio [Contributor's Guide](https://github.com/minio/minioc/blob/master/CONTRIBUTING.md)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: "{build}"
 # Operating system (build VM template)
 os: Windows Server 2012 R2
 
-clone_folder: c:\gopath\src\github.com\minio\mc
+clone_folder: c:\gopath\src\github.com\minio\minioc
 
 # environment variables
 environment:
@@ -18,13 +18,13 @@ install:
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
-  - go test -race github.com/minio/mc/cmd...
-  - go test -race github.com/minio/mc/pkg...
+  - go test -race github.com/minio/minioc/cmd...
+  - go test -race github.com/minio/minioc/pkg...
   - go test -coverprofile=coverage.txt -covermode=atomic
   - go run buildscripts/gen-ldflags.go > temp.txt
   - set /p BUILD_LDFLAGS=<temp.txt
-  - go build -ldflags="%BUILD_LDFLAGS%" -o %GOPATH%\bin\mc.exe
-  - mc version
+  - go build -ldflags="%BUILD_LDFLAGS%" -o %GOPATH%\bin\minioc.exe
+  - minioc version
 
 after_test:
   - bash <(curl -s https://codecov.io/bash)

--- a/buildscripts/checkgopath.sh
+++ b/buildscripts/checkgopath.sh
@@ -26,13 +26,13 @@ _init() {
 
 main() {
     echo "Checking if project is at ${GOPATH}"
-    for mc in $(echo ${GOPATH} | tr ':' ' '); do
-        if [ ! -d ${mc}/src/github.com/minio/mc ]; then
-            echo "Project not found in ${mc}, please follow instructions provided at https://github.com/minio/mc/blob/master/CONTRIBUTING.md#setup-your-mc-github-repository" \
+    for minioc in $(echo ${GOPATH} | tr ':' ' '); do
+        if [ ! -d ${minioc}/src/github.com/minio/minioc ]; then
+            echo "Project not found in ${minioc}, please follow instructions provided at https://github.com/minio/minioc/blob/master/CONTRIBUTING.md#setup-your-minioc-github-repository" \
                 && exit 1
         fi
-        if [ "x${mc}/src/github.com/minio/mc" != "x${PWD}" ]; then
-            echo "Build outside of ${mc}, two source checkouts found. Exiting." && exit 1
+        if [ "x${minioc}/src/github.com/minio/minioc" != "x${PWD}" ]; then
+            echo "Build outside of ${minioc}, two source checkouts found. Exiting." && exit 1
         fi
     done
 }

--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -1,7 +1,7 @@
 // +build ignore
 
 /*
- * Mc Client (C) 2014, 2015, 2016 Minio, Inc.
+ * Minioc Client (C) 2014, 2015, 2016 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,17 +28,17 @@ import (
 
 func genLDFlags(version string) string {
 	var ldflagsStr string
-	ldflagsStr = "-X github.com/minio/mc/cmd.Version=" + version + " "
-	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.ReleaseTag=" + releaseTag(version) + " "
-	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.CommitID=" + commitID() + " "
-	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.ShortCommitID=" + commitID()[:12]
+	ldflagsStr = "-X github.com/minio/minioc/cmd.Version=" + version + " "
+	ldflagsStr = ldflagsStr + "-X github.com/minio/minioc/cmd.ReleaseTag=" + releaseTag(version) + " "
+	ldflagsStr = ldflagsStr + "-X github.com/minio/minioc/cmd.CommitID=" + commitID() + " "
+	ldflagsStr = ldflagsStr + "-X github.com/minio/minioc/cmd.ShortCommitID=" + commitID()[:12]
 	return ldflagsStr
 }
 
 // genReleaseTag prints release tag to the console for easy git tagging.
 func releaseTag(version string) string {
 	relPrefix := "DEVELOPMENT"
-	if prefix := os.Getenv("MC_RELEASE"); prefix != "" {
+	if prefix := os.Getenv("MINIOC_RELEASE"); prefix != "" {
 		relPrefix = prefix
 	}
 

--- a/cmd/admin-heal-list.go
+++ b/cmd/admin-heal-list.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -68,7 +68,7 @@ EXAMPLES:
     1. Heal 'testbucket' in a Minio server represented by its alias 'play'.
        $ {{.HelpName}} play/testbucket/
 
-    2. Heal all objects under 'dir' prefix 
+    2. Heal all objects under 'dir' prefix
        $ {{.HelpName}} --recursive play/testbucket/dir/
 
     3. Issue a fake heal operation to see what the server could report

--- a/cmd/admin-lock.go
+++ b/cmd/admin-lock.go
@@ -47,7 +47,7 @@ COMMANDS:
 `,
 }
 
-// mainAdminLock is the handle for "mc admin lock" command.
+// mainAdminLock is the handle for "minioc admin lock" command.
 func mainAdminLock(ctx *cli.Context) error {
 
 	if ctx.Args().First() != "" { // command help.

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -49,7 +49,7 @@ COMMANDS:
 `,
 }
 
-// mainAdmin is the handle for "mc admin" command.
+// mainAdmin is the handle for "minioc admin" command.
 func mainAdmin(ctx *cli.Context) error {
 
 	if ctx.Args().First() != "" { // command help.

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var adminServiceRestartCmd = cli.Command{

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -24,9 +24,9 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -43,7 +43,7 @@ COMMANDS:
 `,
 }
 
-// mainAdmin is the handle for "mc admin service" command.
+// mainAdmin is the handle for "minioc admin service" command.
 func mainAdminService(ctx *cli.Context) error {
 
 	if ctx.Args().First() != "" { // command help.

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -27,11 +27,11 @@ import (
 
 // getCertsDir - return the full path of certs dir
 func getCertsDir() (string, *probe.Error) {
-	p, err := getMcConfigDir()
+	p, err := getMiniocConfigDir()
 	if err != nil {
 		return "", err.Trace()
 	}
-	return filepath.Join(p, globalMCCertsDir), nil
+	return filepath.Join(p, globalMINIOCCertsDir), nil
 }
 
 // mustGetCertsDir - return the full path of certs dir or empty string when an error occurs
@@ -71,7 +71,7 @@ func getCAsDir() (string, *probe.Error) {
 	if err != nil {
 		return "", err.Trace()
 	}
-	return filepath.Join(p, globalMCCAsDir), nil
+	return filepath.Join(p, globalMINIOCCAsDir), nil
 }
 
 // mustGetCAsDir - return the full path of CAs dir or empty string when an error occurs

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -25,9 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/minio/mc/pkg/httptracer"
 	"github.com/minio/minio/pkg/madmin"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/httptracer"
 )
 
 // newAdminFactory encloses New function with client cache.
@@ -109,7 +109,7 @@ func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 }
 
 // newAdminClientFromAlias gives a new admin client interface for matching
-// alias entry in the mc config file. If no matching host config entry
+// alias entry in the minioc config file. If no matching host config entry
 // is found, fs client is returned.
 func newAdminClientFromAlias(alias string, urlStr string) (*madmin.AdminClient, *probe.Error) {
 	s3Config, err := buildS3Config(alias, urlStr)

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -28,9 +28,9 @@ import (
 
 	"io/ioutil"
 
-	"github.com/minio/mc/pkg/hookreader"
-	"github.com/minio/mc/pkg/ioutils"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/hookreader"
+	"github.com/minio/minioc/pkg/ioutils"
 	"github.com/rjeczalik/notify"
 )
 
@@ -218,7 +218,7 @@ func (f *fsClient) put(reader io.Reader, size int64, metadata map[string][]strin
 		}
 	}
 
-	// Write to a temporary file "object.part.mc" before commit.
+	// Write to a temporary file "object.part.minioc" before commit.
 	objectPartPath := objectPath + partSuffix
 	if objectDir != "" {
 		// Create any missing top level directories.

--- a/cmd/client-s3-trace_v2.go
+++ b/cmd/client-s3-trace_v2.go
@@ -22,8 +22,8 @@ import (
 	"net/http/httputil"
 	"strings"
 
-	"github.com/minio/mc/pkg/console"
-	"github.com/minio/mc/pkg/httptracer"
+	"github.com/minio/minioc/pkg/console"
+	"github.com/minio/minioc/pkg/httptracer"
 )
 
 // traceV2 - tracing structure for signature version '2'.

--- a/cmd/client-s3-trace_v4.go
+++ b/cmd/client-s3-trace_v4.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/minio/mc/pkg/console"
-	"github.com/minio/mc/pkg/httptracer"
+	"github.com/minio/minioc/pkg/console"
+	"github.com/minio/minioc/pkg/httptracer"
 )
 
 // traceV4 - tracing structure for signature version '4'.

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -33,11 +33,11 @@ import (
 
 	"io/ioutil"
 
-	"github.com/minio/mc/pkg/httptracer"
 	"github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/policy"
 	"github.com/minio/minio-go/pkg/s3utils"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/httptracer"
 )
 
 // S3 client

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -143,7 +143,7 @@ func uploadSourceToTargetURL(urls URLs, progress io.Reader) URLs {
 }
 
 // newClientFromAlias gives a new client interface for matching
-// alias entry in the mc config file. If no matching host config entry
+// alias entry in the minioc config file. If no matching host config entry
 // is found, fs client is returned.
 func newClientFromAlias(alias string, urlStr string) (Client, *probe.Error) {
 	s3Config, err := buildS3Config(alias, urlStr)

--- a/cmd/config-host-main.go
+++ b/cmd/config-host-main.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -233,14 +233,14 @@ func mainConfigHost(ctx *cli.Context) error {
 
 // addHost - add a host config.
 func addHost(alias string, hostCfgV8 hostConfigV8) {
-	mcCfgV8, err := loadMcConfig()
-	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config ‘"+mustGetMcConfigPath()+"’.")
+	miniocCfgV8, err := loadMiniocConfig()
+	fatalIf(err.Trace(globalMINIOCConfigVersion), "Unable to load config ‘"+mustGetMiniocConfigPath()+"’.")
 
 	// Add new host.
-	mcCfgV8.Hosts[alias] = hostCfgV8
+	miniocCfgV8.Hosts[alias] = hostCfgV8
 
-	err = saveMcConfig(mcCfgV8)
-	fatalIf(err.Trace(alias), "Unable to update hosts in config version ‘"+mustGetMcConfigPath()+"’.")
+	err = saveMiniocConfig(miniocCfgV8)
+	fatalIf(err.Trace(alias), "Unable to update hosts in config version ‘"+mustGetMiniocConfigPath()+"’.")
 
 	printMsg(hostMessage{
 		op:        "add",
@@ -254,14 +254,14 @@ func addHost(alias string, hostCfgV8 hostConfigV8) {
 
 // removeHost - removes a host.
 func removeHost(alias string) {
-	conf, err := loadMcConfig()
-	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config version ‘"+globalMCConfigVersion+"’.")
+	conf, err := loadMiniocConfig()
+	fatalIf(err.Trace(globalMINIOCConfigVersion), "Unable to load config version ‘"+globalMINIOCConfigVersion+"’.")
 
 	// Remove host.
 	delete(conf.Hosts, alias)
 
-	err = saveMcConfig(conf)
-	fatalIf(err.Trace(alias), "Unable to save deleted hosts in config version ‘"+globalMCConfigVersion+"’.")
+	err = saveMiniocConfig(conf)
+	fatalIf(err.Trace(alias), "Unable to save deleted hosts in config version ‘"+globalMINIOCConfigVersion+"’.")
 
 	printMsg(hostMessage{op: "remove", Alias: alias})
 }
@@ -275,8 +275,8 @@ func (d byAlias) Less(i, j int) bool { return d[i].Alias < d[j].Alias }
 
 // listHosts - list all host URLs.
 func listHosts() {
-	conf, err := loadMcConfig()
-	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config version ‘"+globalMCConfigVersion+"’.")
+	conf, err := loadMiniocConfig()
+	fatalIf(err.Trace(globalMINIOCConfigVersion), "Unable to load config version ‘"+globalMINIOCConfigVersion+"’.")
 
 	var maxAlias = 0
 	for k := range conf.Hosts {

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -35,7 +35,7 @@ var (
 
 var configCmd = cli.Command{
 	Name:   "config",
-	Usage:  "Manage mc configuration file.",
+	Usage:  "Manage minioc configuration file.",
 	Action: mainConfig,
 	Before: setGlobalsFromContext,
 	Flags:  append(configFlags, globalFlags...),
@@ -57,7 +57,7 @@ COMMANDS:
 `,
 }
 
-// mainConfig is the handle for "mc config" command. provides sub-commands which write configuration data in json format to config file.
+// mainConfig is the handle for "minioc config" command. provides sub-commands which write configuration data in json format to config file.
 func mainConfig(ctx *cli.Context) error {
 
 	if ctx.Args().First() != "" { // command help.

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
 	"github.com/minio/minio/pkg/quick"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // migrate config files from the any older version to the latest.
@@ -47,14 +47,14 @@ func migrateConfig() {
 
 // Migrate from config version 1.0 to 1.0.1. Populate example entries and save it back.
 func migrateConfigV1ToV101() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
-	mcCfgV1, e := quick.Load(mustGetMcConfigPath(), newConfigV1())
+	miniocCfgV1, e := quick.Load(mustGetMiniocConfigPath(), newConfigV1())
 	fatalIf(probe.NewError(e), "Unable to load config version ‘1’.")
 
 	// If loaded config version does not match 1.0.0, we do nothing.
-	if mcCfgV1.Version() != "1.0.0" {
+	if miniocCfgV1.Version() != "1.0.0" {
 		return
 	}
 
@@ -62,12 +62,12 @@ func migrateConfigV1ToV101() {
 	cfgV101 := newConfigV101()
 
 	// Copy aliases.
-	for k, v := range mcCfgV1.Data().(*configV1).Aliases {
+	for k, v := range miniocCfgV1.Data().(*configV1).Aliases {
 		cfgV101.Aliases[k] = v
 	}
 
 	// Copy hosts.
-	for k, hostCfgV1 := range mcCfgV1.Data().(*configV1).Hosts {
+	for k, hostCfgV1 := range miniocCfgV1.Data().(*configV1).Hosts {
 		cfgV101.Hosts[k] = hostConfigV101{
 			AccessKeyID:     hostCfgV1.AccessKeyID,
 			SecretAccessKey: hostCfgV1.SecretAccessKey,
@@ -94,75 +94,75 @@ func migrateConfigV1ToV101() {
 	}
 
 	// Save the new config back to the disk.
-	mcCfgV101, e := quick.New(cfgV101)
+	miniocCfgV101, e := quick.New(cfgV101)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘1.0.1’.")
-	e = mcCfgV101.Save(mustGetMcConfigPath())
+	e = miniocCfgV101.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘1.0.1’.")
 
-	console.Infof("Successfully migrated %s from version ‘1.0.0’ to version ‘1.0.1’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘1.0.0’ to version ‘1.0.1’.\n", mustGetMiniocConfigPath())
 }
 
 // Migrate from config ‘1.0.1’ to ‘2’. Drop semantic versioning and move to integer versioning. No other changes.
 func migrateConfigV101ToV2() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
-	mcCfgV101, e := quick.Load(mustGetMcConfigPath(), newConfigV101())
+	miniocCfgV101, e := quick.Load(mustGetMiniocConfigPath(), newConfigV101())
 	fatalIf(probe.NewError(e), "Unable to load config version ‘1.0.1’.")
 
 	// update to newer version
-	if mcCfgV101.Version() != "1.0.1" {
+	if miniocCfgV101.Version() != "1.0.1" {
 		return
 	}
 
 	cfgV2 := newConfigV2()
 
 	// Copy aliases.
-	for k, v := range mcCfgV101.Data().(*configV101).Aliases {
+	for k, v := range miniocCfgV101.Data().(*configV101).Aliases {
 		cfgV2.Aliases[k] = v
 	}
 
 	// Copy hosts.
-	for k, hostCfgV101 := range mcCfgV101.Data().(*configV101).Hosts {
+	for k, hostCfgV101 := range miniocCfgV101.Data().(*configV101).Hosts {
 		cfgV2.Hosts[k] = hostConfigV2{
 			AccessKeyID:     hostCfgV101.AccessKeyID,
 			SecretAccessKey: hostCfgV101.SecretAccessKey,
 		}
 	}
 
-	mcCfgV2, e := quick.New(cfgV2)
+	miniocCfgV2, e := quick.New(cfgV2)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘2’.")
 
-	e = mcCfgV2.Save(mustGetMcConfigPath())
+	e = miniocCfgV2.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘2’.")
 
-	console.Infof("Successfully migrated %s from version ‘1.0.1’ to version ‘2’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘1.0.1’ to version ‘2’.\n", mustGetMiniocConfigPath())
 }
 
 // Migrate from config ‘2’ to ‘3’. Use ‘-’ separated names for
 // hostConfig using struct json tags.
 func migrateConfigV2ToV3() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
 
-	mcCfgV2, e := quick.Load(mustGetMcConfigPath(), newConfigV2())
-	fatalIf(probe.NewError(e), "Unable to load mc config V2.")
+	miniocCfgV2, e := quick.Load(mustGetMiniocConfigPath(), newConfigV2())
+	fatalIf(probe.NewError(e), "Unable to load minioc config V2.")
 
 	// update to newer version
-	if mcCfgV2.Version() != "2" {
+	if miniocCfgV2.Version() != "2" {
 		return
 	}
 
 	cfgV3 := newConfigV3()
 
 	// Copy aliases.
-	for k, v := range mcCfgV2.Data().(*configV2).Aliases {
+	for k, v := range miniocCfgV2.Data().(*configV2).Aliases {
 		cfgV3.Aliases[k] = v
 	}
 
 	// Copy hosts.
-	for k, hostCfgV2 := range mcCfgV2.Data().(*configV2).Hosts {
+	for k, hostCfgV2 := range miniocCfgV2.Data().(*configV2).Hosts {
 		// New hostConfV3 uses struct json tags.
 		cfgV3.Hosts[k] = hostConfigV3{
 			AccessKeyID:     hostCfgV2.AccessKeyID,
@@ -170,38 +170,38 @@ func migrateConfigV2ToV3() {
 		}
 	}
 
-	mcNewCfgV3, e := quick.New(cfgV3)
+	miniocNewCfgV3, e := quick.New(cfgV3)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘3’.")
 
-	e = mcNewCfgV3.Save(mustGetMcConfigPath())
+	e = miniocNewCfgV3.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘3’.")
 
-	console.Infof("Successfully migrated %s from version ‘2’ to version ‘3’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘2’ to version ‘3’.\n", mustGetMiniocConfigPath())
 }
 
 // Migrate from config version ‘3’ to ‘4’. Introduce API Signature
 // field in host config. Also Use JavaScript notation for field names.
 func migrateConfigV3ToV4() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
-	mcCfgV3, e := quick.Load(mustGetMcConfigPath(), newConfigV3())
-	fatalIf(probe.NewError(e), "Unable to load mc config V2.")
+	miniocCfgV3, e := quick.Load(mustGetMiniocConfigPath(), newConfigV3())
+	fatalIf(probe.NewError(e), "Unable to load minioc config V2.")
 
 	// update to newer version
-	if mcCfgV3.Version() != "3" {
+	if miniocCfgV3.Version() != "3" {
 		return
 	}
 
 	cfgV4 := newConfigV4()
-	for k, v := range mcCfgV3.Data().(*configV3).Aliases {
+	for k, v := range miniocCfgV3.Data().(*configV3).Aliases {
 		cfgV4.Aliases[k] = v
 	}
 	// New hostConfig has API signature. All older entries were V4
 	// only. So it is safe to assume V4 as default for all older
 	// entries.
 	// HostConfigV4 als uses JavaScript naming notation for struct JSON tags.
-	for host, hostCfgV3 := range mcCfgV3.Data().(*configV3).Hosts {
+	for host, hostCfgV3 := range miniocCfgV3.Data().(*configV3).Hosts {
 		cfgV4.Hosts[host] = hostConfigV4{
 			AccessKeyID:     hostCfgV3.AccessKeyID,
 			SecretAccessKey: hostCfgV3.SecretAccessKey,
@@ -209,34 +209,34 @@ func migrateConfigV3ToV4() {
 		}
 	}
 
-	mcNewCfgV4, e := quick.New(cfgV4)
+	miniocNewCfgV4, e := quick.New(cfgV4)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘4’.")
 
-	e = mcNewCfgV4.Save(mustGetMcConfigPath())
+	e = miniocNewCfgV4.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘4’.")
 
-	console.Infof("Successfully migrated %s from version ‘3’ to version ‘4’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘3’ to version ‘4’.\n", mustGetMiniocConfigPath())
 
 }
 
 // Migrate config version ‘4’ to ‘5’. Rename hostConfigV4.Signature  -> hostConfigV5.API.
 func migrateConfigV4ToV5() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
-	mcCfgV4, e := quick.Load(mustGetMcConfigPath(), newConfigV4())
-	fatalIf(probe.NewError(e), "Unable to load mc config V4.")
+	miniocCfgV4, e := quick.Load(mustGetMiniocConfigPath(), newConfigV4())
+	fatalIf(probe.NewError(e), "Unable to load minioc config V4.")
 
 	// update to newer version
-	if mcCfgV4.Version() != "4" {
+	if miniocCfgV4.Version() != "4" {
 		return
 	}
 
 	cfgV5 := newConfigV5()
-	for k, v := range mcCfgV4.Data().(*configV4).Aliases {
+	for k, v := range miniocCfgV4.Data().(*configV4).Aliases {
 		cfgV5.Aliases[k] = v
 	}
-	for host, hostCfgV4 := range mcCfgV4.Data().(*configV4).Hosts {
+	for host, hostCfgV4 := range miniocCfgV4.Data().(*configV4).Hosts {
 		cfgV5.Hosts[host] = hostConfigV5{
 			AccessKeyID:     hostCfgV4.AccessKeyID,
 			SecretAccessKey: hostCfgV4.SecretAccessKey,
@@ -244,26 +244,26 @@ func migrateConfigV4ToV5() {
 		}
 	}
 
-	mcNewCfgV5, e := quick.New(cfgV5)
+	miniocNewCfgV5, e := quick.New(cfgV5)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘5’.")
 
-	e = mcNewCfgV5.Save(mustGetMcConfigPath())
+	e = miniocNewCfgV5.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘5’.")
 
-	console.Infof("Successfully migrated %s from version ‘4’ to version ‘5’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘4’ to version ‘5’.\n", mustGetMiniocConfigPath())
 }
 
 // Migrate config version ‘5’ to ‘6’. Add google cloud storage servers
 // to host config. Also remove "." from s3 aws glob rule.
 func migrateConfigV5ToV6() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
-	mcCfgV5, e := quick.Load(mustGetMcConfigPath(), newConfigV5())
-	fatalIf(probe.NewError(e), "Unable to load mc config V5.")
+	miniocCfgV5, e := quick.Load(mustGetMiniocConfigPath(), newConfigV5())
+	fatalIf(probe.NewError(e), "Unable to load minioc config V5.")
 
 	// update to newer version
-	if mcCfgV5.Version() != "5" {
+	if miniocCfgV5.Version() != "5" {
 		return
 	}
 
@@ -272,7 +272,7 @@ func migrateConfigV5ToV6() {
 	// Add new Google Cloud Storage alias.
 	cfgV6.Aliases["gcs"] = "https://storage.googleapis.com"
 
-	for k, v := range mcCfgV5.Data().(*configV5).Aliases {
+	for k, v := range miniocCfgV5.Data().(*configV5).Aliases {
 		cfgV6.Aliases[k] = v
 	}
 
@@ -288,7 +288,7 @@ func migrateConfigV5ToV6() {
 		API:             "S3v2",
 	}
 
-	for host, hostCfgV5 := range mcCfgV5.Data().(*configV5).Hosts {
+	for host, hostCfgV5 := range miniocCfgV5.Data().(*configV5).Hosts {
 		// Find any matching s3 entry and copy keys from it to newer generalized glob entry.
 		if strings.Contains(host, "s3") {
 			if (hostCfgV5.AccessKeyID == "YOUR-ACCESS-KEY-ID-HERE") ||
@@ -310,26 +310,26 @@ func migrateConfigV5ToV6() {
 		}
 	}
 
-	mcNewCfgV6, e := quick.New(cfgV6)
+	miniocNewCfgV6, e := quick.New(cfgV6)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘6’.")
 
-	e = mcNewCfgV6.Save(mustGetMcConfigPath())
+	e = miniocNewCfgV6.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘6’.")
 
-	console.Infof("Successfully migrated %s from version ‘5’ to version ‘6’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘5’ to version ‘6’.\n", mustGetMiniocConfigPath())
 }
 
 // Migrate config version ‘6’ to ‘7'. Remove alias map and introduce
 // named Host config. Also no more glob match for host config entries.
 func migrateConfigV6ToV7() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
 
-	mcCfgV6, e := quick.Load(mustGetMcConfigPath(), newConfigV6())
-	fatalIf(probe.NewError(e), "Unable to load mc config V6.")
+	miniocCfgV6, e := quick.Load(mustGetMiniocConfigPath(), newConfigV6())
+	fatalIf(probe.NewError(e), "Unable to load minioc config V6.")
 
-	if mcCfgV6.Version() != "6" {
+	if miniocCfgV6.Version() != "6" {
 		return
 	}
 
@@ -337,10 +337,10 @@ func migrateConfigV6ToV7() {
 	aliasIndex := 0
 
 	// old Aliases.
-	oldAliases := mcCfgV6.Data().(*configV6).Aliases
+	oldAliases := miniocCfgV6.Data().(*configV6).Aliases
 
 	// We dropped alias support in v7. We only need to migrate host configs.
-	for host, hostCfgV6 := range mcCfgV6.Data().(*configV6).Hosts {
+	for host, hostCfgV6 := range miniocCfgV6.Data().(*configV6).Hosts {
 		// Look through old aliases, if found any matching save those entries.
 		for aliasName, aliasedHost := range oldAliases {
 			if aliasedHost == host {
@@ -389,32 +389,32 @@ func migrateConfigV6ToV7() {
 	}
 	// Load default settings.
 	cfgV7.loadDefaults()
-	mcNewCfgV7, e := quick.New(cfgV7)
+	miniocNewCfgV7, e := quick.New(cfgV7)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘7’.")
 
-	e = mcNewCfgV7.Save(mustGetMcConfigPath())
+	e = miniocNewCfgV7.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘7’.")
 
-	console.Infof("Successfully migrated %s from version ‘6’ to version ‘7’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘6’ to version ‘7’.\n", mustGetMiniocConfigPath())
 }
 
 // Migrate config version ‘7’ to ‘8'. Remove hosts
 // 'play.minio.io:9002' and 'dl.minio.io:9000'.
 func migrateConfigV7ToV8() {
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return
 	}
 
-	mcCfgV7, e := quick.Load(mustGetMcConfigPath(), newConfigV7())
-	fatalIf(probe.NewError(e), "Unable to load mc config V7.")
+	miniocCfgV7, e := quick.Load(mustGetMiniocConfigPath(), newConfigV7())
+	fatalIf(probe.NewError(e), "Unable to load minioc config V7.")
 
-	if mcCfgV7.Version() != "7" {
+	if miniocCfgV7.Version() != "7" {
 		return
 	}
 
 	cfgV8 := newConfigV8()
 	// We dropped alias support in v7. We only need to migrate host configs.
-	for host, hostCfgV7 := range mcCfgV7.Data().(*configV7).Hosts {
+	for host, hostCfgV7 := range miniocCfgV7.Data().(*configV7).Hosts {
 		// Ignore 'player', 'play' and 'dl' aliases.
 		if host == "player" || host == "dl" || host == "play" {
 			continue
@@ -428,11 +428,11 @@ func migrateConfigV7ToV8() {
 	}
 	// Load default settings.
 	cfgV8.loadDefaults()
-	mcNewCfgV8, e := quick.New(cfgV8)
+	miniocNewCfgV8, e := quick.New(cfgV8)
 	fatalIf(probe.NewError(e), "Unable to initialize quick config for config version ‘8’.")
 
-	e = mcNewCfgV8.Save(mustGetMcConfigPath())
+	e = miniocNewCfgV8.Save(mustGetMiniocConfigPath())
 	fatalIf(probe.NewError(e), "Unable to save config version ‘8’.")
 
-	console.Infof("Successfully migrated %s from version ‘7’ to version ‘8’.\n", mustGetMcConfigPath())
+	console.Infof("Successfully migrated %s from version ‘7’ to version ‘8’.\n", mustGetMiniocConfigPath())
 }

--- a/cmd/config-v8.go
+++ b/cmd/config-v8.go
@@ -31,7 +31,7 @@ const (
 var (
 	// set once during first load.
 	cacheCfgV8 *configV8
-	// All access to mc config file should be synchronized.
+	// All access to minioc config file should be synchronized.
 	cfgMutex = &sync.RWMutex{}
 )
 
@@ -52,7 +52,7 @@ type configV8 struct {
 // newConfigV8 - new config version.
 func newConfigV8() *configV8 {
 	cfg := new(configV8)
-	cfg.Version = globalMCConfigVersion
+	cfg.Version = globalMINIOCConfigVersion
 	cfg.Hosts = make(map[string]hostConfigV8)
 	return cfg
 }
@@ -109,7 +109,7 @@ func loadConfigV8() (*configV8, *probe.Error) {
 		return cacheCfgV8, nil
 	}
 
-	if !isMcConfigExists() {
+	if !isMiniocConfigExists() {
 		return nil, errInvalidArgument().Trace()
 	}
 
@@ -121,7 +121,7 @@ func loadConfigV8() (*configV8, *probe.Error) {
 
 	// Load config at configPath, fails if config is not
 	// accessible, malformed or version missing.
-	if e = qc.Load(mustGetMcConfigPath()); e != nil {
+	if e = qc.Load(mustGetMiniocConfigPath()); e != nil {
 		return nil, probe.NewError(e)
 	}
 
@@ -147,9 +147,9 @@ func saveConfigV8(cfgV8 *configV8) *probe.Error {
 	// update the cache.
 	cacheCfgV8 = cfgV8
 
-	e = qs.Save(mustGetMcConfigPath())
+	e = qs.Save(mustGetMiniocConfigPath())
 	if e != nil {
-		return probe.NewError(e).Trace(mustGetMcConfigPath())
+		return probe.NewError(e).Trace(mustGetMiniocConfigPath())
 	}
 	return nil
 }

--- a/cmd/config-validate.go
+++ b/cmd/config-validate.go
@@ -24,9 +24,9 @@ import (
 
 // Check if version of the config is valid
 func validateConfigVersion(config *configV8) (bool, string) {
-	if config.Version != globalMCConfigVersion {
-		return false, fmt.Sprintf("Config version '%s' does not match mc config version '%s', please update your binary.\n",
-			config.Version, globalMCConfigVersion)
+	if config.Version != globalMINIOCConfigVersion {
+		return false, fmt.Sprintf("Config version '%s' does not match minioc config version '%s', please update your binary.\n",
+			config.Version, globalMINIOCConfigVersion)
 	}
 	return true, ""
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -22,22 +22,22 @@ import (
 	"regexp"
 	"runtime"
 
-	"github.com/minio/go-homedir"
 	"github.com/minio/minio/pkg/probe"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
-// mcCustomConfigDir contains the whole path to config dir. Only access via get/set functions.
-var mcCustomConfigDir string
+// miniocCustomConfigDir contains the whole path to config dir. Only access via get/set functions.
+var miniocCustomConfigDir string
 
-// setMcConfigDir - set a custom minio client config folder.
-func setMcConfigDir(configDir string) {
-	mcCustomConfigDir = configDir
+// setMiniocConfigDir - set a custom minio client config folder.
+func setMiniocConfigDir(configDir string) {
+	miniocCustomConfigDir = configDir
 }
 
-// getMcConfigDir - construct minio client config folder.
-func getMcConfigDir() (string, *probe.Error) {
-	if mcCustomConfigDir != "" {
-		return mcCustomConfigDir, nil
+// getMiniocConfigDir - construct minio client config folder.
+func getMiniocConfigDir() (string, *probe.Error) {
+	if miniocCustomConfigDir != "" {
+		return miniocCustomConfigDir, nil
 	}
 	homeDir, e := homedir.Dir()
 	if e != nil {
@@ -46,24 +46,24 @@ func getMcConfigDir() (string, *probe.Error) {
 	var configDir string
 	// For windows the path is slightly different
 	if runtime.GOOS == "windows" {
-		configDir = filepath.Join(homeDir, globalMCConfigWindowsDir)
+		configDir = filepath.Join(homeDir, globalMINIOCConfigWindowsDir)
 	} else {
-		configDir = filepath.Join(homeDir, globalMCConfigDir)
+		configDir = filepath.Join(homeDir, globalMINIOCConfigDir)
 	}
 	return configDir, nil
 }
 
-// mustGetMcConfigDir - construct minio client config folder or fail
-func mustGetMcConfigDir() (configDir string) {
-	configDir, err := getMcConfigDir()
-	fatalIf(err.Trace(), "Unable to get mcConfigDir.")
+// mustGetMiniocConfigDir - construct minio client config folder or fail
+func mustGetMiniocConfigDir() (configDir string) {
+	configDir, err := getMiniocConfigDir()
+	fatalIf(err.Trace(), "Unable to get miniocConfigDir.")
 
 	return configDir
 }
 
-// createMcConfigDir - create minio client config folder
-func createMcConfigDir() *probe.Error {
-	p, err := getMcConfigDir()
+// createMiniocConfigDir - create minio client config folder
+func createMiniocConfigDir() *probe.Error {
+	p, err := getMiniocConfigDir()
 	if err != nil {
 		return err.Trace()
 	}
@@ -73,71 +73,71 @@ func createMcConfigDir() *probe.Error {
 	return nil
 }
 
-// getMcConfigPath - construct minio client configuration path
-func getMcConfigPath() (string, *probe.Error) {
-	if mcCustomConfigDir != "" {
-		return filepath.Join(mcCustomConfigDir, globalMCConfigFile), nil
+// getMiniocConfigPath - construct minio client configuration path
+func getMiniocConfigPath() (string, *probe.Error) {
+	if miniocCustomConfigDir != "" {
+		return filepath.Join(miniocCustomConfigDir, globalMINIOCConfigFile), nil
 	}
-	dir, err := getMcConfigDir()
+	dir, err := getMiniocConfigDir()
 	if err != nil {
 		return "", err.Trace()
 	}
-	return filepath.Join(dir, globalMCConfigFile), nil
+	return filepath.Join(dir, globalMINIOCConfigFile), nil
 }
 
-// mustGetMcConfigPath - similar to getMcConfigPath, ignores errors
-func mustGetMcConfigPath() string {
-	path, err := getMcConfigPath()
-	fatalIf(err.Trace(), "Unable to get mcConfigPath.")
+// mustGetMiniocConfigPath - similar to getMiniocConfigPath, ignores errors
+func mustGetMiniocConfigPath() string {
+	path, err := getMiniocConfigPath()
+	fatalIf(err.Trace(), "Unable to get miniocConfigPath.")
 
 	return path
 }
 
-// newMcConfig - initializes a new version '6' config.
-func newMcConfig() *configV8 {
+// newMiniocConfig - initializes a new version '6' config.
+func newMiniocConfig() *configV8 {
 	cfg := newConfigV8()
 	cfg.loadDefaults()
 	return cfg
 }
 
-// loadMcConfigCached - returns loadMcConfig with a closure for config cache.
-func loadMcConfigFactory() func() (*configV8, *probe.Error) {
+// loadMiniocConfigCached - returns loadMiniocConfig with a closure for config cache.
+func loadMiniocConfigFactory() func() (*configV8, *probe.Error) {
 	// Load once and cache in a closure.
 	cfgCache, err := loadConfigV8()
 
-	// loadMcConfig - reads configuration file and returns config.
+	// loadMiniocConfig - reads configuration file and returns config.
 	return func() (*configV8, *probe.Error) {
 		return cfgCache, err
 	}
 }
 
-// loadMcConfig - returns configuration, initialized later.
-var loadMcConfig func() (*configV8, *probe.Error)
+// loadMiniocConfig - returns configuration, initialized later.
+var loadMiniocConfig func() (*configV8, *probe.Error)
 
-// saveMcConfig - saves configuration file and returns error if any.
-func saveMcConfig(config *configV8) *probe.Error {
+// saveMiniocConfig - saves configuration file and returns error if any.
+func saveMiniocConfig(config *configV8) *probe.Error {
 	if config == nil {
 		return errInvalidArgument().Trace()
 	}
 
-	err := createMcConfigDir()
+	err := createMiniocConfigDir()
 	if err != nil {
-		return err.Trace(mustGetMcConfigDir())
+		return err.Trace(mustGetMiniocConfigDir())
 	}
 
 	// Save the config.
 	if err := saveConfigV8(config); err != nil {
-		return err.Trace(mustGetMcConfigPath())
+		return err.Trace(mustGetMiniocConfigPath())
 	}
 
 	// Refresh the config cache.
-	loadMcConfig = loadMcConfigFactory()
+	loadMiniocConfig = loadMiniocConfigFactory()
 	return nil
 }
 
-// isMcConfigExists returns err if config doesn't exist.
-func isMcConfigExists() bool {
-	configFile, err := getMcConfigPath()
+// isMiniocConfigExists returns err if config doesn't exist.
+func isMiniocConfigExists() bool {
+	configFile, err := getMiniocConfigPath()
 	if err != nil {
 		return false
 	}
@@ -154,14 +154,14 @@ func isValidAlias(alias string) bool {
 
 // getHostConfig retrieves host specific configuration such as access keys, signature type.
 func getHostConfig(alias string) (*hostConfigV8, *probe.Error) {
-	mcCfg, err := loadMcConfig()
+	miniocCfg, err := loadMiniocConfig()
 	if err != nil {
 		return nil, err.Trace(alias)
 	}
 
 	// if host is exact return quickly.
-	if _, ok := mcCfg.Hosts[alias]; ok {
-		hostCfg := mcCfg.Hosts[alias]
+	if _, ok := miniocCfg.Hosts[alias]; ok {
+		hostCfg := miniocCfg.Hosts[alias]
 		return &hostCfg, nil
 	}
 

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -30,8 +30,8 @@ import (
 	"github.com/cheggaaa/pb"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // cp command flags.

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // diff specific flags.
@@ -41,10 +41,10 @@ var diffCmd = cli.Command{
 	Before:      setGlobalsFromContext,
 	Flags:       append(diffFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
-   mc {{.Name}} - {{.Usage}}
+   minioc {{.Name}} - {{.Usage}}
 
 USAGE:
-   mc {{.Name}} [FLAGS] FIRST SECOND
+   minioc {{.Name}} [FLAGS] FIRST SECOND
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // causeMessage container for golang error messages

--- a/cmd/events-add.go
+++ b/cmd/events-add.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -61,7 +61,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. Enable bucket notification with a specific arn
-     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
 
    2. Enable bucket notification with filters parameters
      $ {{.HelpName}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue --events put,delete --prefix photos/ --suffix .jpg

--- a/cmd/events-list.go
+++ b/cmd/events-list.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -47,7 +47,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. List notification configurations associated to a specific arn
-     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
 
    2. List all notification configurations
      $ {{.HelpName}} s3/mybucket

--- a/cmd/events-main.go
+++ b/cmd/events-main.go
@@ -48,7 +48,7 @@ COMMANDS:
 `,
 }
 
-// mainEvents is the handle for "mc events" command.
+// mainEvents is the handle for "minioc events" command.
 func mainEvents(ctx *cli.Context) error {
 
 	if ctx.Args().First() != "" { // command help.

--- a/cmd/events-remove.go
+++ b/cmd/events-remove.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -52,7 +52,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. Remove bucket notification associated to a specific arn
-     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue 
+     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
 
    2. Remove all bucket notifications. --force flag is mandatory here
      $ {{.HelpName}} myminio/mybucket --force

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -21,17 +21,17 @@ import (
 	"github.com/minio/minio/pkg/trie"
 )
 
-// Collection of mc commands currently supported
+// Collection of minioc commands currently supported
 var commands = []cli.Command{}
 
-// Collection of mc commands currently supported in a trie tree
+// Collection of minioc commands currently supported in a trie tree
 var commandsTree = trie.NewTrie()
 
-// Collection of mc flags currently supported
+// Collection of minioc flags currently supported
 var globalFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "config-folder, C",
-		Value: mustGetMcConfigDir(),
+		Value: mustGetMiniocConfigDir(),
 		Usage: "Path to configuration folder.",
 	},
 	cli.BoolFlag{

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -21,22 +21,22 @@ import (
 	"crypto/x509"
 
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minioc/pkg/console"
 )
 
-// mc configuration related constants.
+// minioc configuration related constants.
 const (
-	minGoVersion = ">= 1.7.1" // mc requires at least Go v1.7.1
+	minGoVersion = ">= 1.7.1" // minioc requires at least Go v1.7.1
 )
 
 const (
-	globalMCConfigVersion = "8"
+	globalMINIOCConfigVersion = "8"
 
-	globalMCConfigDir        = ".mc/"
-	globalMCConfigWindowsDir = "mc\\"
-	globalMCConfigFile       = "config.json"
-	globalMCCertsDir         = "certs"
-	globalMCCAsDir           = "CAs"
+	globalMINIOCConfigDir        = ".minioc/"
+	globalMINIOCConfigWindowsDir = "minioc\\"
+	globalMINIOCConfigFile       = "config.json"
+	globalMINIOCCertsDir         = "certs"
+	globalMINIOCCAsDir           = "CAs"
 
 	// session config and shared urls related constants
 	globalSessionDir           = "session"

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // ls specific flags.
@@ -70,7 +70,7 @@ EXAMPLES:
    5. List files recursively on a local filesystem on Microsoft Windows.
       $ {{.HelpName}} --recursive C:\Users\Worf\
 
-   6. List incomplete (previously failed) uploads of objects on Amazon S3. 
+   6. List incomplete (previously failed) uploads of objects on Amazon S3.
       $ {{.HelpName}} --incomplete s3/mybucket
 
 `,
@@ -104,7 +104,7 @@ func checkListSyntax(ctx *cli.Context) {
 	}
 }
 
-// mainList - is a handler for mc ls command
+// mainList - is a handler for minioc ls command
 func mainList(ctx *cli.Context) error {
 	// Additional command specific theme customization.
 	console.SetColor("File", color.New(color.Bold))
@@ -135,7 +135,7 @@ func mainList(ctx *cli.Context) error {
 		if st, err = clnt.Stat(isIncomplete); err != nil {
 			switch err.ToGoError().(type) {
 			case BucketNameEmpty:
-			// For aliases like ``mc ls s3`` it's acceptable to receive BucketNameEmpty error.
+			// For aliases like ``minioc ls s3`` it's acceptable to receive BucketNameEmpty error.
 			// Nothing to do.
 			default:
 				fatalIf(err.Trace(targetURL), "Unable to initialize target ‘"+targetURL+"’.")

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // printDate - human friendly formatted date.

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cheggaaa/pb"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // mirror specific flags.

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -16,7 +16,7 @@
 
 package cmd
 
-import "github.com/minio/mc/pkg/console"
+import "github.com/minio/minioc/pkg/console"
 
 // message interface for all structured messages implementing JSON(), String() methods.
 type message interface {

--- a/cmd/progress-bar.go
+++ b/cmd/progress-bar.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cheggaaa/pb"
 	"github.com/fatih/color"
 
-	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // progress extender.

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // Day time.Duration for day.

--- a/cmd/runtime-checks.go
+++ b/cmd/runtime-checks.go
@@ -21,8 +21,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/hashicorp/go-version"
-	"github.com/minio/mc/pkg/console"
+	version "github.com/hashicorp/go-version"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // check if minimum Go version is met.

--- a/cmd/scan-bar.go
+++ b/cmd/scan-bar.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/cheggaaa/pb"
 	"github.com/dustin/go-humanize"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // fixateScanBar truncates or stretches text to fit within the terminal size.

--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
 	"github.com/minio/minio/pkg/trie"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -147,7 +147,7 @@ func clearSession(sid string) {
 
 	session, err := loadSessionV8(sid)
 	if err != nil {
-		// `mc session clear <broken-session-id>` assumes that user is aware that the session is unuseful
+		// `minioc session clear <broken-session-id>` assumes that user is aware that the session is unuseful
 		// and wants the associated session files to be removed
 		removeSessionFile(sid)
 		removeSessionDataFile(sid)
@@ -232,7 +232,7 @@ func mainSession(ctx *cli.Context) error {
 			if len(closestSessions) > 0 {
 				errorMsg += fmt.Sprintf("\n\nDid you mean?\n")
 				for _, session := range closestSessions {
-					errorMsg += fmt.Sprintf("        ‘mc resume session %s’", session)
+					errorMsg += fmt.Sprintf("        ‘minioc resume session %s’", session)
 					// break on the first one, it is good enough.
 					break
 				}

--- a/cmd/session-migrate.go
+++ b/cmd/session-migrate.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
 	"github.com/minio/minio/pkg/quick"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // Migrates session header version '7' to '8'. The only
@@ -34,11 +34,11 @@ func migrateSessionV7ToV8() {
 			if os.IsNotExist(err.ToGoError()) {
 				continue
 			}
-			fatalIf(err.Trace(sid), "Unable to load version ‘7’. Migration failed please report this issue at https://github.com/minio/mc/issues.")
+			fatalIf(err.Trace(sid), "Unable to load version ‘7’. Migration failed please report this issue at https://github.com/minio/minioc/issues.")
 		}
 
 		sessionVersion, e := strconv.Atoi(sV7.Header.Version)
-		fatalIf(probe.NewError(e), "Unable to load version ‘7’. Migration failed please report this issue at https://github.com/minio/mc/issues.")
+		fatalIf(probe.NewError(e), "Unable to load version ‘7’. Migration failed please report this issue at https://github.com/minio/minioc/issues.")
 		if sessionVersion > 7 { // It is new format.
 			continue
 		}
@@ -86,11 +86,11 @@ func migrateSessionV6ToV7() {
 			if os.IsNotExist(err.ToGoError()) {
 				continue
 			}
-			fatalIf(err.Trace(sid), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/mc/issues.")
+			fatalIf(err.Trace(sid), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/minioc/issues.")
 		}
 
 		sessionVersion, e := strconv.Atoi(sV6Header.Version)
-		fatalIf(probe.NewError(e), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/mc/issues.")
+		fatalIf(probe.NewError(e), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/minioc/issues.")
 		if sessionVersion > 6 { // It is new format.
 			continue
 		}
@@ -136,11 +136,11 @@ func migrateSessionV5ToV6() {
 			if os.IsNotExist(err.ToGoError()) {
 				continue
 			}
-			fatalIf(err.Trace(sid), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/mc/issues.")
+			fatalIf(err.Trace(sid), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/minioc/issues.")
 		}
 
 		sessionVersion, e := strconv.Atoi(sV6Header.Version)
-		fatalIf(probe.NewError(e), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/mc/issues.")
+		fatalIf(probe.NewError(e), "Unable to load version ‘6’. Migration failed please report this issue at https://github.com/minio/minioc/issues.")
 		if sessionVersion > 5 { // It is new format.
 			continue
 		}

--- a/cmd/session-v8.go
+++ b/cmd/session-v8.go
@@ -28,9 +28,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
 	"github.com/minio/minio/pkg/quick"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // sessionV8Header for resumable sessions.
@@ -139,7 +139,7 @@ func loadSessionV8(sid string) (*sessionV8, *probe.Error) {
 	// Validate if the version matches with expected current version.
 	sV8Header := qs.Data().(*sessionV8Header)
 	if sV8Header.Version != globalSessionConfigVersion {
-		msg := fmt.Sprintf("Session header version %s does not match mc session version %s.\n",
+		msg := fmt.Sprintf("Session header version %s does not match minioc session version %s.\n",
 			sV8Header.Version, globalSessionConfigVersion)
 		return nil, probe.NewError(errors.New(msg)).Trace(sid, sV8Header.Version)
 	}
@@ -371,7 +371,7 @@ func (s *sessionV8) Delete() *probe.Error {
 // Close a session and exit.
 func (s sessionV8) CloseAndDie() {
 	s.Close()
-	console.Fatalln("Session safely terminated. To resume session ‘mc session resume " + s.SessionID + "’")
+	console.Fatalln("Session safely terminated. To resume session ‘minioc session resume " + s.SessionID + "’")
 }
 
 // Create a factory function to simplify checking if

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -51,7 +51,7 @@ func createSessionDir() *probe.Error {
 
 // getSessionDir - get session directory.
 func getSessionDir() (string, *probe.Error) {
-	configDir, err := getMcConfigDir()
+	configDir, err := getMiniocConfigDir()
 	if err != nil {
 		return "", err.Trace()
 	}

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (
@@ -72,12 +72,12 @@ func migrateShare() {
 	}
 }
 
-// mainShare - main handler for mc share command.
+// mainShare - main handler for minioc share command.
 func mainShare(ctx *cli.Context) error {
 
 	if ctx.Args().First() != "" { // command help.
 		cli.ShowCommandHelp(ctx, ctx.Args().First())
-	} else { // mc help.
+	} else { // minioc help.
 		cli.ShowAppHelp(ctx)
 	}
 

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 const (
@@ -104,7 +104,7 @@ func shareSetColor() {
 
 // Get share dir name.
 func getShareDir() (string, *probe.Error) {
-	configDir, err := getMcConfigDir()
+	configDir, err := getMiniocConfigDir()
 	if err != nil {
 		return "", err.Trace()
 	}
@@ -113,7 +113,7 @@ func getShareDir() (string, *probe.Error) {
 	return sharedURLsDataDir, nil
 }
 
-// Get share dir name or die. (NOTE: This ‘Die’ approach is only OK for mc like tools.).
+// Get share dir name or die. (NOTE: This ‘Die’ approach is only OK for minioc like tools.).
 func mustGetShareDir() string {
 	shareDir, err := getShareDir()
 	fatalIf(err.Trace(), "Unable to determine share folder.")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,8 +17,8 @@
 package cmd
 
 import (
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // Status implements a interface that can be used in quit mode or with progressbar.

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -36,7 +36,7 @@ var (
 	}
 
 	errInvalidAliasedURL = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Use ‘mc config host add mycloud " + URL + " ...’ to add an alias. Use the alias for S3 operations.")).Untrace()
+		return probe.NewError(errors.New("Use ‘minioc config host add mycloud " + URL + " ...’ to add an alias. Use the alias for S3 operations.")).Untrace()
 	}
 
 	errNoMatchingHost = func(URL string) *probe.Error {

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // command specific flags.
@@ -44,7 +44,7 @@ var (
 // Check for new software updates.
 var updateCmd = cli.Command{
 	Name:   "update",
-	Usage:  "Check for new mc update.",
+	Usage:  "Check for new minioc update.",
 	Action: mainUpdate,
 	Before: setGlobalsFromContext,
 	Flags:  append(updateFlags, globalFlags...),
@@ -69,8 +69,8 @@ EXAMPLES:
 
 // update URL endpoints.
 const (
-	mcUpdateStableURL       = "https://dl.minio.io/client/mc/release"
-	mcUpdateExperimentalURL = "https://dl.minio.io/client/mc/experimental"
+	miniocUpdateStableURL       = "https://dl.minio.io/client/minioc/release"
+	miniocUpdateExperimentalURL = "https://dl.minio.io/client/minioc/experimental"
 )
 
 // updateMessage container to hold update messages.
@@ -84,7 +84,7 @@ type updateMessage struct {
 // String colorized update message.
 func (u updateMessage) String() string {
 	if !u.Update {
-		return console.Colorize("Update", "You are already running the most recent version of ‘mc’.")
+		return console.Colorize("Update", "You are already running the most recent version of ‘minioc’.")
 	}
 	var msg string
 	if runtime.GOOS == "windows" {
@@ -116,8 +116,8 @@ func parseReleaseData(data string) (time.Time, *probe.Error) {
 	if len(releaseDateSplits) < 3 {
 		return time.Time{}, probe.NewError(errors.New("Update data malformed"))
 	}
-	if releaseDateSplits[0] != "mc" {
-		return time.Time{}, probe.NewError(errors.New("Update data malformed, missing mc tag"))
+	if releaseDateSplits[0] != "minioc" {
+		return time.Time{}, probe.NewError(errors.New("Update data malformed, missing minioc tag"))
 	}
 	// "OFFICIAL" tag is still kept for backward compatibility, we should remove this for the next release.
 	if releaseDateSplits[1] != "RELEASE" && releaseDateSplits[1] != "OFFICIAL" {
@@ -141,7 +141,7 @@ func parseReleaseData(data string) (time.Time, *probe.Error) {
 func getReleaseUpdate(updateURL string) (updateMsg updateMessage, errMsg string, err *probe.Error) {
 	// Construct a new update url.
 	newUpdateURLPrefix := updateURL + "/" + runtime.GOOS + "-" + runtime.GOARCH
-	newUpdateURL := newUpdateURLPrefix + "/mc.shasum"
+	newUpdateURL := newUpdateURLPrefix + "/minioc.shasum"
 
 	// Instantiate a new client with 3 sec timeout.
 	client := &http.Client{
@@ -153,10 +153,10 @@ func getReleaseUpdate(updateURL string) (updateMsg updateMessage, errMsg string,
 	switch runtime.GOOS {
 	case "windows":
 		// For windows and darwin.
-		downloadURL = newUpdateURLPrefix + "/mc.exe"
+		downloadURL = newUpdateURLPrefix + "/minioc.exe"
 	default:
 		// For all other operating systems.
-		downloadURL = newUpdateURLPrefix + "/mc"
+		downloadURL = newUpdateURLPrefix + "/minioc"
 	}
 
 	data, e := client.Get(newUpdateURL)
@@ -193,13 +193,13 @@ func getReleaseUpdate(updateURL string) (updateMsg updateMessage, errMsg string,
 
 	latest, err := parseReleaseData(string(body))
 	if err != nil {
-		errMsg = "Please report this issue at https://github.com/minio/mc/issues."
+		errMsg = "Please report this issue at https://github.com/minio/minioc/issues."
 		return updateMessage{}, errMsg, err.Trace(newUpdateURL)
 	}
 
 	if latest.IsZero() {
 		err = errDummy().Trace(newUpdateURL)
-		errMsg = "Unable to validate any update available at this time. Please open an issue at https://github.com/minio/mc/issues"
+		errMsg = "Unable to validate any update available at this time. Please open an issue at https://github.com/minio/minioc/issues"
 		return updateMessage{}, errMsg, err
 	}
 
@@ -224,9 +224,9 @@ func mainUpdate(ctx *cli.Context) error {
 	var err *probe.Error
 	// Check for update.
 	if ctx.Bool("experimental") {
-		updateMsg, errMsg, err = getReleaseUpdate(mcUpdateExperimentalURL)
+		updateMsg, errMsg, err = getReleaseUpdate(miniocUpdateExperimentalURL)
 	} else {
-		updateMsg, errMsg, err = getReleaseUpdate(mcUpdateStableURL)
+		updateMsg, errMsg, err = getReleaseUpdate(miniocUpdateStableURL)
 	}
 	fatalIf(err, errMsg)
 	printMsg(updateMsg)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 func isErrIgnored(err *probe.Error) (ignored bool) {
@@ -103,7 +103,7 @@ func buildS3Config(alias, urlStr string) (*Config, *probe.Error) {
 	s3Config := new(Config)
 
 	// Fetch keys from the environnement, otherwise, get them from the config file
-	keys := splitStr(os.Getenv("MC_SECRET_"+alias), ":", 2)
+	keys := splitStr(os.Getenv("MINIOC_SECRET_"+alias), ":", 2)
 	if isValidAccessKey(keys[0]) && isValidSecretKey(keys[1]) {
 		s3Config.AccessKey = keys[0]
 		s3Config.SecretKey = keys[1]
@@ -121,7 +121,7 @@ func buildS3Config(alias, urlStr string) (*Config, *probe.Error) {
 	}
 
 	s3Config.Signature = hostCfg.API
-	s3Config.AppName = "mc"
+	s3Config.AppName = "minioc"
 	s3Config.AppVersion = Version
 	s3Config.AppComments = []string{os.Args[0], runtime.GOOS, runtime.GOARCH}
 	s3Config.HostURL = urlStr

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -28,8 +28,8 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio/pkg/probe"
+	"github.com/minio/minioc/pkg/console"
 )
 
 var (

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -4,20 +4,20 @@
 
 Please go through this link [Maintainer Responsibility](https://gist.github.com/abperiasamy/f4d9b31d3186bbd26522)
 
-### Setup your mc Github Repository
+### Setup your minioc Github Repository
 
-Fork [mc upstream](https://github.com/minio/mc/fork) source repository to your own personal repository.
+Fork [minioc upstream](https://github.com/minio/minioc/fork) source repository to your own personal repository.
 
 ```sh
 
 $ mkdir -p $GOPATH/src/github.com/minio
 $ cd $GOPATH/src/github.com/minio
-$ git clone https://github.com/$USER_ID/mc
-$ 
+$ git clone https://github.com/$USER_ID/minioc
+$
 
 ```
 
-``mc`` uses [govendor](https://github.com/kardianos/govendor) for its dependency management.
+``minioc`` uses [govendor](https://github.com/kardianos/govendor) for its dependency management.
 
 ### To manage dependencies
 
@@ -27,7 +27,7 @@ $
   - Edit your code to import foo/bar
   - Run `govendor add foo/bar` from top-level folder
 
-#### Remove dependencies 
+#### Remove dependencies
 
   - Run `govendor remove foo/bar`
 
@@ -37,8 +37,8 @@ $
   - Run to update the dependent package `go get -u foo/bar`
   - Run `govendor add +external`
 
-### Making new releases 
+### Making new releases
 
-`mc` doesn't follow semantic versioning style, `mc` instead uses the release date and time as the release versions.
+`minioc` doesn't follow semantic versioning style, `minioc` instead uses the release date and time as the release versions.
 
 `make release` will generate new binary into `release` directory.

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -1,6 +1,6 @@
 # Minio Client Complete Guide [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
 
-Minio Client (mc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
+Minio Client (minioc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
 
 ```sh
 
@@ -27,33 +27,33 @@ version       Print version.
 
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc|
-||32-bit Intel|https://dl.minio.io/client/mc/release/linux-386/mc|
-||32-bit ARM|https://dl.minio.io/client/mc/release/linux-arm/mc|
-|Apple OS X|64-bit Intel|https://dl.minio.io/client/mc/release/darwin-amd64/mc|
-|Microsoft Windows|64-bit|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe|
-||32-bit|https://dl.minio.io/client/mc/release/windows-386/mc.exe |
-|FreeBSD|64-bit|https://dl.minio.io/client/mc/release/freebsd-amd64/mc|
-|Solaris/Illumos|64-bit|https://dl.minio.io/client/mc/release/solaris-amd64/mc|
+|GNU/Linux|64-bit Intel|https://dl.minio.io/client/minioc/release/linux-amd64/minioc|
+||32-bit Intel|https://dl.minio.io/client/minioc/release/linux-386/minioc|
+||32-bit ARM|https://dl.minio.io/client/minioc/release/linux-arm/minioc|
+|Apple OS X|64-bit Intel|https://dl.minio.io/client/minioc/release/darwin-amd64/minioc|
+|Microsoft Windows|64-bit|https://dl.minio.io/client/minioc/release/windows-amd64/minioc.exe|
+||32-bit|https://dl.minio.io/client/minioc/release/windows-386/minioc.exe |
+|FreeBSD|64-bit|https://dl.minio.io/client/minioc/release/freebsd-amd64/minioc|
+|Solaris/Illumos|64-bit|https://dl.minio.io/client/minioc/release/solaris-amd64/minioc|
 
 ### Install from Homebrew
 
-Install minio packages using [Homebrew](http://brew.sh/) 
+Install minio packages using [Homebrew](http://brew.sh/)
 
 ```sh
-brew install minio-mc
-mc --help
+brew install minio-minioc
+minioc --help
 ```
 
 ### Install from Source
 
-Source installation is intended only for developers and advanced users. `mc update` command does not support upgrading from source based installation. Please download official releases from https://minio.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `minioc update` command does not support upgrading from source based installation. Please download official releases from https://minio.io/downloads/#minio-client.
 
 If you do not have a working Golang environment, please follow [How to install Golang](https://docs.minio.io/docs/how-to-install-golang).
 
 ```sh
 
-go get -u github.com/minio/mc
+go get -u github.com/minio/minioc
 
 ```
 
@@ -63,8 +63,8 @@ go get -u github.com/minio/mc
 
 ```sh
 
-chmod +x mc
-./mc --help
+chmod +x minioc
+./minioc --help
 
 ```
 
@@ -72,8 +72,8 @@ chmod +x mc
 
 ```sh
 
-chmod 755 mc
-./mc --help
+chmod 755 minioc
+./minioc --help
 
 ```
 
@@ -81,7 +81,7 @@ chmod 755 mc
 
 ```sh
 
-mc.exe --help
+minioc.exe --help
 
 ```
 
@@ -89,8 +89,8 @@ mc.exe --help
 
 ```sh
 
-chmod 755 mc
-./mc --help
+chmod 755 minioc
+./minioc --help
 
 ```
 
@@ -98,22 +98,22 @@ chmod 755 mc
 
 ```sh
 
-chmod 755 mc
-./mc --help
+chmod 755 minioc
+./minioc --help
 
 ```
 
 ## 3. Add a Cloud Storage Service
 
-Note: If you are planning to use `mc` only on POSIX compatible filesystems, you may skip this step and proceed to **Step 4**.
+Note: If you are planning to use `minioc` only on POSIX compatible filesystems, you may skip this step and proceed to **Step 4**.
 
-To add one or more Amazon S3 compatible hosts, please follow the instructions below. `mc` stores all its configuration information in ``~/.mc/config.json`` file.
+To add one or more Amazon S3 compatible hosts, please follow the instructions below. `minioc` stores all its configuration information in ``~/.minioc/config.json`` file.
 
 #### Usage
 
 ```sh
 
-mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY> <API-SIGNATURE>
+minioc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY> <API-SIGNATURE>
 
 ```
 
@@ -126,7 +126,7 @@ Minio server displays URL, access and secret keys.
 
 ```sh
 
-mc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
+minioc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
 
 ```
 
@@ -136,7 +136,7 @@ Get your AccessKeyID and SecretAccessKey by following [AWS Credentials Guide](ht
 
 ```sh
 
-mc config host add s3 https://s3.amazonaws.com BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
+minioc config host add s3 https://s3.amazonaws.com BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
 
 ```
 
@@ -146,7 +146,7 @@ Get your AccessKeyID and SecretAccessKey by following [Google Credentials Guide]
 
 ```sh
 
-mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2
+minioc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2
 
 ```
 
@@ -154,7 +154,7 @@ NOTE: Google Cloud Storage only supports Legacy Signature Version 2, so you have
 
 ## 4. Test Your Setup
 
-`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`minioc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
@@ -162,7 +162,7 @@ List all buckets from https://play.minio.io:9000
 
 ```sh
 
-mc ls play
+minioc ls play
 [2016-03-22 19:47:48 PDT]     0B my-bucketname/
 [2016-03-22 22:01:07 PDT]     0B mytestbucket/
 [2016-03-22 20:04:39 PDT]     0B mybucketname/
@@ -177,11 +177,11 @@ You may add shell aliases to override your common Unix tools.
 
 ```sh
 
-alias ls='mc ls'
-alias cp='mc cp'
-alias cat='mc cat'
-alias mkdir='mc mb'
-alias pipe='mc pipe'
+alias ls='minioc ls'
+alias cp='minioc cp'
+alias cat='minioc cat'
+alias mkdir='minioc mb'
+alias pipe='minioc pipe'
 
 ```
 
@@ -189,23 +189,23 @@ alias pipe='mc pipe'
 
 ### Option [--debug]
 
-Debug option enables debug output to console. 
+Debug option enables debug output to console.
 
-*Example: Display verbose debug output for `ls` command.* 
+*Example: Display verbose debug output for `ls` command.*
 
 ```sh
 
-mc --debug ls play
-mc: <DEBUG> GET / HTTP/1.1
+minioc --debug ls play
+minioc: <DEBUG> GET / HTTP/1.1
 Host: play.minio.io:9000
-User-Agent: Minio (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
+User-Agent: Minio (darwin; amd64) minio-go/1.0.1 minioc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
 X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 X-Amz-Date: 20160408T145236Z
 Accept-Encoding: gzip
 
-mc: <DEBUG> HTTP/1.1 200 OK
+minioc: <DEBUG> HTTP/1.1 200 OK
 Transfer-Encoding: chunked
 Accept-Ranges: bytes
 Content-Type: text/xml; charset=utf-8
@@ -214,7 +214,7 @@ Server: Minio/DEVELOPMENT.2016-04-07T18-53-27Z (linux; amd64)
 Vary: Origin
 X-Amz-Request-Id: HP30I0W2U49BDBIO
 
-mc: <DEBUG> Response Time:  1.220112837s
+minioc: <DEBUG> Response Time:  1.220112837s
 
 [...]
 
@@ -233,7 +233,7 @@ JSON option enables parseable output in JSON format.
 
 ```sh
 
-mc --json ls play
+minioc --json ls play
 {"status":"success","type":"folder","lastModified":"2016-04-08T03:56:14.577+05:30","size":0,"key":"albums/"}
 {"status":"success","type":"folder","lastModified":"2016-04-04T16:11:45.349+05:30","size":0,"key":"backup/"}
 {"status":"success","type":"folder","lastModified":"2016-04-01T20:10:53.941+05:30","size":0,"key":"deebucket/"}
@@ -265,7 +265,7 @@ Skip SSL certificate verification.
 |[**cp** - Copy objects](#cp)   | [**rm** - Remove objects](#rm)  | [**pipe** - Pipe to an object](#pipe)  |
 | [**share** - Share access](#share)  |[**mirror** - Mirror buckets](#mirror)   |[**diff** - Diff buckets](#diff)   |
 |[**policy** - Set public policy on bucket or prefix](#policy)   |[**session** - Manage saved sessions](#session)   | [**config** - Manage config file](#config)  |
-| [**watch** - Watch for events](#watch)   | [**events** - Manage events on your buckets](#events)   |   | 
+| [**watch** - Watch for events](#watch)   | [**events** - Manage events on your buckets](#events)   |   |
 | [**update** - Manage software updates](#update)  | [**version** - Show version](#version)  |   |
 
 
@@ -276,20 +276,20 @@ Skip SSL certificate verification.
 ```sh
 
 USAGE:
-   mc ls [FLAGS] TARGET [TARGET ...]
+   minioc ls [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
   --help, -h					Help of ls.
   --recursive, -r				List recursively.
   --incomplete, -I				List incomplete uploads.
-  
+
 ```
 
 *Example: List all buckets on https://play.minio.io:9000.*
 
 ```sh
 
-mc ls play
+minioc ls play
 [2016-04-08 03:56:14 IST]     0B albums/
 [2016-04-04 16:11:45 IST]     0B backup/
 [2016-04-01 20:10:53 IST]     0B deebucket/
@@ -300,18 +300,18 @@ mc ls play
 <a name="mb"></a>
 ### Command `mb` - Make a Bucket
 
-`mb` command creates a new bucket on an object storage. On a filesystem, it behaves like `mkdir -p` command. Bucket is equivalent of a drive or mount point in filesystems and should not be treated as folders. Minio does not place any limits on the number of buckets created per user. 
-On Amazon S3, each account is limited to 100 buckets. Please refer to [Buckets Restrictions and Limitations on S3](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) for more information.  
+`mb` command creates a new bucket on an object storage. On a filesystem, it behaves like `mkdir -p` command. Bucket is equivalent of a drive or mount point in filesystems and should not be treated as folders. Minio does not place any limits on the number of buckets created per user.
+On Amazon S3, each account is limited to 100 buckets. Please refer to [Buckets Restrictions and Limitations on S3](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) for more information.
 
 ```sh
 
 USAGE:
-   mc mb [FLAGS] TARGET [TARGET...]
+   minioc mb [FLAGS] TARGET [TARGET...]
 
 FLAGS:
   --help, -h					Help of mb.
   --region "us-east-1"			Specify bucket region. Defaults to ‘us-east-1’.
-  
+
 ```
 
 *Example: Create a new bucket named "mybucket" on https://play.minio.io:9000.*
@@ -319,7 +319,7 @@ FLAGS:
 
 ```sh
 
-mc mb play/mybucket
+minioc mb play/mybucket
 Bucket created successfully ‘play/mybucket’.
 
 ```
@@ -333,7 +333,7 @@ Bucket created successfully ‘play/mybucket’.
 ```sh
 
 USAGE:
-   mc cat [FLAGS] SOURCE [SOURCE...]
+   minioc cat [FLAGS] SOURCE [SOURCE...]
 
 FLAGS:
   --help, -h					Help of cat.
@@ -344,7 +344,7 @@ FLAGS:
 
 ```sh
 
-mc cat play/mybucket/myobject.txt
+minioc cat play/mybucket/myobject.txt
 Hello Minio!!
 
 ```
@@ -356,7 +356,7 @@ Hello Minio!!
 ```sh
 
 USAGE:
-   mc pipe [FLAGS] [TARGET]
+   minioc pipe [FLAGS] [TARGET]
 
 FLAGS:
   --help, -h					Help of pipe.
@@ -366,7 +366,7 @@ FLAGS:
 
 ```sh
 
-mysqldump -u root -p ******* accountsdb | mc pipe s3/ferenginar/backups/accountsdb-oct-9-2015.sql
+mysqldump -u root -p ******* accountsdb | minioc pipe s3/ferenginar/backups/accountsdb-oct-9-2015.sql
 
 ```
 
@@ -378,8 +378,8 @@ mysqldump -u root -p ******* accountsdb | mc pipe s3/ferenginar/backups/accounts
 ```sh
 
 USAGE:
-   mc cp [FLAGS] SOURCE [SOURCE...] TARGET
-   
+   minioc cp [FLAGS] SOURCE [SOURCE...] TARGET
+
 FLAGS:
   --help, -h					Help of cp.
   --recursive, -r				Copy recursively.
@@ -390,7 +390,7 @@ FLAGS:
 
 ```sh
 
-mc cp myobject.txt play/mybucket
+minioc cp myobject.txt play/mybucket
 myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
 
 ```
@@ -402,7 +402,7 @@ Use `rm` command to remove file or bucket
 ```sh
 
 USAGE:
-   mc rm [FLAGS] TARGET [TARGET ...]
+   minioc rm [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
   --help, -h				Show this help.
@@ -419,7 +419,7 @@ FLAGS:
 
 ```sh
 
-mc rm play/mybucket/myobject.txt
+minioc rm play/mybucket/myobject.txt
 Removed ‘play/mybucket/myobject.txt’.
 
 ```
@@ -428,7 +428,7 @@ Removed ‘play/mybucket/myobject.txt’.
 
 ```sh
 
-mc rm --recursive --force play/myobject
+minioc rm --recursive --force play/myobject
 Removed ‘play/myobject/newfile.txt’.
 Removed 'play/myobject/otherobject.txt’.
 
@@ -438,7 +438,7 @@ Removed 'play/myobject/otherobject.txt’.
 
 ```sh
 
-mc rm  --incomplete --recursive --force play/mybucket
+minioc rm  --incomplete --recursive --force play/mybucket
 Removed ‘play/mybucket/mydvd.iso’.
 Removed 'play/mybucket/backup.tgz’.
 
@@ -446,20 +446,20 @@ Removed 'play/mybucket/backup.tgz’.
 *Example: Remove object only if its created older than one day.*
 
 ```sh
-mc rm --force --older-than=1 play/mybucket/oldsongs
+minioc rm --force --older-than=1 play/mybucket/oldsongs
 ```
 
 <a name="share"></a>
 ### Command `share` - Share Access
 
-`share` command securely grants upload or download access to object storage. This access is only temporary and it is safe to share with remote users and applications. If you want to grant permanent access, you may look at `mc policy` command instead.
+`share` command securely grants upload or download access to object storage. This access is only temporary and it is safe to share with remote users and applications. If you want to grant permanent access, you may look at `minioc policy` command instead.
 
 Generated URL has access credentials encoded in it. Any attempt to tamper the URL will invalidate the access. To understand how this mechanism works, please follow [Pre-Signed URL](http://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html) technique.
 
 ```sh
 
 USAGE:
-   mc share [FLAGS] COMMAND
+   minioc share [FLAGS] COMMAND
 
 FLAGS:
   --help, -h					Help of share.
@@ -478,7 +478,7 @@ COMMANDS:
 ```sh
 
 USAGE:
-   mc share download [OPTIONS] TARGET [TARGET...]
+   minioc share download [OPTIONS] TARGET [TARGET...]
 
 OPTIONS:
   --help, -h					Help of share download.
@@ -491,7 +491,7 @@ OPTIONS:
 
 ```sh
 
-mc share download --expire 4h play/mybucket/myobject.txt
+minioc share download --expire 4h play/mybucket/myobject.txt
 URL: https://play.minio.io:9000/mybucket/myobject.txt
 Expire: 0 days 4 hours 0 minutes 0 seconds
 Share: https://play.minio.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
@@ -505,7 +505,7 @@ Share: https://play.minio.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMA
 ```sh
 
 USAGE:
-   mc share upload [OPTIONS] TARGET [TARGET...]
+   minioc share upload [OPTIONS] TARGET [TARGET...]
 
 OPTIONS:
   --help, -h					Help of share upload.
@@ -518,7 +518,7 @@ OPTIONS:
 
 ```sh
 
-mc share upload play/mybucket/myotherobject.txt
+minioc share upload play/mybucket/myotherobject.txt
 URL: https://play.minio.io:9000/mybucket/myotherobject.txt
 Expire: 7 days 0 hours 0 minutes 0 seconds
 Share: curl https://play.minio.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
@@ -532,7 +532,7 @@ Share: curl https://play.minio.io:9000/mybucket -F x-amz-date=20160408T182356Z -
 ```sh
 
 USAGE:
-   mc share list COMMAND
+   minioc share list COMMAND
 
 COMMAND:
    upload:   list previously shared access to uploads.
@@ -548,7 +548,7 @@ COMMAND:
 ```sh
 
 USAGE:
-   mc mirror [FLAGS] SOURCE TARGET
+   minioc mirror [FLAGS] SOURCE TARGET
 
 FLAGS:
   --help, -h				Help of mirror.
@@ -557,13 +557,13 @@ FLAGS:
   --watch, -w                          Watch and mirror for changes.
   --remove					Remove extraneous file(s) on target.
 
-``` 
+```
 
 *Example: Mirror a local directory to 'mybucket' on https://play.minio.io:9000.*
 
 ```sh
 
-mc mirror localdir/ play/mybucket
+minioc mirror localdir/ play/mybucket
 localdir/b.txt:  40 B / 40 B  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃  100.00 % 73 B/s 0
 
 ```
@@ -572,7 +572,7 @@ localdir/b.txt:  40 B / 40 B  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓�
 
 ```sh
 
-mc mirror -w localdir play/mybucket
+minioc mirror -w localdir play/mybucket
 localdir/new.txt:  10 MB / 10 MB  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃  100.00 % 1 MB/s 15s
 
 ```
@@ -587,7 +587,7 @@ It *DOES NOT* compare the contents, so it is possible that the objects which are
 ```sh
 
 USAGE:
-   mc diff [FLAGS] FIRST SECOND
+   minioc diff [FLAGS] FIRST SECOND
 
 FLAGS:
   --help, -h					Help of diff.
@@ -598,7 +598,7 @@ FLAGS:
 
 ```sh
 
- mc diff localdir play/mybucket
+ minioc diff localdir play/mybucket
 ‘localdir/notes.txt’ and ‘https://play.minio.io:9000/mybucket/notes.txt’ - only in first.
 
 ```
@@ -612,7 +612,7 @@ storage and filesystem.
 ```sh
 
 USAGE:
-   mc watch [FLAGS]
+   minioc watch [FLAGS]
 
 FLAGS:
    --help, -h					Help of watch.
@@ -627,7 +627,7 @@ FLAGS:
 
 ```sh
 
-mc watch play/testbucket
+minioc watch play/testbucket
 [2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.minio.io:9000/testbucket/CONTRIBUTING.md
 [2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.minio.io:9000/testbucket/MAINTAINERS.md
 [2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.minio.io:9000/testbucket/README.md
@@ -638,7 +638,7 @@ mc watch play/testbucket
 
 ```sh
 
-mc watch ~/Photos
+minioc watch ~/Photos
 [2016-08-17T17:54:19.565Z] 3.7MiB ObjectCreated /home/minio/Downloads/tmp/5467026530_a8611b53f9_o.jpg
 [2016-08-17T17:54:19.565Z] 3.7MiB ObjectCreated /home/minio/Downloads/tmp/5467026530_a8611b53f9_o.jpg
 ...
@@ -649,12 +649,12 @@ mc watch ~/Photos
 <a name="events"></a>
 ### Command `events` - Manage bucket event notification.
 
-``events`` provides a convenient way to configure various types of event notifications on a bucket. Minio event notification can be configured to use AMQP, Redis, ElasticSearch, NATS and PostgreSQL services. Minio configuration provides more details on how these services can be configured. 
+``events`` provides a convenient way to configure various types of event notifications on a bucket. Minio event notification can be configured to use AMQP, Redis, ElasticSearch, NATS and PostgreSQL services. Minio configuration provides more details on how these services can be configured.
 
 ```sh
 
 USAGE:
-   mc events [FLAGS] COMMAND
+   minioc events [FLAGS] COMMAND
 
 COMMANDS:
    add          Add new bucket notification.
@@ -669,7 +669,7 @@ FLAGS:
 
 ```sh
 
-mc events list play/andoria
+minioc events list play/andoria
 MyTopic        arn:minio:sns:us-east-1:1:TestTopic    s3:ObjectCreated:*,s3:ObjectRemoved:*   suffix:.jpg
 
 ```
@@ -678,7 +678,7 @@ MyTopic        arn:minio:sns:us-east-1:1:TestTopic    s3:ObjectCreated:*,s3:Obje
 
 ```sh
 
-mc events add play/andoria arn:minio:sqs:us-east-1:1:your-queue --events put
+minioc events add play/andoria arn:minio:sqs:us-east-1:1:your-queue --events put
 
 ```
 
@@ -689,7 +689,7 @@ Add `prefix` and `suffix` filtering rules for `sqs` notification resource.
 ```sh
 
 
-mc events add play/andoria arn:minio:sqs:us-east-1:1:your-queue --prefix photos/ --suffix .jpg
+minioc events add play/andoria arn:minio:sqs:us-east-1:1:your-queue --prefix photos/ --suffix .jpg
 
 ```
 
@@ -697,7 +697,7 @@ mc events add play/andoria arn:minio:sqs:us-east-1:1:your-queue --prefix photos/
 
 ```sh
 
-mc events remove play/andoria arn:minio:sqs:us-east-1:1:your-queue
+minioc events remove play/andoria arn:minio:sqs:us-east-1:1:your-queue
 
 ```
 
@@ -708,8 +708,8 @@ Manage anonymous bucket policies to a bucket and its contents
 ```sh
 
 USAGE:
-   mc policy [FLAGS] PERMISSION TARGET
-   mc policy [FLAGS] TARGET
+   minioc policy [FLAGS] PERMISSION TARGET
+   minioc policy [FLAGS] TARGET
 
 PERMISSION:
    Allowed policies are: [none, download, upload, public].
@@ -717,7 +717,7 @@ PERMISSION:
 FLAGS:
   --help, -h					Help of policy.
 
-```   
+```
 
 *Example: Show current anonymous bucket policy*
 
@@ -725,7 +725,7 @@ Show current anonymous bucket policy for ``mybucket/myphotos/2020/`` sub-directo
 
 ```sh
 
-mc policy play/mybucket/myphotos/2020/
+minioc policy play/mybucket/myphotos/2020/
 Access permission for ‘play/mybucket/myphotos/2020/’ is ‘none’
 
 ```
@@ -736,7 +736,7 @@ Set anonymous bucket policy  for ``mybucket/myphotos/2020/`` sub-directory and i
 
 ```sh
 
-mc policy download play/mybucket/myphotos/2020/
+minioc policy download play/mybucket/myphotos/2020/
 Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'download'
 
 ```
@@ -747,7 +747,7 @@ Remove any bucket policy for *mybucket/myphotos/2020/* sub-directory.
 
 ```sh
 
-mc policy none play/mybucket/myphotos/2020/
+minioc policy none play/mybucket/myphotos/2020/
 Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'none'
 
 ```
@@ -760,7 +760,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'none'
 ```sh
 
 USAGE:
-   mc session [FLAGS] OPERATION [ARG]
+   minioc session [FLAGS] OPERATION [ARG]
 
 OPERATION:
    resume   		     Resume a previously saved session.
@@ -779,7 +779,7 @@ FLAGS:
 
 ```sh
 
-mc session list
+minioc session list
 IXWKjpQM -> [2016-04-08 19:11:14 IST] cp assets.go play/mybucket
 ApwAxSwa -> [2016-04-08 01:49:19 IST] mirror miniodoc/ play/mybucket
 
@@ -789,7 +789,7 @@ ApwAxSwa -> [2016-04-08 01:49:19 IST] mirror miniodoc/ play/mybucket
 
 ```sh
 
-mc session resume IXWKjpQM 
+minioc session resume IXWKjpQM
 ...assets.go: 1.68 KB / 1.68 KB  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 784 B/s 2s
 
 ```
@@ -798,7 +798,7 @@ mc session resume IXWKjpQM
 
 ```sh
 
-$mc session clear ApwAxSwa
+$minioc session clear ApwAxSwa
 Session ‘ApwAxSwa’ cleared successfully.
 
 ```
@@ -806,12 +806,12 @@ Session ‘ApwAxSwa’ cleared successfully.
 <a name="config"></a>
 ### Command `config` - Manage Config File
 
-`config host` command provides a convenient way to manage host entries in your config file `~/.mc/config.json`. It is also OK to edit the config file manually using a text editor.  
+`config host` command provides a convenient way to manage host entries in your config file `~/.minioc/config.json`. It is also OK to edit the config file manually using a text editor.
 
 ```sh
 
 USAGE:
-   mc config host OPERATION
+   minioc config host OPERATION
 
 OPERATION:
    add ALIAS URL ACCESS-KEY SECRET-KEY [API]
@@ -830,7 +830,7 @@ Add Minio server access and secret keys to config file host entry. Note that, th
 ```sh
 
 set +o history
-mc config host add myminio http://localhost:9000 OMQAGGOL63D7UNVQFY8X GcY5RHNmnEWvD/1QxD3spEIGj+Vt9L7eHaAaBTkJ
+minioc config host add myminio http://localhost:9000 OMQAGGOL63D7UNVQFY8X GcY5RHNmnEWvD/1QxD3spEIGj+Vt9L7eHaAaBTkJ
 set -o history
 
 ```
@@ -843,7 +843,7 @@ Check for new software updates from [https://dl.minio.io](https://dl.minio.io). 
 ```sh
 
 USAGE:
-   mc update [FLAGS]
+   minioc update [FLAGS]
 
 FLAGS:
   --help, -h					Help for update.
@@ -854,32 +854,32 @@ FLAGS:
 
 ```sh
 
-mc update
-You are already running the most recent version of ‘mc’.
+minioc update
+You are already running the most recent version of ‘minioc’.
 
 ```
 
 <a name="version"></a>
 ### Command `version` - Display Version
 
-Display the current version of `mc` installed
+Display the current version of `minioc` installed
 
 ```sh
 
 USAGE:
-   mc version [FLAGS]
+   minioc version [FLAGS]
 
 FLAGS:
   --help, -h					Help for version.
 
 
 ```
- 
- *Example: Print version of mc.*
- 
+
+ *Example: Print version of minioc.*
+
 ```sh
 
-mc version
+minioc version
 Version: 2016-04-01T00:22:11Z
 Release-tag: RELEASE.2016-04-01T00-22-11Z
 Commit-id: 12adf3be326f5b6610cdd1438f72dfd861597fce

--- a/docs/minio-client-configuration-files.md
+++ b/docs/minio-client-configuration-files.md
@@ -3,13 +3,13 @@
 In this document we will walk you through the configuration files of Minio Client.
 
 ## Minio Client configuration directory
-Minio Client configurations are stored in file name ``.mc``.  It is a hidden file which resides on user's home directory.
+Minio Client configurations are stored in file name ``.minioc``.  It is a hidden file which resides on user's home directory.
 
 **This how the structure of the directory looks like:**
 
 ```sh
-tree ~/.mc
-/home/supernova/.mc
+tree ~/.minioc
+/home/supernova/.minioc
 ├── config.json
 ├── session
 └── share
@@ -18,13 +18,13 @@ tree ~/.mc
 ### Files and directories
 
 #### ``session`` directory
-``session`` directory keeps metadata information of all incomplete upload or mirror. You can run ``mc session list`` to list the same. 
+``session`` directory keeps metadata information of all incomplete upload or mirror. You can run ``minioc session list`` to list the same.
 
 #### ``config.json``
-config.json is the configuration file for Minio Client, it gets generated after you install and start Minio. All the credentials, endpoint information we add via ``mc config host`` are stored/modified here. 
+config.json is the configuration file for Minio Client, it gets generated after you install and start Minio. All the credentials, endpoint information we add via ``minioc config host`` are stored/modified here.
 
 ```sh
-cat config.json 
+cat config.json
 {
 	"version": "8",
 	"hosts": {
@@ -70,7 +70,7 @@ cat config.json
 This file keeps previous config file version details.
 
 #### ``share`` directory
-``share`` directory keeps metadata information of all upload and download URL for objects which is used by  Minio client ``mc share`` command. 
+``share`` directory keeps metadata information of all upload and download URL for objects which is used by  Minio client ``minioc share`` command.
 
 ## Explore Further
 * [Minio Client Complete Guide](https://docs.minio.io/docs/minio-client-complete-guide)

--- a/main.go
+++ b/main.go
@@ -16,14 +16,14 @@
 
 /*
  * Below main package has canonical imports for 'go get' and 'go build'
- * to work with all other clones of github.com/minio/mc repository. For
+ * to work with all other clones of github.com/minio/minioc repository. For
  * more information refer https://golang.org/doc/go1.4#canonicalimports
  */
 
-package main // import "github.com/minio/mc"
+package main
 
-import mc "github.com/minio/mc/cmd"
+import minioc "github.com/minio/minioc/cmd"
 
 func main() {
-	mc.Main()
+	minioc.Main()
 }

--- a/pkg/httptracer/httptracer.go
+++ b/pkg/httptracer/httptracer.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minioc/pkg/console"
 )
 
 // HTTPTracer provides callback hook mechanism for HTTP transport.

--- a/pkg/ioutils/ioutils_test.go
+++ b/pkg/ioutils/ioutils_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/minio/mc/pkg/ioutils"
+	"github.com/minio/minioc/pkg/ioutils"
 
 	. "gopkg.in/check.v1"
 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,2 +1,2 @@
-## mc-tests
+## minioc-tests
 Scripts written for daily automated testing.

--- a/tests/test-minio.sh
+++ b/tests/test-minio.sh
@@ -43,9 +43,9 @@ function run_minio()
     minio --anonymous server "$MINIO_WORK_DIR" || fatal 1 "failed to run minio server."
 }
 
-function install_mc()
+function install_minioc()
 {
-    go_get github.com/minio/mc || fatal 2
+    go_get github.com/minio/minioc || fatal 2
 }
 
 function main()
@@ -58,7 +58,7 @@ function main()
         run_minio
     fi
 
-    msg "Running all mc tests."
+    msg "Running all minioc tests."
     for test_script in $TEST_CASE_DIR/*; do
         if [ -x "$test_script" ]; then
             "$test_script" "$@" || error "test $test_script failed."

--- a/tests/tests/README.md
+++ b/tests/tests/README.md
@@ -2,4 +2,4 @@
 
 * Test case is usually a bash shell script, but technically any executable
 * Test case is run with two arguments now ie server-name and source-dir-name.
-* Test case should check/validate mc command output and return exit code accordingly.
+* Test case should check/validate minioc command output and return exit code accordingly.

--- a/tests/tests/access-test.sh
+++ b/tests/tests/access-test.sh
@@ -2,5 +2,5 @@
 
 server="$1"
 
-mc --json access set download "$server/testbucket"
+minioc --json access set download "$server/testbucket"
 # TODO: validate output

--- a/tests/tests/cat-test.sh
+++ b/tests/tests/cat-test.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
 
 
-# Testing mc cat
+# Testing minioc cat
 # 1. Pass a variable as stdin
-# 2. Assert result returned by mc cat is the same
-# 3. Repeat the same for mc pipe with no arguments
+# 2. Assert result returned by minioc cat is the same
+# 3. Repeat the same for minioc pipe with no arguments
 # 4. Take a random string to test for non existent files
 
 dummy_string="asdasd"
 
-cat_result=`mc cat <<< $dummy_string`
+cat_result=`minioc cat <<< $dummy_string`
 if [ "$cat_result" == "$dummy_string" ]; then
-    echo "mc cat STDIN Test Passed"
+    echo "minioc cat STDIN Test Passed"
 else
-    echo "mc cat STDIN Test Failed"
+    echo "minioc cat STDIN Test Failed"
 fi
 
-pipe_result=`mc pipe <<< $dummy_string`
+pipe_result=`minioc pipe <<< $dummy_string`
 if [ "$pipe_result" == "$dummy_string" ]; then
-    echo "mc pipe STDIN Test Passed"
+    echo "minioc pipe STDIN Test Passed"
 else
-    echo "mc pipe STDIN Test Failed"
+    echo "minioc pipe STDIN Test Failed"
 fi
 
 random_string="asd.jasd"
 
-cat_json_result=`mc cat --json $random_string`
+cat_json_result=`minioc cat --json $random_string`
 if [[ "$cat_json_result" == *"\"status\":\"error\""* ]]
 then
-    echo "mc cat Non-Existent File Test Passed"
+    echo "minioc cat Non-Existent File Test Passed"
 else
-    echo "mc cat Non-Existent File Test Failed"
+    echo "minioc cat Non-Existent File Test Failed"
 fi

--- a/tests/tests/config-host-test.sh
+++ b/tests/tests/config-host-test.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 
 
-# Testing mc config  hosts
+# Testing minioc config  hosts
 # 1. Get number of previous hosts
 # 2. Add a host
 # 3. Assert the increase in number of hosts by one.
 # 4. Delete the new host
 
 
-initial_count=`mc config host list | wc -l`
-add_test_result=`mc config --json host add testdisk  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2`
-final_count=`mc config host list | wc -l`
-remove_test_result=`mc config host remove testdisk`
+initial_count=`minioc config host list | wc -l`
+add_test_result=`minioc config --json host add testdisk  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v2`
+final_count=`minioc config host list | wc -l`
+remove_test_result=`minioc config host remove testdisk`
 
 if [ "$add_test_result" == "Added ‘testdisk’ successfully." ]; then
-    echo "mc config host add Test Passed";
+    echo "minioc config host add Test Passed";
 else
-    echo "mc config host add Test Failed";
+    echo "minioc config host add Test Failed";
 fi
 
 if [ $((initial_count + 1)) -ne $final_count ]; then
-    echo "mc config host list Test Failed";
+    echo "minioc config host list Test Failed";
 else
-    echo "mc config host list Test Passed";
+    echo "minioc config host list Test Passed";
 fi
 
 if [ "$remove_test_result" == "Removed ‘testdisk’ successfully." ]; then
-    echo "mc config host remove Test Passed";
+    echo "minioc config host remove Test Passed";
 else
-    echo "mc config host remove Test Failed";
+    echo "minioc config host remove Test Failed";
 fi

--- a/tests/tests/cp-test.sh
+++ b/tests/tests/cp-test.sh
@@ -3,5 +3,5 @@
 server="$1"
 dir="$2"
 
-mc --json cp "$dir..." "$server/testbucket"
+minioc --json cp "$dir..." "$server/testbucket"
 # TODO: validate output

--- a/tests/tests/ls-test.sh
+++ b/tests/tests/ls-test.sh
@@ -2,5 +2,5 @@
 
 server="$1"
 
-mc --json ls "$server"
+minioc --json ls "$server"
 # TODO: validate output

--- a/tests/tests/rm-test.sh
+++ b/tests/tests/rm-test.sh
@@ -2,5 +2,5 @@
 
 server="$1"
 
-mc --json rm --force "$server/testbucket..."
+minioc --json rm --force "$server/testbucket..."
 # TODO: validate output


### PR DESCRIPTION
mc is already occupied by the still popular "midnight commander"
therefore he who comes second must suffer ;)

I have changed all /mc/i refs to minioc (obeyeing the given upper and
lower case)

Since the refactor works under the assumption that this repo will be renamed to minioc as well testing was a little bit flaky. The dockerfile for example didn't build because the repo doesn't exist (yet)
 