### PR TITLE
admin: Add config get command

### DIFF
--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -1,0 +1,95 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+
+	"github.com/minio/cli"
+	"github.com/minio/minio/pkg/probe"
+)
+
+var adminConfigGetCmd = cli.Command{
+	Name:   "get",
+	Usage:  "Get config of a Minio server/cluster.",
+	Before: setGlobalsFromContext,
+	Action: mainAdminConfigGet,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} ALIAS/
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Get server configuration of a Minio server/cluster.
+     $ {{.HelpName}} play/
+
+`,
+}
+
+// configGetMessage container to hold locks information.
+type configGetMessage struct {
+	Status string `json:"status"`
+	Config []byte `json:"config"`
+}
+
+// String colorized service status message.
+func (u configGetMessage) String() string {
+	return string(u.Config)
+}
+
+// JSON jsonified service status Message message.
+func (u configGetMessage) JSON() string {
+	u.Status = "success"
+	statusJSONBytes, e := json.Marshal(u)
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(statusJSONBytes)
+}
+
+// checkAdminConfigGetSyntax - validate all the passed arguments
+func checkAdminConfigGetSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 || len(ctx.Args()) > 2 {
+		cli.ShowCommandHelpAndExit(ctx, "get", 1) // last argument is exit code
+	}
+}
+
+func mainAdminConfigGet(ctx *cli.Context) error {
+
+	checkAdminConfigGetSyntax(ctx)
+
+	// Get the alias parameter from cli
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new Minio Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Cannot get a configured admin connection.")
+
+	// Call get config API
+	c, e := client.GetConfig()
+	fatalIf(probe.NewError(e), "Cannot get server configuration file.")
+
+	// Print
+	printMsg(configGetMessage{Config: c})
+
+	return nil
+}

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016, 2017 Minio, Inc.
+ * Minio Client (C) 2017 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,30 +18,21 @@ package cmd
 
 import "github.com/minio/cli"
 
-var (
-	adminFlags = []cli.Flag{}
-)
-
-var adminCmd = cli.Command{
-	Name:            "admin",
-	Usage:           "Manage Minio servers.",
-	Action:          mainAdmin,
-	HideHelpCommand: true,
-	Before:          setGlobalsFromContext,
-	Flags:           append(adminFlags, globalFlags...),
+var adminConfigCmd = cli.Command{
+	Name:   "config",
+	Usage:  "Manage configuration file.",
+	Action: mainAdminConfig,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
 	Subcommands: []cli.Command{
-		adminServiceCmd,
-		adminInfoCmd,
-		adminPasswordCmd,
-		adminConfigCmd,
-		adminLockCmd,
-		adminHealCmd,
+		adminConfigGetCmd,
 	},
+	HideHelpCommand: true,
 }
 
-// mainAdmin is the handle for "mc admin" command.
-func mainAdmin(ctx *cli.Context) error {
+// mainAdminConfig is the handle for "mc admin config" command.
+func mainAdminConfig(ctx *cli.Context) error {
 	cli.ShowCommandHelp(ctx, ctx.Args().First())
 	return nil
-	// Sub-commands like "service", "heal", "lock" have their own main.
+	// Sub-commands like "get", "set" have their own main.
 }


### PR DESCRIPTION
The new command is `mc admin config get alias/` and returns a plain config file 

Fixes #2034 