### PR TITLE
Improve admin subcommand structure

### DIFF
--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -20,7 +20,7 @@ import "github.com/minio/cli"
 
 var adminConfigCmd = cli.Command{
 	Name:   "config",
-	Usage:  "Manage configuration file.",
+	Usage:  "Manage configuration file",
 	Action: mainAdminConfig,
 	Before: setGlobalsFromContext,
 	Flags:  globalFlags,

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -33,15 +33,15 @@ var (
 	adminHealFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "recursive, r",
-			Usage: "Heal recursively.",
+			Usage: "Heal recursively",
 		},
 		cli.BoolFlag{
 			Name:  "fake, k",
-			Usage: "Issue a fake heal operation.",
+			Usage: "Issue a fake heal operation",
 		},
 		cli.BoolFlag{
 			Name:  "incomplete, I",
-			Usage: "Heal uploads recursively.",
+			Usage: "Heal uploads recursively",
 		},
 	}
 )
@@ -62,10 +62,10 @@ EXAMPLES:
     1. Heal 'testbucket' in a Minio server represented by its alias 'play'.
        $ {{.HelpName}} play/testbucket/
 
-    2. Heal all objects under 'dir' prefix 
+    2. Heal all objects under 'dir' prefix
        $ {{.HelpName}} --recursive play/testbucket/dir/
 
-    3. Heal all uploads under 'dir' prefix 
+    3. Heal all uploads under 'dir' prefix
        $ {{.HelpName}} --incomplete --recursive play/testbucket/dir/
 
     4. Issue a fake heal operation to see what the server could report
@@ -74,7 +74,7 @@ EXAMPLES:
 `
 var adminHealCmd = cli.Command{
 	Name:   "heal",
-	Usage:  "Manage heal tasks.",
+	Usage:  "Manage heal tasks",
 	Before: setGlobalsFromContext,
 	Action: mainAdminHeal,
 	Flags:  append(adminHealFlags, globalFlags...),

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -35,7 +35,7 @@ var (
 
 var adminInfoCmd = cli.Command{
 	Name:   "info",
-	Usage:  "Get information of a Minio server",
+	Usage:  "Get Minio server information",
 	Action: mainAdminInfo,
 	Before: setGlobalsFromContext,
 	Flags:  append(adminInfoFlags, globalFlags...),

--- a/cmd/admin-lock-list.go
+++ b/cmd/admin-lock-list.go
@@ -31,7 +31,7 @@ var (
 	adminLockListFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "duration, d",
-			Usage: "Only show locks that are hold for longer than NN[h|m|s].",
+			Usage: "Only show locks that are held for longer than NN[h|m|s]",
 			Value: "24h",
 		},
 	}
@@ -39,7 +39,7 @@ var (
 
 var adminLockListCmd = cli.Command{
 	Name:   "list",
-	Usage:  "Get the list of locks hold in a given Minio server",
+	Usage:  "List locks held in a given Minio server",
 	Action: mainAdminLockList,
 	Before: setGlobalsFromContext,
 	Flags:  append(adminLockListFlags, globalFlags...),
@@ -53,13 +53,13 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-    1. List hold locks related to testbucket in a Minio server represented by its alias 'play'.
+    1. List locks held on 'testbucket' in a Minio server with alias 'play'.
        $ {{.HelpName}} play/testbucket/
 
-    2. List locks that are hold for more than 15 minutes.
+    2. List locks held on 'testbucket' for more than 15 minutes.
        $ {{.HelpName}} --duration 15m play/testbucket/
 
-    3. List locks hold by all objects under dir prefix
+    3. List locks held on all objects under prefix 'dir'.
        $ {{.HelpName}} play/testbucket/dir/
 
 `,

--- a/cmd/admin-lock.go
+++ b/cmd/admin-lock.go
@@ -24,7 +24,7 @@ var (
 
 var adminLockCmd = cli.Command{
 	Name:   "lock",
-	Usage:  "Control locks in servers.",
+	Usage:  "Control locks in servers",
 	Action: mainAdminLock,
 	Before: setGlobalsFromContext,
 	Flags:  append(adminLockFlags, globalFlags...),

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -32,7 +32,7 @@ var adminCmd = cli.Command{
 	Subcommands: []cli.Command{
 		adminServiceCmd,
 		adminInfoCmd,
-		adminPasswordCmd,
+		adminCredsCmd,
 		adminConfigCmd,
 		adminLockCmd,
 		adminHealCmd,

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -24,7 +24,7 @@ var (
 
 var adminCmd = cli.Command{
 	Name:            "admin",
-	Usage:           "Manage Minio servers.",
+	Usage:           "Manage Minio servers",
 	Action:          mainAdmin,
 	HideHelpCommand: true,
 	Before:          setGlobalsFromContext,

--- a/cmd/admin-password.go
+++ b/cmd/admin-password.go
@@ -22,14 +22,16 @@ import (
 )
 
 var (
-	adminPasswordFlags = []cli.Flag{}
+	adminCredsFlags = []cli.Flag{}
 )
 
-var adminPasswordCmd = cli.Command{
-	Name:   "password",
+const credsCmdName = "credentials"
+
+var adminCredsCmd = cli.Command{
+	Name:   credsCmdName,
 	Usage:  "Change server access and secret keys.",
-	Action: mainAdminPassword,
-	Flags:  append(adminPasswordFlags, globalFlags...),
+	Action: mainAdminCreds,
+	Flags:  append(adminCredsFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
@@ -46,30 +48,31 @@ EXAMPLES:
 `,
 }
 
-// checkAdminPasswordSyntax - validate all the passed arguments
-func checkAdminPasswordSyntax(ctx *cli.Context) {
+// checkAdminCredsSyntax - validate all the passed arguments
+func checkAdminCredsSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 3 {
-		cli.ShowCommandHelpAndExit(ctx, "password", 1) // last argument is exit code
+		cli.ShowCommandHelpAndExit(ctx, credsCmdName, 1) // last argument is exit code
 	}
 }
 
-func mainAdminPassword(ctx *cli.Context) error {
+func mainAdminCreds(ctx *cli.Context) error {
 
 	setGlobalsFromContext(ctx)
 
-	checkAdminPasswordSyntax(ctx)
+	checkAdminCredsSyntax(ctx)
 
 	// Get the alias parameter from cli
 	args := ctx.Args()
-	aliasedURL := args.Get(0)
-	accessKey := args.Get(1)
-	secretKey := args.Get(2)
+	// TODO: if accessKey and secretKey are not supplied we should
+	// display the existing credentials. This needs GetCredentials
+	// support from Minio server.
+	accessKey, secretKey, aliasedURL := args.Get(0), args.Get(1), args.Get(2)
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 
-	// Change the password of the specified Minio server
+	// Change the credentials of the specified Minio server
 	e := client.SetCredentials(accessKey, secretKey)
 	fatalIf(probe.NewError(e), "Unable to set new credentials to '"+aliasedURL+"'")
 

--- a/cmd/admin-password.go
+++ b/cmd/admin-password.go
@@ -29,7 +29,7 @@ const credsCmdName = "credentials"
 
 var adminCredsCmd = cli.Command{
 	Name:   credsCmdName,
-	Usage:  "Change server access and secret keys.",
+	Usage:  "Change server access and secret keys",
 	Action: mainAdminCreds,
 	Flags:  append(adminCredsFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -20,7 +20,7 @@ import "github.com/minio/cli"
 
 var adminServiceCmd = cli.Command{
 	Name:            "service",
-	Usage:           "Control servers.",
+	Usage:           "Control servers",
 	Action:          mainAdminService,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -130,7 +130,7 @@ func checkRmSyntax(ctx *cli.Context) {
 	// For all recursive operations make sure to check for 'force' flag.
 	if (isRecursive || isStdin) && !isForce {
 		fatalIf(errDummy().Trace(),
-			"Removal requires --force option. This operational is *IRREVERSIBLE*. Please review carefully before performing this *DANGEROUS* operation.")
+			"Removal requires --force option. This operation is *IRREVERSIBLE*. Please review carefully before performing this *DANGEROUS* operation.")
 	}
 }
 


### PR DESCRIPTION
The proposal for changed `mc-admin` command structure is captured here: https://gist.github.com/krisis/98f4171e12bed9e9c022cd79b74db754. Removal of `heal-list` in favour of `--fake` flag is missing.