### PR TITLE
fs watch: Use a dynamically sized channel

### DIFF
--- a/cmd/pipechan.go
+++ b/cmd/pipechan.go
@@ -1,0 +1,89 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "github.com/rjeczalik/notify"
+
+// Dynamically sized logical channel: a pipe which never blocks even when
+// it receives too many elements. Memory consumption is increased and decresed
+// on the fly following the number of elements. Here is the benchmark which
+// compares a regular channel which a large capacity (like 1 Million) in
+// contrast to a PipeChan with an realtime increasing/decreasing capacity.
+//
+// BenchmarkRegular1M-4                 200         172809399 ns/op
+// BenchmarkPipeChan1M-4                100         316668338 ns/op
+// BenchmarkRegular100K-4              2000          16540648 ns/op
+// BenchmarkPipeChan100K-4             1000          31905966 ns/op
+// BenchmarkRegular10K-4              20000           1637665 ns/op
+// BenchmarkPipeChan10K-4             10000           3324329 ns/op
+// BenchmarkRegular1K-4              200000            168512 ns/op
+// BenchmarkPipeChan1K-4             100000            550623 ns/op
+
+// PipeChan builds a new dynamically sized channel
+func PipeChan(capacity int) (inputCh chan notify.EventInfo, outputCh chan notify.EventInfo) {
+
+	// A set of channels which store all elements received from input
+	channels := make(chan chan notify.EventInfo, 1000)
+
+	inputCh = make(chan notify.EventInfo, capacity)
+
+	// A goroutine which receives elements from inputCh and creates
+	// new channels when needed.
+	go func() {
+		// Create the first channel
+		currCh := make(chan notify.EventInfo, capacity)
+		channels <- currCh
+
+		for elem := range inputCh {
+			// Prepare next channel with a double capacity when
+			// half of the current channel is already filled.
+			if len(currCh) >= cap(currCh)/2 {
+				close(currCh)
+				currCh = make(chan notify.EventInfo, cap(currCh)*2)
+				channels <- currCh
+			}
+			// Prepare next channel with half capacity when
+			// current channel is 1/4 filled
+			if len(currCh) >= capacity && len(currCh) <= cap(currCh)/4 {
+				close(currCh)
+				currCh = make(chan notify.EventInfo, cap(currCh)/2)
+				channels <- currCh
+			}
+			// Send element to current channel
+			currCh <- elem
+		}
+
+		close(currCh)
+		close(channels)
+	}()
+
+	// Copy elements from infinite channel set to the output
+	outputCh = make(chan notify.EventInfo, capacity)
+	go func() {
+		for {
+			currCh, ok := <-channels
+			if !ok {
+				break
+			}
+			for v := range currCh {
+				outputCh <- v
+			}
+		}
+		close(outputCh)
+	}()
+	return inputCh, outputCh
+}

--- a/cmd/pipechan_test.go
+++ b/cmd/pipechan_test.go
@@ -1,0 +1,141 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/rjeczalik/notify"
+)
+
+func testPipeChan(inputCh, outputCh chan notify.EventInfo, totalMsgs int) error {
+
+	var wg sync.WaitGroup
+
+	msgCtnt := notify.EventInfo(nil)
+
+	// Send messages up to totalMsgs
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < totalMsgs; i++ {
+			select {
+			case inputCh <- msgCtnt:
+			}
+		}
+		close(inputCh)
+	}()
+
+	// Goroutine to receive and check messages
+	var recvMsgs int
+	var recvErr error
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for msg := range outputCh {
+			recvMsgs++
+			if msg != msgCtnt {
+				recvErr = fmt.Errorf("Corrupted message, expected = `%s`, found = `%s`", msgCtnt, msg)
+				return
+			}
+		}
+	}()
+
+	// Wait until we finish sending and receiving messages
+	wg.Wait()
+
+	if recvErr != nil {
+		return recvErr
+	}
+
+	// Check if all messages are received
+	if recvMsgs != totalMsgs {
+		return fmt.Errorf("unable to receive all messages, expected: %d, lost: %d", totalMsgs, totalMsgs-recvMsgs)
+	}
+
+	return nil
+}
+
+// Testing code
+
+func TestPipeChannel(t *testing.T) {
+	fastCh, slowCh := PipeChan(1000)
+	err := testPipeChan(fastCh, slowCh, 10*1000)
+	if err != nil {
+		t.Errorf("ERR: %v\n", err)
+	}
+}
+
+func TestRegularChannel(t *testing.T) {
+	ch := make(chan notify.EventInfo, 1000)
+	err := testPipeChan(ch, ch, 10*1000)
+	if err != nil {
+		t.Errorf("ERR: %v\n", err)
+	}
+}
+
+// Benchmark code
+
+func benchmarkRegular(b *testing.B, msgsNum int) {
+	for n := 0; n < b.N; n++ {
+		ch := make(chan notify.EventInfo, msgsNum)
+		testPipeChan(ch, ch, msgsNum)
+	}
+}
+
+func benchmarkPipeChan(b *testing.B, msgsNum int) {
+	for n := 0; n < b.N; n++ {
+		fastCh, slowCh := PipeChan(1000)
+		testPipeChan(fastCh, slowCh, msgsNum)
+	}
+}
+
+func BenchmarkRegular1M(b *testing.B) {
+	benchmarkRegular(b, 1*1000*1000)
+}
+
+func BenchmarkPipeChan1M(b *testing.B) {
+	benchmarkPipeChan(b, 1*1000*1000)
+}
+
+func BenchmarkRegular100K(b *testing.B) {
+	benchmarkRegular(b, 100*1000)
+}
+
+func BenchmarkPipeChan100K(b *testing.B) {
+	benchmarkPipeChan(b, 100*1000)
+}
+
+func BenchmarkRegular10K(b *testing.B) {
+	benchmarkRegular(b, 10*1000)
+}
+
+func BenchmarkPipeChan10K(b *testing.B) {
+	benchmarkPipeChan(b, 10*1000)
+}
+
+func BenchmarkRegular1K(b *testing.B) {
+	benchmarkRegular(b, 1*1000)
+}
+
+func BenchmarkPipeChan1K(b *testing.B) {
+	benchmarkPipeChan(b, 1*1000)
+}


### PR DESCRIPTION
Write and use a growing/shrinking channel to be able to absorb file system
notify events even when they come in large numbers.