### PR TITLE
Revert "trace: Avoid httputil for less memory consumption (#2102)"

### DIFF
--- a/cmd/client-s3-trace_v4.go
+++ b/cmd/client-s3-trace_v4.go
@@ -18,8 +18,8 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"regexp"
 	"strings"
 
@@ -54,17 +54,11 @@ func (t traceV4) Request(req *http.Request) (err error) {
 		// Set a temporary redacted auth
 		req.Header.Set("Authorization", newAuth)
 
-		// Store requests headers in buf
-		var buf bytes.Buffer
-		if err = req.Header.Write(&buf); err != nil {
-			return err
+		var reqTrace []byte
+		reqTrace, err = httputil.DumpRequestOut(req, false) // Only display header
+		if err == nil {
+			console.Debug(string(reqTrace))
 		}
-
-		// Build debug and add headers
-		reqTrace := append(buf.Bytes(), []byte("\r\n")...)
-
-		// Print debug text
-		console.Debug(string(reqTrace))
 
 		// Undo
 		req.Header.Set("Authorization", origAuth)
@@ -74,34 +68,35 @@ func (t traceV4) Request(req *http.Request) (err error) {
 
 // Response - Trace HTTP Response
 func (t traceV4) Response(resp *http.Response) (err error) {
-
-	// Store headers in buf
-	var buf bytes.Buffer
-	if err = resp.Header.Write(&buf); err != nil {
-		return err
-	}
-
-	// Build debug text and add headers
-	respTrace := append(buf.Bytes(), []byte("\r\n")...)
-
+	var respTrace []byte
 	// For errors we make sure to dump response body as well.
 	if resp.StatusCode != http.StatusOK &&
 		resp.StatusCode != http.StatusPartialContent &&
 		resp.StatusCode != http.StatusNoContent {
-		// Load response body
-		respBody, rErr := ioutil.ReadAll(resp.Body)
-		if rErr != nil {
-			return rErr
+		respTrace, err = httputil.DumpResponse(resp, true)
+	} else {
+		// WORKAROUND for https://github.com/golang/go/issues/13942.
+		// httputil.DumpResponse does not print response headers for
+		// all successful calls which have response ContentLength set
+		// to zero. Keep this workaround until the above bug is fixed.
+		if resp.ContentLength == 0 {
+			var buffer bytes.Buffer
+			if err = resp.Header.Write(&buffer); err != nil {
+				return err
+			}
+			respTrace = buffer.Bytes()
+			respTrace = append(respTrace, []byte("\r\n")...)
+		} else {
+			respTrace, err = httputil.DumpResponse(resp, false)
+			if err != nil {
+				return err
+			}
 		}
-		// Add response body to debug text
-		respTrace = append(respTrace, respBody...)
-		respTrace = append(respTrace, []byte("\r\n")...)
+	}
+	if err == nil {
+		console.Debug(string(respTrace))
 	}
 
-	// Print debug text
-	console.Debug(string(respTrace))
-
-	// Print TLS certificates when applicable
 	if globalInsecure && resp.TLS != nil {
 		dumpTLSCertificates(resp.TLS)
 	}


### PR DESCRIPTION
This reverts commit eafa942a30ccdda195328507f24c09b18c9487d6.

The change that replaced httputil wasn't able to show headers like Host and Transfer-Encoding,