### PR TITLE
	difference() sends errors on channel

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -173,6 +173,10 @@ func doDiffMain(firstURL, secondURL string) error {
 
 	// Diff first and second urls.
 	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL) {
+		if diffMsg.Error != nil {
+			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
+			break
+		}
 		printMsg(diffMsg)
 	}
 

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -581,6 +581,9 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context) *probe.Error {
 	if mirrorAllBuckets {
 		// Synchronize buckets using dirDifference function
 		for d := range dirDifference(srcClt, dstClt, srcURL, dstURL) {
+			if d.Error != nil {
+				mj.status.fatalIf(d.Error, fmt.Sprintf("Failed to start monitoring."))
+			}
 			if d.Diff == differInSecond {
 				// Ignore buckets that only exist in target instance
 				continue

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -97,6 +97,10 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 
 	// List both source and target, compare and return values through channel.
 	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL) {
+		if diffMsg.Error != nil {
+			errorIf(diffMsg.Error, "Unable to mirror objects.")
+			break
+		}
 		switch diffMsg.Diff {
 		case differInNone:
 			// No difference, continue.


### PR DESCRIPTION
It doesn't make sense to continue to calculate to the difference
between the source and target when source or target returns a listing error

Fixes 2^11 (#2048)