### PR TITLE
trace: Avoid httputil for less memory consumption

### DIFF
--- a/cmd/client-s3-trace_v2.go
+++ b/cmd/client-s3-trace_v2.go
@@ -18,8 +18,8 @@ package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 	"strings"
 
 	"github.com/minio/mc/pkg/console"
@@ -45,11 +45,17 @@ func (t traceV2) Request(req *http.Request) (err error) {
 		// Set a temporary redacted auth
 		req.Header.Set("Authorization", "AWS **REDACTED**:**REDACTED**")
 
-		var reqTrace []byte
-		reqTrace, err = httputil.DumpRequestOut(req, false) // Only display header
-		if err == nil {
-			console.Debug(string(reqTrace))
+		// Store headers in buf
+		var buf bytes.Buffer
+		if err = req.Header.Write(&buf); err != nil {
+			return err
 		}
+
+		// Add headers to the debug text
+		reqTrace := append(buf.Bytes(), []byte("\r\n")...)
+
+		// Print debug information
+		console.Debug(string(reqTrace))
 
 		// Undo
 		req.Header.Set("Authorization", origAuth)
@@ -59,35 +65,34 @@ func (t traceV2) Request(req *http.Request) (err error) {
 
 // Response - Trace HTTP Response
 func (t traceV2) Response(resp *http.Response) (err error) {
-	var respTrace []byte
+
+	// Store headers in buf
+	var buf bytes.Buffer
+	if err = resp.Header.Write(&buf); err != nil {
+		return err
+	}
+
+	// Build debug message and add headers information
+	respTrace := append(buf.Bytes(), []byte("\r\n")...)
+
 	// For errors we make sure to dump response body as well.
 	if resp.StatusCode != http.StatusOK &&
 		resp.StatusCode != http.StatusPartialContent &&
 		resp.StatusCode != http.StatusNoContent {
-		respTrace, err = httputil.DumpResponse(resp, true)
-	} else {
-		// WORKAROUND for https://github.com/golang/go/issues/13942.
-		// httputil.DumpResponse does not print response headers for
-		// all successful calls which have response ContentLength set
-		// to zero. Keep this workaround until the above bug is fixed.
-		if resp.ContentLength == 0 {
-			var buffer bytes.Buffer
-			if err = resp.Header.Write(&buffer); err != nil {
-				return err
-			}
-			respTrace = buffer.Bytes()
-			respTrace = append(respTrace, []byte("\r\n")...)
-		} else {
-			respTrace, err = httputil.DumpResponse(resp, false)
-			if err != nil {
-				return err
-			}
+		// Load response body
+		respBody, rErr := ioutil.ReadAll(resp.Body)
+		if rErr != nil {
+			return rErr
 		}
-	}
-	if err == nil {
-		console.Debug(string(respTrace))
+		// Append response body to the debug text
+		respTrace = append(respTrace, respBody...)
+		respTrace = append(respTrace, []byte("\r\n")...)
 	}
 
+	// Print debug
+	console.Debug(string(respTrace))
+
+	// Print TLS certificates if applicable
 	if globalInsecure && resp.TLS != nil {
 		dumpTLSCertificates(resp.TLS)
 	}

--- a/cmd/client-s3-trace_v4.go
+++ b/cmd/client-s3-trace_v4.go
@@ -18,8 +18,8 @@ package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 	"regexp"
 	"strings"
 
@@ -54,11 +54,17 @@ func (t traceV4) Request(req *http.Request) (err error) {
 		// Set a temporary redacted auth
 		req.Header.Set("Authorization", newAuth)
 
-		var reqTrace []byte
-		reqTrace, err = httputil.DumpRequestOut(req, false) // Only display header
-		if err == nil {
-			console.Debug(string(reqTrace))
+		// Store requests headers in buf
+		var buf bytes.Buffer
+		if err = req.Header.Write(&buf); err != nil {
+			return err
 		}
+
+		// Build debug and add headers
+		reqTrace := append(buf.Bytes(), []byte("\r\n")...)
+
+		// Print debug text
+		console.Debug(string(reqTrace))
 
 		// Undo
 		req.Header.Set("Authorization", origAuth)
@@ -68,35 +74,34 @@ func (t traceV4) Request(req *http.Request) (err error) {
 
 // Response - Trace HTTP Response
 func (t traceV4) Response(resp *http.Response) (err error) {
-	var respTrace []byte
+
+	// Store headers in buf
+	var buf bytes.Buffer
+	if err = resp.Header.Write(&buf); err != nil {
+		return err
+	}
+
+	// Build debug text and add headers
+	respTrace := append(buf.Bytes(), []byte("\r\n")...)
+
 	// For errors we make sure to dump response body as well.
 	if resp.StatusCode != http.StatusOK &&
 		resp.StatusCode != http.StatusPartialContent &&
 		resp.StatusCode != http.StatusNoContent {
-		respTrace, err = httputil.DumpResponse(resp, true)
-	} else {
-		// WORKAROUND for https://github.com/golang/go/issues/13942.
-		// httputil.DumpResponse does not print response headers for
-		// all successful calls which have response ContentLength set
-		// to zero. Keep this workaround until the above bug is fixed.
-		if resp.ContentLength == 0 {
-			var buffer bytes.Buffer
-			if err = resp.Header.Write(&buffer); err != nil {
-				return err
-			}
-			respTrace = buffer.Bytes()
-			respTrace = append(respTrace, []byte("\r\n")...)
-		} else {
-			respTrace, err = httputil.DumpResponse(resp, false)
-			if err != nil {
-				return err
-			}
+		// Load response body
+		respBody, rErr := ioutil.ReadAll(resp.Body)
+		if rErr != nil {
+			return rErr
 		}
-	}
-	if err == nil {
-		console.Debug(string(respTrace))
+		// Add response body to debug text
+		respTrace = append(respTrace, respBody...)
+		respTrace = append(respTrace, []byte("\r\n")...)
 	}
 
+	// Print debug text
+	console.Debug(string(respTrace))
+
+	// Print TLS certificates when applicable
 	if globalInsecure && resp.TLS != nil {
 		dumpTLSCertificates(resp.TLS)
 	}


### PR DESCRIPTION
Rewrite tracing without httputil since it consumes memory with
requests that have huge data.

Copying 829 MiB file when --debug is enabled reduces RSS from ~400 Mb to 14 Mb

Fixes #2086