### PR TITLE
admin: Add set config command

### DIFF
--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -1,0 +1,134 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minio/pkg/madmin"
+	"github.com/minio/minio/pkg/probe"
+)
+
+var adminConfigSetCmd = cli.Command{
+	Name:   "set",
+	Usage:  "Set new config file to a Minio server/cluster.",
+	Before: setGlobalsFromContext,
+	Action: mainAdminConfigSet,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} ALIAS/
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Set server configuration of a Minio server/cluster.
+     $ cat myconfig | {{.HelpName}} myminio/
+
+`,
+}
+
+// configSetMessage container to hold locks information.
+type configSetMessage struct {
+	Status               string `json:"status"`
+	setConfigStatus      bool
+	SetConfigNodeSummary []madmin.NodeSummary `json:"nodesSummary"`
+}
+
+// String colorized service status message.
+func (u configSetMessage) String() (msg string) {
+	// For each node, print if set config was successful or not
+	for _, s := range u.SetConfigNodeSummary {
+		if s.ErrSet {
+			// An error occurred when setting the new config
+			msg += console.Colorize("SetConfigFailure",
+				fmt.Sprintf("Failed to apply the new configuration to `%s` (%s).", s.Name, s.ErrMsg))
+		} else {
+			msg += console.Colorize("SetConfigSuccess",
+				fmt.Sprintf("New configuration applied to `%s` successfully.", s.Name))
+		}
+		msg += "\n"
+	}
+	// Print the general set config status
+	if u.setConfigStatus {
+		msg += console.Colorize("SetConfigSuccess",
+			"Setting new Minio configuration file has been successful.\n")
+	} else {
+		msg += console.Colorize("SetConfigFailure",
+			"Setting new Minio configuration file has failed.\n")
+	}
+	return
+}
+
+// JSON jsonified service status Message message.
+func (u configSetMessage) JSON() string {
+	if u.setConfigStatus {
+		u.Status = "success"
+	} else {
+		u.Status = "error"
+	}
+	statusJSONBytes, e := json.Marshal(u)
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(statusJSONBytes)
+}
+
+// checkAdminConfigSetSyntax - validate all the passed arguments
+func checkAdminConfigSetSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 || len(ctx.Args()) > 2 {
+		cli.ShowCommandHelpAndExit(ctx, "set", 1) // last argument is exit code
+	}
+}
+
+// main config set function
+func mainAdminConfigSet(ctx *cli.Context) error {
+
+	// Check command arguments
+	checkAdminConfigSetSyntax(ctx)
+
+	// Set color preference of command outputs
+	console.SetColor("SetConfigSuccess", color.New(color.FgGreen, color.Bold))
+	console.SetColor("SetConfigFailure", color.New(color.FgRed, color.Bold))
+
+	// Get the alias parameter from cli
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new Minio Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Cannot get a configured admin connection.")
+
+	// Call get config API
+	c, e := client.SetConfig(os.Stdin)
+	fatalIf(probe.NewError(e), "Cannot get server configuration file.")
+
+	// Print set config result
+	printMsg(configSetMessage{
+		setConfigStatus:      c.Status,
+		SetConfigNodeSummary: c.NodeResults,
+	})
+
+	return nil
+}

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -26,6 +26,7 @@ var adminConfigCmd = cli.Command{
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminConfigGetCmd,
+		adminConfigSetCmd,
 	},
 	HideHelpCommand: true,
 }

--- a/vendor/github.com/minio/minio/pkg/madmin/API.md
+++ b/vendor/github.com/minio/minio/pkg/madmin/API.md
@@ -39,7 +39,7 @@ func main() {
 | Service operations|LockInfo operations|Healing operations|Config operations| Misc |
 |:---|:---|:---|:---|:---|
 |[`ServiceStatus`](#ServiceStatus)| [`ListLocks`](#ListLocks)| [`ListObjectsHeal`](#ListObjectsHeal)|[`GetConfig`](#GetConfig)| [`SetCredentials`](#SetCredentials)|
-|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)|||
+|[`ServiceRestart`](#ServiceRestart)| [`ClearLocks`](#ClearLocks)| [`ListBucketsHeal`](#ListBucketsHeal)|[`SetConfig`](#SetConfig)||
 | | |[`HealBucket`](#HealBucket) |||
 | | |[`HealObject`](#HealObject)|||
 | | |[`HealFormat`](#HealFormat)|||
@@ -306,7 +306,7 @@ __Example__
 
 <a name="SetCredentials"></a>
 
-### SetCredentials() error 
+### SetCredentials() error
 Set new credentials of a Minio setup.
 
 __Example__
@@ -320,4 +320,36 @@ __Example__
 
 ```
 
+<a name="SetConfig"></a>
+### SetConfig(config io.Reader) (SetConfigResult, error)
+Set config.json of a minio setup and restart setup for configuration
+change to take effect.
 
+
+| Param  | Type  | Description  |
+|---|---|---|
+|`st.Status`            | _bool_  | true if set-config succeeded, false otherwise. |
+|`st.NodeSummary.Name`  | _string_  | Network address of the node. |
+|`st.NodeSummary.ErrSet`   | _bool_ | Bool representation indicating if an error is encountered with the node.|
+|`st.NodeSummary.ErrMsg`   | _string_ | String representation of the error (if any) on the node.|
+
+
+__Example__
+
+``` go
+    config := bytes.NewReader([]byte(`config.json contents go here`))
+    result, err := madmClnt.SetConfig(config)
+    if err != nil {
+        log.Fatalf("failed due to: %v", err)
+    }
+
+    var buf bytes.Buffer
+    enc := json.NewEncoder(&buf)
+    enc.SetEscapeHTML(false)
+    enc.SetIndent("", "\t")
+    err = enc.Encode(result)
+    if err != nil {
+        log.Fatalln(err)
+    }
+    log.Println("SetConfig: ", string(buf.Bytes()))
+```

--- a/vendor/github.com/minio/minio/pkg/madmin/config-commands.go
+++ b/vendor/github.com/minio/minio/pkg/madmin/config-commands.go
@@ -18,15 +18,37 @@
 package madmin
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 )
 
+const (
+	configQueryParam = "config"
+)
+
+// NodeSummary - represents the result of an operation part of
+// set-config on a node.
+type NodeSummary struct {
+	Name   string `json:"name"`
+	ErrSet bool   `json:"errSet"`
+	ErrMsg string `json:"errMsg"`
+}
+
+// SetConfigResult - represents detailed results of a set-config
+// operation.
+type SetConfigResult struct {
+	NodeResults []NodeSummary `json:"nodeResults"`
+	Status      bool          `json:"status"`
+}
+
 // GetConfig - returns the config.json of a minio setup.
 func (adm *AdminClient) GetConfig() ([]byte, error) {
 	queryVal := make(url.Values)
-	queryVal.Set("config", "")
+	queryVal.Set(configQueryParam, "")
 
 	hdrs := make(http.Header)
 	hdrs.Set(minioAdminOpHeader, "get")
@@ -36,7 +58,7 @@ func (adm *AdminClient) GetConfig() ([]byte, error) {
 		customHeaders: hdrs,
 	}
 
-	// Execute GET on /?lock to list locks.
+	// Execute GET on /?config to get config of a setup.
 	resp, err := adm.executeMethod("GET", reqData)
 
 	defer closeResponse(resp)
@@ -44,6 +66,59 @@ func (adm *AdminClient) GetConfig() ([]byte, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp)
+	}
+
 	// Return the JSON marshalled bytes to user.
 	return ioutil.ReadAll(resp.Body)
+}
+
+// SetConfig - set config supplied as config.json for the setup.
+func (adm *AdminClient) SetConfig(config io.Reader) (SetConfigResult, error) {
+	queryVal := url.Values{}
+	queryVal.Set(configQueryParam, "")
+
+	// Set x-minio-operation to set.
+	hdrs := make(http.Header)
+	hdrs.Set(minioAdminOpHeader, "set")
+
+	// Read config bytes to calculate MD5, SHA256 and content length.
+	configBytes, err := ioutil.ReadAll(config)
+	if err != nil {
+		return SetConfigResult{}, err
+	}
+
+	reqData := requestData{
+		queryValues:        queryVal,
+		customHeaders:      hdrs,
+		contentBody:        bytes.NewReader(configBytes),
+		contentMD5Bytes:    sumMD5(configBytes),
+		contentSHA256Bytes: sum256(configBytes),
+	}
+
+	// Execute PUT on /?config to set config.
+	resp, err := adm.executeMethod("PUT", reqData)
+
+	defer closeResponse(resp)
+	if err != nil {
+		return SetConfigResult{}, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return SetConfigResult{}, httpRespToErrorResponse(resp)
+	}
+
+	var result SetConfigResult
+	jsonBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return SetConfigResult{}, err
+	}
+
+	err = json.Unmarshal(jsonBytes, &result)
+	if err != nil {
+		return SetConfigResult{}, err
+	}
+
+	return result, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -80,10 +80,10 @@
 			"revisionTime": "2016-08-18T00:31:20Z"
 		},
 		{
-			"checksumSHA1": "YXWc03D9uOm36IsMc5jNVFrtgY4=",
+			"checksumSHA1": "U2PFIqUAO4PpfqYZhouq/7KCXkU=",
 			"path": "github.com/minio/minio/pkg/madmin",
-			"revision": "f170f7b9d828ebc59b5cc53be1b7a997c87ea8dd",
-			"revisionTime": "2017-02-25T15:19:50Z"
+			"revision": "e5d4e7aa9d7ba16bbf0c0fe135eb05102132b528",
+			"revisionTime": "2017-03-03T11:01:42Z"
 		},
 		{
 			"path": "github.com/minio/minio/pkg/probe",


### PR DESCRIPTION
Currently, it only work this way `cat config.json | mc admin config set myminio/`, 

Can we discuss if we need to add other way to pass the new config file ?