### PR TITLE
vendor: Update minio-go package

### DIFF
--- a/vendor/github.com/minio/minio-go/api-get-object.go
+++ b/vendor/github.com/minio/minio-go/api-get-object.go
@@ -26,6 +26,29 @@ import (
 	"time"
 )
 
+// GetEncryptedObject deciphers and streams data stored in the server after applying a specifed encryption materiels
+func (c Client) GetEncryptedObject(bucketName, objectName string, encryptMaterials EncryptionMaterials) (io.Reader, error) {
+
+	if encryptMaterials == nil {
+		return nil, ErrInvalidArgument("Unable to recognize empty encryption properties")
+	}
+
+	// Fetch encrypted object
+	encReader, err := c.GetObject(bucketName, objectName)
+	if err != nil {
+		return nil, err
+	}
+	// Stat object to get its encryption metadata
+	st, err := encReader.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	encryptMaterials.SetupDecryptMode(encReader, st.Metadata)
+
+	return encryptMaterials, nil
+}
+
 // GetObject - returns an seekable, readable object.
 func (c Client) GetObject(bucketName, objectName string) (*Object, error) {
 	// Input validation.

--- a/vendor/github.com/minio/minio-go/api-list.go
+++ b/vendor/github.com/minio/minio-go/api-list.go
@@ -347,14 +347,14 @@ func (c Client) ListObjects(bucketName, objectPrefix string, recursive bool, don
 // ?delimiter - A delimiter is a character you use to group keys.
 // ?prefix - Limits the response to keys that begin with the specified prefix.
 // ?max-keys - Sets the maximum number of keys returned in the response body.
-func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimiter string, maxkeys int) (listBucketResult, error) {
+func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimiter string, maxkeys int) (ListBucketResult, error) {
 	// Validate bucket name.
 	if err := isValidBucketName(bucketName); err != nil {
-		return listBucketResult{}, err
+		return ListBucketResult{}, err
 	}
 	// Validate object prefix.
 	if err := isValidObjectPrefix(objectPrefix); err != nil {
-		return listBucketResult{}, err
+		return ListBucketResult{}, err
 	}
 	// Get resources properly escaped and lined up before
 	// using them in http request.
@@ -386,15 +386,15 @@ func (c Client) listObjectsQuery(bucketName, objectPrefix, objectMarker, delimit
 	})
 	defer closeResponse(resp)
 	if err != nil {
-		return listBucketResult{}, err
+		return ListBucketResult{}, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return listBucketResult{}, httpRespToErrorResponse(resp, bucketName, "")
+			return ListBucketResult{}, httpRespToErrorResponse(resp, bucketName, "")
 		}
 	}
 	// Decode listBuckets XML.
-	listBucketResult := listBucketResult{}
+	listBucketResult := ListBucketResult{}
 	err = xmlDecoder(resp.Body, &listBucketResult)
 	if err != nil {
 		return listBucketResult, err
@@ -528,7 +528,7 @@ func (c Client) listIncompleteUploads(bucketName, objectPrefix string, recursive
 // ?delimiter - A delimiter is a character you use to group keys.
 // ?prefix - Limits the response to keys that begin with the specified prefix.
 // ?max-uploads - Sets the maximum number of multipart uploads returned in the response body.
-func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker, prefix, delimiter string, maxUploads int) (listMultipartUploadsResult, error) {
+func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker, prefix, delimiter string, maxUploads int) (ListMultipartUploadsResult, error) {
 	// Get resources properly escaped and lined up before using them in http request.
 	urlValues := make(url.Values)
 	// Set uploads.
@@ -564,15 +564,15 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 	})
 	defer closeResponse(resp)
 	if err != nil {
-		return listMultipartUploadsResult{}, err
+		return ListMultipartUploadsResult{}, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return listMultipartUploadsResult{}, httpRespToErrorResponse(resp, bucketName, "")
+			return ListMultipartUploadsResult{}, httpRespToErrorResponse(resp, bucketName, "")
 		}
 	}
 	// Decode response body.
-	listMultipartUploadsResult := listMultipartUploadsResult{}
+	listMultipartUploadsResult := ListMultipartUploadsResult{}
 	err = xmlDecoder(resp.Body, &listMultipartUploadsResult)
 	if err != nil {
 		return listMultipartUploadsResult, err
@@ -581,10 +581,10 @@ func (c Client) listMultipartUploadsQuery(bucketName, keyMarker, uploadIDMarker,
 }
 
 // listObjectParts list all object parts recursively.
-func (c Client) listObjectParts(bucketName, objectName, uploadID string) (partsInfo map[int]objectPart, err error) {
+func (c Client) listObjectParts(bucketName, objectName, uploadID string) (partsInfo map[int]ObjectPart, err error) {
 	// Part number marker for the next batch of request.
 	var nextPartNumberMarker int
-	partsInfo = make(map[int]objectPart)
+	partsInfo = make(map[int]ObjectPart)
 	for {
 		// Get list of uploaded parts a maximum of 1000 per request.
 		listObjPartsResult, err := c.listObjectPartsQuery(bucketName, objectName, uploadID, nextPartNumberMarker, 1000)
@@ -659,7 +659,7 @@ func (c Client) getTotalMultipartSize(bucketName, objectName, uploadID string) (
 // ?part-number-marker - Specifies the part after which listing should
 // begin.
 // ?max-parts - Maximum parts to be listed per request.
-func (c Client) listObjectPartsQuery(bucketName, objectName, uploadID string, partNumberMarker, maxParts int) (listObjectPartsResult, error) {
+func (c Client) listObjectPartsQuery(bucketName, objectName, uploadID string, partNumberMarker, maxParts int) (ListObjectPartsResult, error) {
 	// Get resources properly escaped and lined up before using them in http request.
 	urlValues := make(url.Values)
 	// Set part number marker.
@@ -682,15 +682,15 @@ func (c Client) listObjectPartsQuery(bucketName, objectName, uploadID string, pa
 	})
 	defer closeResponse(resp)
 	if err != nil {
-		return listObjectPartsResult{}, err
+		return ListObjectPartsResult{}, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return listObjectPartsResult{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return ListObjectPartsResult{}, httpRespToErrorResponse(resp, bucketName, objectName)
 		}
 	}
 	// Decode list object parts XML.
-	listObjectPartsResult := listObjectPartsResult{}
+	listObjectPartsResult := ListObjectPartsResult{}
 	err = xmlDecoder(resp.Body, &listObjectPartsResult)
 	if err != nil {
 		return listObjectPartsResult, err

--- a/vendor/github.com/minio/minio-go/api-put-object-common.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-common.go
@@ -44,7 +44,7 @@ func isReadAt(reader io.Reader) (ok bool) {
 }
 
 // shouldUploadPart - verify if part should be uploaded.
-func shouldUploadPart(objPart objectPart, uploadReq uploadPartReq) bool {
+func shouldUploadPart(objPart ObjectPart, uploadReq uploadPartReq) bool {
 	// If part not found should upload the part.
 	if uploadReq.Part == nil {
 		return true
@@ -185,9 +185,9 @@ func (c Client) newUploadID(bucketName, objectName string, metaData map[string][
 
 // getMpartUploadSession returns the upload id and the uploaded parts to continue a previous upload session
 // or initiate a new multipart session if no current one found
-func (c Client) getMpartUploadSession(bucketName, objectName string, metaData map[string][]string) (string, map[int]objectPart, error) {
+func (c Client) getMpartUploadSession(bucketName, objectName string, metaData map[string][]string) (string, map[int]ObjectPart, error) {
 	// A map of all uploaded parts.
-	var partsInfo map[int]objectPart
+	var partsInfo map[int]ObjectPart
 	var err error
 
 	uploadID, err := c.findUploadID(bucketName, objectName)
@@ -220,7 +220,7 @@ func (c Client) getMpartUploadSession(bucketName, objectName string, metaData ma
 
 	// Allocate partsInfo if not done yet
 	if partsInfo == nil {
-		partsInfo = make(map[int]objectPart)
+		partsInfo = make(map[int]ObjectPart)
 	}
 
 	return uploadID, partsInfo, nil

--- a/vendor/github.com/minio/minio-go/api-put-object-file.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-file.go
@@ -228,7 +228,7 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 				}
 
 				// Create the part to be uploaded.
-				verifyObjPart := objectPart{
+				verifyObjPart := ObjectPart{
 					ETag:       hex.EncodeToString(hashSums["md5"]),
 					PartNumber: uploadReq.PartNum,
 					Size:       partSize,
@@ -242,7 +242,7 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 				// Verify if part should be uploaded.
 				if shouldUploadPart(verifyObjPart, uploadReq) {
 					// Proceed to upload the part.
-					var objPart objectPart
+					var objPart ObjectPart
 					objPart, err = c.uploadPart(bucketName, objectName, uploadID, sectionReader, uploadReq.PartNum, hashSums["md5"], hashSums["sha256"], prtSize)
 					if err != nil {
 						uploadedPartsCh <- uploadedPartRes{
@@ -285,7 +285,7 @@ func (c Client) putObjectMultipartFromFile(bucketName, objectName string, fileRe
 			}
 		}
 		// Store the part to be completed.
-		complMultipartUpload.Parts = append(complMultipartUpload.Parts, completePart{
+		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,
 			PartNumber: part.PartNumber,
 		})

--- a/vendor/github.com/minio/minio-go/api-put-object-multipart.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-multipart.go
@@ -125,13 +125,13 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		part, ok := partsInfo[partNumber]
 
 		// Verify if part should be uploaded.
-		if !ok || shouldUploadPart(objectPart{
+		if !ok || shouldUploadPart(ObjectPart{
 			ETag:       hex.EncodeToString(hashSums["md5"]),
 			PartNumber: partNumber,
 			Size:       prtSize,
 		}, uploadPartReq{PartNum: partNumber, Part: &part}) {
 			// Proceed to upload the part.
-			var objPart objectPart
+			var objPart ObjectPart
 			objPart, err = c.uploadPart(bucketName, objectName, uploadID, reader, partNumber, hashSums["md5"], hashSums["sha256"], prtSize)
 			if err != nil {
 				// Reset the temporary buffer upon any error.
@@ -179,7 +179,7 @@ func (c Client) putObjectMultipartStream(bucketName, objectName string, reader i
 		if !ok {
 			return 0, ErrInvalidArgument(fmt.Sprintf("Missing part number %d", i))
 		}
-		complMultipartUpload.Parts = append(complMultipartUpload.Parts, completePart{
+		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,
 			PartNumber: part.PartNumber,
 		})
@@ -251,25 +251,25 @@ func (c Client) initiateMultipartUpload(bucketName, objectName string, metaData 
 }
 
 // uploadPart - Uploads a part in a multipart upload.
-func (c Client) uploadPart(bucketName, objectName, uploadID string, reader io.Reader, partNumber int, md5Sum, sha256Sum []byte, size int64) (objectPart, error) {
+func (c Client) uploadPart(bucketName, objectName, uploadID string, reader io.Reader, partNumber int, md5Sum, sha256Sum []byte, size int64) (ObjectPart, error) {
 	// Input validation.
 	if err := isValidBucketName(bucketName); err != nil {
-		return objectPart{}, err
+		return ObjectPart{}, err
 	}
 	if err := isValidObjectName(objectName); err != nil {
-		return objectPart{}, err
+		return ObjectPart{}, err
 	}
 	if size > maxPartSize {
-		return objectPart{}, ErrEntityTooLarge(size, maxPartSize, bucketName, objectName)
+		return ObjectPart{}, ErrEntityTooLarge(size, maxPartSize, bucketName, objectName)
 	}
 	if size <= -1 {
-		return objectPart{}, ErrEntityTooSmall(size, bucketName, objectName)
+		return ObjectPart{}, ErrEntityTooSmall(size, bucketName, objectName)
 	}
 	if partNumber <= 0 {
-		return objectPart{}, ErrInvalidArgument("Part number cannot be negative or equal to zero.")
+		return ObjectPart{}, ErrInvalidArgument("Part number cannot be negative or equal to zero.")
 	}
 	if uploadID == "" {
-		return objectPart{}, ErrInvalidArgument("UploadID cannot be empty.")
+		return ObjectPart{}, ErrInvalidArgument("UploadID cannot be empty.")
 	}
 
 	// Get resources properly escaped and lined up before using them in http request.
@@ -293,15 +293,15 @@ func (c Client) uploadPart(bucketName, objectName, uploadID string, reader io.Re
 	resp, err := c.executeMethod("PUT", reqMetadata)
 	defer closeResponse(resp)
 	if err != nil {
-		return objectPart{}, err
+		return ObjectPart{}, err
 	}
 	if resp != nil {
 		if resp.StatusCode != http.StatusOK {
-			return objectPart{}, httpRespToErrorResponse(resp, bucketName, objectName)
+			return ObjectPart{}, httpRespToErrorResponse(resp, bucketName, objectName)
 		}
 	}
 	// Once successfully uploaded, return completed part.
-	objPart := objectPart{}
+	objPart := ObjectPart{}
 	objPart.Size = size
 	objPart.PartNumber = partNumber
 	// Trim off the odd double quotes from ETag in the beginning and end.

--- a/vendor/github.com/minio/minio-go/api-put-object-progress.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-progress.go
@@ -30,6 +30,27 @@ func (c Client) PutObjectWithProgress(bucketName, objectName string, reader io.R
 	return c.PutObjectWithMetadata(bucketName, objectName, reader, metaData, progress)
 }
 
+// PutEncryptedObject - Encrypt and store object.
+func (c Client) PutEncryptedObject(bucketName, objectName string, reader io.Reader, encryptMaterials EncryptionMaterials, metaData map[string][]string, progress io.Reader) (n int64, err error) {
+
+	if encryptMaterials == nil {
+		return 0, ErrInvalidArgument("Unable to recognize empty encryption properties")
+	}
+
+	if err := encryptMaterials.SetupEncryptMode(reader); err != nil {
+		return 0, err
+	}
+
+	if metaData == nil {
+		metaData = make(map[string][]string)
+	}
+	for k, v := range encryptMaterials.GetHeaders() {
+		metaData[k] = v
+	}
+
+	return c.PutObjectWithMetadata(bucketName, objectName, encryptMaterials, metaData, progress)
+}
+
 // PutObjectWithMetadata - with metadata.
 func (c Client) PutObjectWithMetadata(bucketName, objectName string, reader io.Reader, metaData map[string][]string, progress io.Reader) (n int64, err error) {
 	// Input validation.

--- a/vendor/github.com/minio/minio-go/api-put-object-readat.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-readat.go
@@ -32,16 +32,16 @@ type uploadedPartRes struct {
 	Error   error // Any error encountered while uploading the part.
 	PartNum int   // Number of the part uploaded.
 	Size    int64 // Size of the part uploaded.
-	Part    *objectPart
+	Part    *ObjectPart
 }
 
 type uploadPartReq struct {
 	PartNum int         // Number of the part uploaded.
-	Part    *objectPart // Size of the part uploaded.
+	Part    *ObjectPart // Size of the part uploaded.
 }
 
 // shouldUploadPartReadAt - verify if part should be uploaded.
-func shouldUploadPartReadAt(objPart objectPart, uploadReq uploadPartReq) bool {
+func shouldUploadPartReadAt(objPart ObjectPart, uploadReq uploadPartReq) bool {
 	// If part not found part should be uploaded.
 	if uploadReq.Part == nil {
 		return true
@@ -164,7 +164,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 				}
 
 				// Verify object if its uploaded.
-				verifyObjPart := objectPart{
+				verifyObjPart := ObjectPart{
 					PartNumber: uploadReq.PartNum,
 					Size:       partSize,
 				}
@@ -178,7 +178,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 				// to update any progress bar.
 				if shouldUploadPartReadAt(verifyObjPart, uploadReq) {
 					// Proceed to upload the part.
-					var objPart objectPart
+					var objPart ObjectPart
 					objPart, err = c.uploadPart(bucketName, objectName, uploadID, tmpBuffer, uploadReq.PartNum, hashSums["md5"], hashSums["sha256"], prtSize)
 					if err != nil {
 						uploadedPartsCh <- uploadedPartRes{
@@ -224,7 +224,7 @@ func (c Client) putObjectMultipartFromReadAt(bucketName, objectName string, read
 			}
 		}
 		// Store the parts to be completed in order.
-		complMultipartUpload.Parts = append(complMultipartUpload.Parts, completePart{
+		complMultipartUpload.Parts = append(complMultipartUpload.Parts, CompletePart{
 			ETag:       part.ETag,
 			PartNumber: part.PartNumber,
 		})

--- a/vendor/github.com/minio/minio-go/api-put-object.go
+++ b/vendor/github.com/minio/minio-go/api-put-object.go
@@ -125,7 +125,7 @@ func getReaderSize(reader io.Reader) (size int64, err error) {
 
 // completedParts is a collection of parts sortable by their part numbers.
 // used for sorting the uploaded parts before completing the multipart request.
-type completedParts []completePart
+type completedParts []CompletePart
 
 func (a completedParts) Len() int           { return len(a) }
 func (a completedParts) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/vendor/github.com/minio/minio-go/api-s3-datatypes.go
+++ b/vendor/github.com/minio/minio-go/api-s3-datatypes.go
@@ -71,7 +71,7 @@ type listBucketV2Result struct {
 }
 
 // listBucketResult container for listObjects response.
-type listBucketResult struct {
+type ListBucketResult struct {
 	// A response can contain CommonPrefixes only if you have
 	// specified a delimiter.
 	CommonPrefixes []commonPrefix
@@ -103,7 +103,7 @@ type listBucketResult struct {
 }
 
 // listMultipartUploadsResult container for ListMultipartUploads response
-type listMultipartUploadsResult struct {
+type ListMultipartUploadsResult struct {
 	Bucket             string
 	KeyMarker          string
 	UploadIDMarker     string `xml:"UploadIdMarker"`
@@ -132,7 +132,7 @@ type copyObjectResult struct {
 }
 
 // objectPart container for particular part of an object.
-type objectPart struct {
+type ObjectPart struct {
 	// Part number identifies the part.
 	PartNumber int
 
@@ -148,7 +148,7 @@ type objectPart struct {
 }
 
 // listObjectPartsResult container for ListObjectParts response.
-type listObjectPartsResult struct {
+type ListObjectPartsResult struct {
 	Bucket   string
 	Key      string
 	UploadID string `xml:"UploadId"`
@@ -163,7 +163,7 @@ type listObjectPartsResult struct {
 
 	// Indicates whether the returned list of parts is truncated.
 	IsTruncated bool
-	ObjectParts []objectPart `xml:"Part"`
+	ObjectParts []ObjectPart `xml:"Part"`
 
 	EncodingType string
 }
@@ -187,7 +187,7 @@ type completeMultipartUploadResult struct {
 
 // completePart sub container lists individual part numbers and their
 // md5sum, part of completeMultipartUpload.
-type completePart struct {
+type CompletePart struct {
 	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Part" json:"-"`
 
 	// Part number identifies the part.
@@ -198,7 +198,7 @@ type completePart struct {
 // completeMultipartUpload container for completing multipart upload.
 type completeMultipartUpload struct {
 	XMLName xml.Name       `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CompleteMultipartUpload" json:"-"`
-	Parts   []completePart `xml:"Part"`
+	Parts   []CompletePart `xml:"Part"`
 }
 
 // createBucketConfiguration container for bucket configuration.

--- a/vendor/github.com/minio/minio-go/bucket-notification.go
+++ b/vendor/github.com/minio/minio-go/bucket-notification.go
@@ -28,10 +28,13 @@ type NotificationEventType string
 // 	http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations
 const (
 	ObjectCreatedAll                     NotificationEventType = "s3:ObjectCreated:*"
-	ObjectCreatePut                                            = "s3:ObjectCreated:Put"
+	ObjectCreatedPut                                           = "s3:ObjectCreated:Put"
 	ObjectCreatedPost                                          = "s3:ObjectCreated:Post"
 	ObjectCreatedCopy                                          = "s3:ObjectCreated:Copy"
-	ObjectCreatedCompleteMultipartUpload                       = "sh:ObjectCreated:CompleteMultipartUpload"
+	ObjectCreatedCompleteMultipartUpload                       = "s3:ObjectCreated:CompleteMultipartUpload"
+	ObjectAccessedGet                                          = "s3:ObjectAccessed:Get"
+	ObjectAccessedHead                                         = "s3:ObjectAccessed:Head"
+	ObjectAccessedAll                                          = "s3:ObjectAccessed:*"
 	ObjectRemovedAll                                           = "s3:ObjectRemoved:*"
 	ObjectRemovedDelete                                        = "s3:ObjectRemoved:Delete"
 	ObjectRemovedDeleteMarkerCreated                           = "s3:ObjectRemoved:DeleteMarkerCreated"

--- a/vendor/github.com/minio/minio-go/core.go
+++ b/vendor/github.com/minio/minio-go/core.go
@@ -1,0 +1,108 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import "io"
+import "encoding/hex"
+
+// Inherits Client and adds new methods to expose the low level S3 APIs.
+type Core struct {
+	*Client
+}
+
+// NewCoreClient - Returns new Core.
+func NewCore(endpoint string, accessKeyID, secretAccessKey string, secure bool) (*Core, error) {
+	var s3Client Core
+	client, err := NewV4(endpoint, accessKeyID, secretAccessKey, secure)
+	if err != nil {
+		return nil, err
+	}
+	s3Client.Client = client
+	return &s3Client, nil
+}
+
+// ListObjects - List the objects.
+func (c Core) ListObjects(bucket, prefix, marker, delimiter string, maxKeys int) (result ListBucketResult, err error) {
+	return c.listObjectsQuery(bucket, prefix, marker, delimiter, maxKeys)
+}
+
+// PutObject - Upload object. Uploads using single PUT call.
+func (c Core) PutObject(bucket, object string, size int64, data io.Reader, md5Sum string, sha256Sum string, metadata map[string][]string) (ObjectInfo, error) {
+	var md5SumBytes []byte
+	var sha256SumBytes []byte
+	var err error
+	if md5Sum != "" {
+		md5SumBytes, err = hex.DecodeString(md5Sum)
+		if err != nil {
+			return ObjectInfo{}, err
+		}
+	}
+	if sha256Sum != "" {
+		sha256SumBytes, err = hex.DecodeString(sha256Sum)
+		if err != nil {
+			return ObjectInfo{}, err
+		}
+	}
+	return c.putObjectDo(bucket, object, data, md5SumBytes, sha256SumBytes, size, metadata)
+}
+
+// NewMultipartUpload - Initiates new multipart upload and returns the new uploaID.
+func (c Core) NewMultipartUpload(bucket, object string, metadata map[string][]string) (uploadID string, err error) {
+	result, err := c.initiateMultipartUpload(bucket, object, metadata)
+	return result.UploadID, err
+}
+
+// ListMultipartUploads - List incomplete uploads.
+func (c Core) ListMultipartUploads(bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartUploadsResult, err error) {
+	return c.listMultipartUploadsQuery(bucket, keyMarker, uploadIDMarker, prefix, delimiter, maxUploads)
+}
+
+// PutObjectPart - Upload an object part.
+func (c Core) PutObjectPart(bucket, object, uploadID string, partID int, size int64, data io.Reader, md5Sum, sha256Sum string) (ObjectPart, error) {
+	var md5SumBytes []byte
+	var sha256SumBytes []byte
+	var err error
+	if md5Sum != "" {
+		md5SumBytes, err = hex.DecodeString(md5Sum)
+		if err != nil {
+			return ObjectPart{}, err
+		}
+	}
+	if sha256Sum != "" {
+		sha256SumBytes, err = hex.DecodeString(sha256Sum)
+		if err != nil {
+			return ObjectPart{}, err
+		}
+	}
+	return c.uploadPart(bucket, object, uploadID, data, partID, md5SumBytes, sha256SumBytes, size)
+}
+
+// ListObjectParts - List uploaded parts of an incomplete upload.
+func (c Core) ListObjectParts(bucket, object, uploadID string, partNumberMarker int, maxParts int) (result ListObjectPartsResult, err error) {
+	return c.listObjectPartsQuery(bucket, object, uploadID, partNumberMarker, maxParts)
+}
+
+// CompleteMultipartUpload - Concatenate uploaded parts and commit to an object.
+func (c Core) CompleteMultipartUpload(bucket, object, uploadID string, parts []CompletePart) error {
+	_, err := c.completeMultipartUpload(bucket, object, uploadID, completeMultipartUpload{Parts: parts})
+	return err
+}
+
+// AbortMultipartUpload - Abort an incomplete upload.
+func (c Core) AbortMultipartUpload(bucket, object, uploadID string) error {
+	return c.abortMultipartUpload(bucket, object, uploadID)
+}

--- a/vendor/github.com/minio/minio-go/encryption-cbc.go
+++ b/vendor/github.com/minio/minio-go/encryption-cbc.go
@@ -1,0 +1,294 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+)
+
+const (
+	amzHeaderIV      = "X-Amz-Meta-X-Amz-Iv"
+	amzHeaderKey     = "X-Amz-Meta-X-Amz-Key"
+	amzHeaderMatDesc = "X-Amz-Meta-X-Amz-Matdesc"
+)
+
+// Crypt mode - encryption or decryption
+type cryptMode int
+
+const (
+	encryptMode cryptMode = iota
+	decryptMode
+)
+
+// CBCSecureMaterials encrypts/decrypts data using AES CBC algorithm
+type CBCSecureMaterials struct {
+
+	// Data stream to encrypt/decrypt
+	stream io.Reader
+
+	// Last internal error
+	err error
+
+	// End of file reached
+	eof bool
+
+	// Holds initial data
+	srcBuf *bytes.Buffer
+
+	// Holds transformed data (encrypted or decrypted)
+	dstBuf *bytes.Buffer
+
+	// Encryption algorithm
+	encryptionKey EncryptionKey
+
+	// Key to encrypts/decrypts data
+	contentKey []byte
+
+	// Encrypted form of contentKey
+	cryptedKey []byte
+
+	// Initialization vector
+	iv []byte
+
+	// matDesc - currently unused
+	matDesc []byte
+
+	// Indicate if we are going to encrypt or decrypt
+	cryptMode cryptMode
+
+	// Helper that encrypts/decrypts data
+	blockMode cipher.BlockMode
+}
+
+// NewCBCSecureMaterials builds new CBC crypter module with the specified encryption key
+// (symmetric or asymmetric)
+func NewCBCSecureMaterials(key EncryptionKey) (*CBCSecureMaterials, error) {
+	if key == nil {
+		return nil, ErrInvalidArgument("Unable to recognize empty encryption properties")
+	}
+	return &CBCSecureMaterials{
+		srcBuf:        bytes.NewBuffer([]byte{}),
+		dstBuf:        bytes.NewBuffer([]byte{}),
+		encryptionKey: key,
+		matDesc:       []byte("{}"),
+	}, nil
+
+}
+
+// SetInputStream - set data which needs to be encrypted or decrypted
+// func (s *CBCSecureMaterials) SetInputStream(stream io.Reader) {
+//	s.stream = stream
+// }
+
+// SetEncryptMode - tells CBC that we are going to encrypt data
+func (s *CBCSecureMaterials) SetupEncryptMode(stream io.Reader) error {
+
+	// Set mode to encrypt
+	s.cryptMode = encryptMode
+
+	// Set underlying reader
+	s.stream = stream
+
+	s.eof = false
+	s.srcBuf.Reset()
+	s.dstBuf.Reset()
+
+	var err error
+
+	// Generate random content key
+	s.contentKey = make([]byte, aes.BlockSize*2)
+	if _, err := rand.Read(s.contentKey); err != nil {
+		return err
+	}
+	// Encrypt content key
+	s.cryptedKey, err = s.encryptionKey.Encrypt(s.contentKey)
+	if err != nil {
+		return err
+	}
+	// Generate random IV
+	s.iv = make([]byte, aes.BlockSize)
+	if _, err = rand.Read(s.iv); err != nil {
+		return err
+	}
+	// New cipher
+	encryptContentBlock, err := aes.NewCipher(s.contentKey)
+	if err != nil {
+		return err
+	}
+
+	s.blockMode = cipher.NewCBCEncrypter(encryptContentBlock, s.iv)
+
+	return nil
+}
+
+// SetupDecryptMode - tells CBC that we are going to decrypt data
+func (s *CBCSecureMaterials) SetupDecryptMode(stream io.Reader, metadata http.Header) error {
+
+	// Set mode to decrypt
+	s.cryptMode = decryptMode
+
+	// Set underlying reader
+	s.stream = stream
+
+	// Reset
+	s.eof = false
+	s.srcBuf.Reset()
+	s.dstBuf.Reset()
+
+	var err error
+
+	// Get IV
+	s.iv, err = base64.StdEncoding.DecodeString(metadata.Get(amzHeaderIV))
+	if err != nil {
+		return err
+	}
+	// Get encrypted content key
+	s.cryptedKey, err = base64.StdEncoding.DecodeString(metadata.Get(amzHeaderKey))
+	if err != nil {
+		return err
+	}
+	// Decrypt content key
+	s.contentKey, err = s.encryptionKey.Decrypt(s.cryptedKey)
+	if err != nil {
+		return err
+	}
+
+	// New cipher
+	decryptContentBlock, err := aes.NewCipher(s.contentKey)
+	if err != nil {
+		return err
+	}
+
+	s.blockMode = cipher.NewCBCDecrypter(decryptContentBlock, s.iv)
+	return nil
+}
+
+// GetHeaders - returns headers data to be sent along with data to the S3 server
+// it contains encryption information needed to decrypt later
+func (s *CBCSecureMaterials) GetHeaders() http.Header {
+
+	m := make(http.Header)
+
+	m.Set(amzHeaderMatDesc, string(s.matDesc))
+	m.Set(amzHeaderIV, base64.StdEncoding.EncodeToString(s.iv))
+	m.Set(amzHeaderKey, base64.StdEncoding.EncodeToString(s.cryptedKey))
+
+	return m
+}
+
+// Fill buf with encrypted/decrypted data
+func (s *CBCSecureMaterials) Read(buf []byte) (n int, err error) {
+	// Always fill buf from bufChunk at the end of this function
+	defer func() {
+		if s.err != nil {
+			n, err = 0, s.err
+		} else {
+			n, err = s.dstBuf.Read(buf)
+		}
+	}()
+
+	// Return
+	if s.eof {
+		return
+	}
+
+	// Fill dest buffer if its length is less than buf
+	for !s.eof && s.dstBuf.Len() < len(buf) {
+
+		srcPart := make([]byte, aes.BlockSize)
+		dstPart := make([]byte, aes.BlockSize)
+
+		// Fill src buffer
+		for s.srcBuf.Len() < aes.BlockSize*2 {
+			_, err = io.CopyN(s.srcBuf, s.stream, aes.BlockSize)
+			if err != nil {
+				break
+			}
+		}
+
+		// Quit immediately for errors other than io.EOF
+		if err != nil && err != io.EOF {
+			s.err = err
+			return
+		}
+
+		// Mark current encrypting/decrypting as finished
+		s.eof = (err == io.EOF)
+
+		if s.eof && s.cryptMode == encryptMode {
+			if srcPart, err = pkcs5Pad(s.srcBuf.Bytes(), aes.BlockSize); err != nil {
+				s.err = err
+				return
+			}
+		} else {
+			_, _ = s.srcBuf.Read(srcPart)
+		}
+
+		// Crypt srcPart content
+		for len(srcPart) > 0 {
+
+			// Crypt current part
+			s.blockMode.CryptBlocks(dstPart, srcPart[:aes.BlockSize])
+
+			// Unpad when this is the last part and we are decrypting
+			if s.eof && s.cryptMode == decryptMode {
+				dstPart, err = pkcs5Unpad(dstPart, aes.BlockSize)
+				if err != nil {
+					s.err = err
+					return
+				}
+			}
+
+			// Send crypted data to dstBuf
+			if _, wErr := s.dstBuf.Write(dstPart); wErr != nil {
+				s.err = wErr
+				return
+			}
+			// Move to the next part
+			srcPart = srcPart[aes.BlockSize:]
+		}
+	}
+	return
+}
+
+// Unpad a set of bytes following PKCS5 algorithm
+func pkcs5Unpad(buf []byte, blockSize int) ([]byte, error) {
+	len := len(buf)
+	if len == 0 {
+		return nil, errors.New("buffer is empty")
+	}
+	pad := int(buf[len-1])
+	if pad > len || pad > blockSize {
+		return nil, errors.New("invalid padding size")
+	}
+	return buf[:len-pad], nil
+}
+
+// Pad a set of bytes following PKCS5 algorithm
+func pkcs5Pad(buf []byte, blockSize int) ([]byte, error) {
+	len := len(buf)
+	pad := blockSize - (len % blockSize)
+	padText := bytes.Repeat([]byte{byte(pad)}, pad)
+	return append(buf, padText...), nil
+}

--- a/vendor/github.com/minio/minio-go/encryption-keys.go
+++ b/vendor/github.com/minio/minio-go/encryption-keys.go
@@ -1,0 +1,164 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+)
+
+// EncryptionKey - generic interface to encrypt/decrypt a key.
+// We use it to encrypt/decrypt content key which is the key
+// that encrypt/decrypt object data.
+type EncryptionKey interface {
+	// Encrypt data using to the set encryption key
+	Encrypt([]byte) ([]byte, error)
+	// Decrypt data using to the set encryption key
+	Decrypt([]byte) ([]byte, error)
+}
+
+// SymmetricKey - encrypts data with a symmetric master key
+type SymmetricKey struct {
+	masterKey []byte
+}
+
+// Encrypt passed bytes
+func (s *SymmetricKey) Encrypt(plain []byte) ([]byte, error) {
+	// Initialize an AES encryptor using a master key
+	keyBlock, err := aes.NewCipher(s.masterKey)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	// Pad the key before encryption
+	plain, _ = pkcs5Pad(plain, aes.BlockSize)
+
+	encKey := []byte{}
+	encPart := make([]byte, aes.BlockSize)
+
+	// Encrypt the passed key by block
+	for {
+		if len(plain) < aes.BlockSize {
+			break
+		}
+		// Encrypt the passed key
+		keyBlock.Encrypt(encPart, plain[:aes.BlockSize])
+		// Add the encrypted block to the total encrypted key
+		encKey = append(encKey, encPart...)
+		// Pass to the next plain block
+		plain = plain[aes.BlockSize:]
+	}
+	return encKey, nil
+}
+
+// Decrypt passed bytes
+func (s *SymmetricKey) Decrypt(cipher []byte) ([]byte, error) {
+	// Initialize AES decrypter
+	keyBlock, err := aes.NewCipher(s.masterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var plain []byte
+	plainPart := make([]byte, aes.BlockSize)
+
+	// Decrypt the encrypted data block by block
+	for {
+		if len(cipher) < aes.BlockSize {
+			break
+		}
+		keyBlock.Decrypt(plainPart, cipher[:aes.BlockSize])
+		// Add the decrypted block to the total result
+		plain = append(plain, plainPart...)
+		// Pass to the next cipher block
+		cipher = cipher[aes.BlockSize:]
+	}
+
+	// Unpad the resulted plain data
+	plain, err = pkcs5Unpad(plain, aes.BlockSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return plain, nil
+}
+
+// NewSymmetricKey generates a new encrypt/decrypt crypto using
+// an AES master key password
+func NewSymmetricKey(b []byte) *SymmetricKey {
+	return &SymmetricKey{masterKey: b}
+}
+
+// AsymmetricKey - struct which encrypts/decrypts data
+// using RSA public/private certificates
+type AsymmetricKey struct {
+	publicKey  *rsa.PublicKey
+	privateKey *rsa.PrivateKey
+}
+
+// Encrypt data using public key
+func (a *AsymmetricKey) Encrypt(plain []byte) ([]byte, error) {
+	cipher, err := rsa.EncryptPKCS1v15(rand.Reader, a.publicKey, plain)
+	if err != nil {
+		return nil, err
+	}
+	return cipher, nil
+}
+
+// Decrypt data using public key
+func (a *AsymmetricKey) Decrypt(cipher []byte) ([]byte, error) {
+	cipher, err := rsa.DecryptPKCS1v15(rand.Reader, a.privateKey, cipher)
+	if err != nil {
+		return nil, err
+	}
+	return cipher, nil
+}
+
+// NewAsymmetricKey - generates a crypto module able to encrypt/decrypt
+// data using a pair for private and public key
+func NewAsymmetricKey(privData []byte, pubData []byte) (*AsymmetricKey, error) {
+	// Parse private key from passed data
+	priv, err := x509.ParsePKCS8PrivateKey(privData)
+	if err != nil {
+		return nil, err
+	}
+	privKey, ok := priv.(*rsa.PrivateKey)
+	if !ok {
+		return nil, ErrInvalidArgument("not a valid private key")
+	}
+
+	// Parse public key from passed data
+	pub, err := x509.ParsePKIXPublicKey(pubData)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil, ErrInvalidArgument("not a valid public key")
+	}
+
+	// Associate the private key with the passed public key
+	privKey.PublicKey = *pubKey
+
+	return &AsymmetricKey{
+		publicKey:  pubKey,
+		privateKey: privKey,
+	}, nil
+}

--- a/vendor/github.com/minio/minio-go/encryption.go
+++ b/vendor/github.com/minio/minio-go/encryption.go
@@ -1,0 +1,44 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"io"
+	"net/http"
+)
+
+// EncryptionMaterials - provides generic interface to encrypt
+// any stream of data. Some crypt information can be
+// save in the object metadata
+type EncryptionMaterials interface {
+
+	// Return encrypted/decrypted data.
+	Read(b []byte) (int, error)
+
+	// Metadata that will be stored with the object
+	GetHeaders() http.Header
+
+	// Setup encrypt mode, further calls of Read() function
+	// will return the encrypted form of data streamed
+	// by the passed reader
+	SetupEncryptMode(io.Reader) error
+
+	// Setup decrypted mode, further calls of Read() function
+	// will return the decrypted form of data streamed
+	// by the passed reader
+	SetupDecryptMode(io.Reader, http.Header) error
+}

--- a/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v2.go
+++ b/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v2.go
@@ -316,7 +316,7 @@ func writeCanonicalizedResource(buf *bytes.Buffer, req http.Request, isPreSign b
 				// Request parameters
 				if len(vv[0]) > 0 {
 					buf.WriteByte('=')
-					buf.WriteString(strings.Replace(url.QueryEscape(vv[0]), "+", "%20", -1))
+					buf.WriteString(vv[0])
 				}
 			}
 		}

--- a/vendor/github.com/minio/minio-go/retry.go
+++ b/vendor/github.com/minio/minio-go/retry.go
@@ -78,6 +78,9 @@ func (c Client) newRetryTimer(maxRetry int, unit time.Duration, cap time.Duratio
 
 // isNetErrorRetryable - is network error retryable.
 func isNetErrorRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
 	switch err.(type) {
 	case net.Error:
 		switch err.(type) {
@@ -95,6 +98,9 @@ func isNetErrorRetryable(err error) bool {
 				return true
 			} else if strings.Contains(err.Error(), "i/o timeout") {
 				// If error is - tcp timeoutError, retry.
+				return true
+			} else if strings.Contains(err.Error(), "connection timed out") {
+				// If err is a net.Dial timeout, retry.
 				return true
 			}
 		}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -50,10 +50,10 @@
 			"revisionTime": "2015-10-24T22:24:27-07:00"
 		},
 		{
-			"checksumSHA1": "MPTks/0y7+QupC/HNeQt181sXk4=",
+			"checksumSHA1": "q2mnNtdkxvuzEx8d5W0uCO0wmgI=",
 			"path": "github.com/minio/minio-go",
-			"revision": "1ab82c59c8c49e452528964d1195d3524e297a76",
-			"revisionTime": "2017-03-10T11:59:35Z"
+			"revision": "ef0dc7e81b008739bd2ab9cb5b5cfbdc22bf32a5",
+			"revisionTime": "2017-04-01T21:28:19Z"
 		},
 		{
 			"checksumSHA1": "qTxOBp3GVxCC70ykb7Hxg6UgWwA=",


### PR DESCRIPTION
New minio-go commits are introduced:

### Changes 
 sigv2: Do not encode canonical sub-resource value (#636)
 Core.PutObject takes md5 and sha256 sums (#635)
 allow bucket location responses with empty Message (fixes #629) (#630)
 listen: Add support for HEAD/GET bucket events (#634)
 docs:  Remove extra space from code blocks (#632)
 docs: Remove extra space from code blocks. (#631)
 Implement a new NewWithRegion() API for static region. (#627)
 Fix table syntax for SetBucketPolicy parameters (#628)
 Changes needed for implementing "minio gateway s3" (#623)
 Typo in variable name (#625)
 api: Support encryption for Put/Get Object (#613)
 api/retry: Support connection retry for Dial timeout. (#622)