### PR TITLE
cli: Remove help sub-command and --version flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -284,11 +284,6 @@ func registerApp() *cli.App {
 		Usage: "Show help.",
 	}
 
-	cli.VersionFlag = cli.BoolFlag{
-		Name:  "version, v",
-		Usage: "Print the version.",
-	}
-
 	app := cli.NewApp()
 	app.Action = func(ctx *cli.Context) {
 		if strings.HasPrefix(Version, "RELEASE.") {
@@ -297,6 +292,8 @@ func registerApp() *cli.App {
 		}
 		cli.ShowAppHelp(ctx)
 	}
+	app.HideVersion = true
+	app.HideHelpCommand = true
 	app.Usage = "Minio Client for cloud storage and filesystems."
 	app.Commands = commands
 	app.Author = "Minio.io"

--- a/vendor/github.com/minio/cli/app.go
+++ b/vendor/github.com/minio/cli/app.go
@@ -45,8 +45,10 @@ type App struct {
 	Flags []Flag
 	// Boolean to enable bash completion commands
 	EnableBashCompletion bool
-	// Boolean to hide built-in help command
+	// Boolean to hide built-in help flag
 	HideHelp bool
+	// Boolean to hide built-in help command
+	HideHelpCommand bool
 	// Boolean to hide built-in version flag and the VERSION section of help
 	HideVersion bool
 	// Populate on app startup, only gettable through method Categories()
@@ -144,9 +146,11 @@ func (a *App) Setup() {
 	}
 	a.Commands = newCmds
 
-	if a.Command(helpCommand.Name) == nil && !a.HideHelp {
-		a.Commands = append(a.Commands, helpCommand)
-		if (HelpFlag != BoolFlag{}) {
+	if a.Command(helpCommand.Name) == nil {
+		if !a.HideHelpCommand {
+			a.Commands = append(a.Commands, helpCommand)
+		}
+		if !a.HideHelp && (HelpFlag != BoolFlag{}) {
 			a.appendFlag(HelpFlag)
 		}
 	}
@@ -285,9 +289,11 @@ func (a *App) RunAndExitOnError() {
 func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	// append help to commands
 	if len(a.Commands) > 0 {
-		if a.Command(helpCommand.Name) == nil && !a.HideHelp {
-			a.Commands = append(a.Commands, helpCommand)
-			if (HelpFlag != BoolFlag{}) {
+		if a.Command(helpCommand.Name) == nil {
+			if !a.HideHelpCommand {
+				a.Commands = append(a.Commands, helpCommand)
+			}
+			if !a.HideHelp && (HelpFlag != BoolFlag{}) {
 				a.appendFlag(HelpFlag)
 			}
 		}

--- a/vendor/github.com/minio/cli/command.go
+++ b/vendor/github.com/minio/cli/command.go
@@ -51,8 +51,10 @@ type Command struct {
 	// removed n version 2 since it only works under specific conditions so we
 	// backport here by exposing it as an option for compatibility.
 	SkipArgReorder bool
-	// Boolean to hide built-in help command
+	// Boolean to hide built-in help flag
 	HideHelp bool
+	// Boolean to hide built-in help command
+	HideHelpCommand bool
 	// Boolean to hide this command from help or completion
 	Hidden bool
 
@@ -261,6 +263,7 @@ func (c Command) startApp(ctx *Context) error {
 	app.Commands = c.Subcommands
 	app.Flags = c.Flags
 	app.HideHelp = c.HideHelp
+	app.HideHelpCommand = c.HideHelpCommand
 
 	app.Version = ctx.App.Version
 	app.HideVersion = ctx.App.HideVersion

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,10 +39,10 @@
 			"revisionTime": "2015-12-11T09:06:21+09:00"
 		},
 		{
-			"checksumSHA1": "x3rk+f4RmPCpMd/ocFOp9Xvz4Mo=",
+			"checksumSHA1": "7PcmjItrQSx/1sZ6Q395LCzT+iw=",
 			"path": "github.com/minio/cli",
-			"revision": "94143931a558fd1cc27146bad1a987b5f99cfd3d",
-			"revisionTime": "2017-02-19T08:25:02Z"
+			"revision": "06bb2061ef1493532baf0444818eb5fb4c83caac",
+			"revisionTime": "2017-02-20T03:57:28Z"
 		},
 		{
 			"path": "github.com/minio/go-homedir",


### PR DESCRIPTION
This is to bring consistent CLI experience as before.