### PR TITLE
Fix for issue #2093 NAME:

### DIFF
--- a/cmd/share-list-main.go
+++ b/cmd/share-list-main.go
@@ -43,7 +43,7 @@ COMMAND:
    download: list previously shared access to downloads.
 
 USAGE:
-   {{.HelpName}}
+   {{.HelpName}} COMMAND
 
 EXAMPLES:
    1. List previously shared downloads, that haven't expired yet.


### PR DESCRIPTION
   The `mc share list` help text misleading...