### PR TITLE
[PROPOSAL] Add size output for `diff` command.

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/console"
@@ -29,7 +30,12 @@ import (
 
 // diff specific flags.
 var (
-	diffFlags = []cli.Flag{}
+	diffFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "size",
+			Usage: "Prints the diff in size from source and target",
+		},
+	}
 )
 
 // Compute differences between two files or folders.
@@ -67,9 +73,31 @@ type diffMessage struct {
 	FirstURL      string       `json:"first"`
 	SecondURL     string       `json:"second"`
 	Diff          differType   `json:"diff"`
+	FirstSize     int64        `json:"firstSize"`
+	SecondSize    int64        `json:"secondSize"`
 	Error         *probe.Error `json:"error,omitempty"`
 	firstContent  *clientContent
 	secondContent *clientContent
+}
+
+type diffTotalSize struct {
+	Status     string `json:"status"`
+	SourceSize int64  `json:"sourceSize"`
+	TargetSize int64  `json:"targetSize"`
+}
+
+func (t diffTotalSize) String() string {
+	msg := console.Colorize("DiffSize", fmt.Sprintf("SourceSize: %s TargetSize: %s",
+		humanize.IBytes(uint64(t.SourceSize)),
+		humanize.IBytes(uint64(t.TargetSize))))
+	return msg
+}
+
+func (t diffTotalSize) JSON() string {
+	t.Status = "success"
+	diffJSONBytes, e := json.Marshal(t)
+	fatalIf(probe.NewError(e), "Unable to marshal diff total size message")
+	return string(diffJSONBytes)
 }
 
 // String colorized diff message
@@ -144,7 +172,7 @@ func checkDiffSyntax(ctx *cli.Context) {
 }
 
 // doDiffMain runs the diff.
-func doDiffMain(firstURL, secondURL string) error {
+func doDiffMain(firstURL, secondURL string, isSize bool) error {
 	// Source and targets are always directories
 	sourceSeparator := string(newClientURL(firstURL).Separator)
 	if !strings.HasSuffix(firstURL, sourceSeparator) {
@@ -171,15 +199,26 @@ func doDiffMain(firstURL, secondURL string) error {
 			fmt.Sprintf("Failed to diff '%s' and '%s'", firstURL, secondURL))
 	}
 
+	var firstSize, secondSize int64
 	// Diff first and second urls.
 	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
 			break
 		}
+		if diffMsg.Diff == differInFirst {
+			firstSize += diffMsg.FirstSize
+		} else if diffMsg.Diff == differInSecond {
+			secondSize += diffMsg.SecondSize
+		}
 		printMsg(diffMsg)
 	}
-
+	if isSize {
+		printMsg(diffTotalSize{
+			SourceSize: firstSize,
+			TargetSize: secondSize,
+		})
+	}
 	return nil
 }
 
@@ -200,5 +239,7 @@ func mainDiff(ctx *cli.Context) error {
 	firstURL := URLs.Get(0)
 	secondURL := URLs.Get(1)
 
-	return doDiffMain(firstURL, secondURL)
+	isSize := ctx.Bool("size")
+
+	return doDiffMain(firstURL, secondURL, isSize)
 }

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -108,6 +108,7 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 				diffCh <- diffMessage{
 					SecondURL:     tgtCtnt.URL.String(),
 					Diff:          differInSecond,
+					SecondSize:    tgtCtnt.Size,
 					secondContent: tgtCtnt,
 				}
 				tgtCtnt, tgtOk = <-tgtCh
@@ -119,6 +120,7 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 				diffCh <- diffMessage{
 					FirstURL:     srcCtnt.URL.String(),
 					Diff:         differInFirst,
+					FirstSize:    srcCtnt.Size,
 					firstContent: srcCtnt,
 				}
 				srcCtnt, srcOk = <-srcCh
@@ -153,6 +155,7 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 				diffCh <- diffMessage{
 					FirstURL:     srcCtnt.URL.String(),
 					Diff:         differInFirst,
+					FirstSize:    srcCtnt.Size,
 					firstContent: srcCtnt,
 				}
 				srcCtnt, srcOk = <-srcCh
@@ -163,7 +166,7 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 				srcSize, tgtSize := srcCtnt.Size, tgtCtnt.Size
 				if srcType.IsRegular() && !tgtType.IsRegular() ||
 					!srcType.IsRegular() && tgtType.IsRegular() {
-					// Type differes. Source is never a directory.
+					// Type differs. Source is never a directory.
 					diffCh <- diffMessage{
 						FirstURL:      srcCtnt.URL.String(),
 						SecondURL:     tgtCtnt.URL.String(),
@@ -172,11 +175,13 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 						secondContent: tgtCtnt,
 					}
 				} else if (srcType.IsRegular() && tgtType.IsRegular()) && srcSize != tgtSize {
-					// Regular files differing in size.
+					// Regular files to differ in size.
 					diffCh <- diffMessage{
 						FirstURL:      srcCtnt.URL.String(),
 						SecondURL:     tgtCtnt.URL.String(),
 						Diff:          differInSize,
+						FirstSize:     srcCtnt.Size,
+						SecondSize:    tgtCtnt.Size,
 						firstContent:  srcCtnt,
 						secondContent: tgtCtnt,
 					}
@@ -187,6 +192,8 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 						FirstURL:      srcCtnt.URL.String(),
 						SecondURL:     tgtCtnt.URL.String(),
 						Diff:          differInNone,
+						FirstSize:     srcCtnt.Size,
+						SecondSize:    tgtCtnt.Size,
 						firstContent:  srcCtnt,
 						secondContent: tgtCtnt,
 					}
@@ -199,6 +206,7 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 			diffCh <- diffMessage{
 				SecondURL:     tgtCtnt.URL.String(),
 				Diff:          differInSecond,
+				SecondSize:    tgtCtnt.Size,
 				secondContent: tgtCtnt,
 			}
 			tgtCtnt, tgtOk = <-tgtCh


### PR DESCRIPTION
It is useful to know before hand what will be total
size to be copied when a user initiates `mc mirror`