### PR TITLE
admin: HealObjectInfo can be nil skip it.

### DIFF
--- a/cmd/admin-heal-list.go
+++ b/cmd/admin-heal-list.go
@@ -205,6 +205,10 @@ func mainAdminHealList(ctx *cli.Context) error {
 				errorIf(probe.NewError(obj.Err), "Cannot heal object `"+obj.Key+"`.")
 				continue
 			}
+			// Skip for non-recursive use case.
+			if obj.HealObjectInfo == nil {
+				continue
+			}
 			printMsg(healListMessage{Bucket: currBucket, Object: obj})
 		}
 	}

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -159,6 +159,10 @@ func mainAdminHeal(ctx *cli.Context) error {
 			errorIf(probe.NewError(obj.Err), "Cannot list objects to be healed.")
 			continue
 		}
+		// Heal object info is nil skip it, must be a directory.
+		if obj.HealObjectInfo == nil {
+			continue
+		}
 
 		// Check the heal status, and call heal object API only when an object can be healed
 		switch healInfo := *obj.HealObjectInfo; healInfo.Status {


### PR DESCRIPTION
Fixes #2058