### PR TITLE
minor fixes to `mc share download` command; improved error messages and issue with `--recursive` option. (#2099)

### DIFF
--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -150,7 +150,7 @@ func (e EmptyPath) Error() string {
 type ObjectMissing struct{}
 
 func (e ObjectMissing) Error() string {
-	return "Object key is missing, object key cannot be empty"
+	return "Object does not exist"
 }
 
 // UnexpectedShortWrite - write wrote less bytes than expected.

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -89,9 +89,15 @@ func checkShareDownloadSyntax(ctx *cli.Context) {
 		fatalIf(errDummy().Trace(expiry.String()), "Expiry cannot be larger than 7 days.")
 	}
 
-	for _, url := range ctx.Args() {
-		_, _, err := url2Stat(url)
-		fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
+	// Validate if object exists only if the `--recursive` option was NOT specified
+	isRecursive := ctx.Bool("recursive")
+	if !isRecursive {
+		for _, url := range ctx.Args() {
+			_, _, err := url2Stat(url)
+			if err != nil {
+				fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Verified that all the test cases below are working as expected... 

`mc ls play/foo` should show two objects `bar1`, `bar2`

```
Scotts-MacBook-Pro-2:mc scott$ mc ls play/foo
[2017-04-03 13:10:00 PDT] 2.0MiB bar1
[2017-04-03 13:10:19 PDT] 1.1MiB bar2
```

All of these `mc share download` commands should generate an error ... 

```
Scotts-MacBook-Pro-2:mc scott$ mc share download play/foo/invalid
mc: <ERROR> Object `play/foo/invalid` does not exist. 
Scotts-MacBook-Pro-2:mc scott$ mc share download play/foo/invalid --recursive
mc: <ERROR> Object `play/foo/invalid` does not exist. 
Scotts-MacBook-Pro-2:mc scott$ mc share download play/foo/bar
mc: <ERROR> Object `play/foo/bar` does not exist. 
```
Prior to this fix, the error message above was confusing, and the middle case failed without an error message. 

`mc share download play/foo/bar --recursive` should generate two download share URLs... 

```
Scotts-MacBook-Pro-2:mc scott$ mc share download play/foo/bar --recursive
URL: https://play.minio.io:9000/foo/bar1
Expire: 7 days 0 hours 0 minutes 0 seconds
Share: <.... URL deleted...>

URL: https://play.minio.io:9000/foo/bar2
Expire: 7 days 0 hours 0 minutes 0 seconds
Share: <.... URL deleted...>
```

Prior to this fix, this case would give an error instead of returning the two download share URLs.