### PR TITLE
Fix solaris build

### DIFF
--- a/cmd/client-fs_other.go
+++ b/cmd/client-fs_other.go
@@ -1,4 +1,4 @@
-// +build darwin,freebsd,solaris
+// +build darwin freebsd solaris
 
 /*
  * Minio Client (C) 2015, 2016, 2017 Minio, Inc.


### PR DESCRIPTION
On solaris, I see

go get -u github.com/minio/mc
# github.com/minio/mc/cmd
src/github.com/minio/mc/cmd/client-fs.go:110: undefined: EventTypePut
src/github.com/minio/mc/cmd/client-fs.go:112: undefined: EventTypeDelete
src/github.com/minio/mc/cmd/client-fs.go:114: undefined: EventTypeGet
src/github.com/minio/mc/cmd/client-fs.go:149: undefined: IsPutEvent
src/github.com/minio/mc/cmd/client-fs.go:171: undefined: IsDeleteEvent
src/github.com/minio/mc/cmd/client-fs.go:178: undefined: IsGetEvent

It ought to be selecting  cmd/client-fs_other.go but fails to do so because
the build specification there is incorrect. (Commas will AND the selection,
which will never match - I presume other platform builds will fail as well.)