### PR TITLE
session: Close data session file when migrating

### DIFF
--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -134,7 +134,7 @@ func clearSession(sid string) {
 			session, err := loadSessionV8(sid)
 			fatalIf(err.Trace(sid), "Unable to load session `"+sid+"`.")
 
-			fatalIf(session.Delete().Trace(sid), "Unable to load session `"+sid+"`.")
+			fatalIf(session.Delete().Trace(sid), "Unable to remove session `"+sid+"`.")
 
 			printMsg(clearSessionMessage{Status: "success", SessionID: sid})
 		}
@@ -156,7 +156,7 @@ func clearSession(sid string) {
 	}
 
 	if session != nil {
-		fatalIf(session.Delete().Trace(sid), "Unable to load session `"+sid+"`.")
+		fatalIf(session.Delete().Trace(sid), "Unable to remove session `"+sid+"`.")
 		printMsg(clearSessionMessage{Status: "success", SessionID: sid})
 	}
 }

--- a/cmd/session-migrate.go
+++ b/cmd/session-migrate.go
@@ -37,6 +37,9 @@ func migrateSessionV7ToV8() {
 			fatalIf(err.Trace(sid), "Unable to load version `7`. Migration failed please report this issue at https://github.com/minio/mc/issues.")
 		}
 
+		// Close underlying session data file.
+		sV7.DataFP.Close()
+
 		sessionVersion, e := strconv.Atoi(sV7.Header.Version)
 		fatalIf(probe.NewError(e), "Unable to load version `7`. Migration failed please report this issue at https://github.com/minio/mc/issues.")
 		if sessionVersion > 7 { // It is new format.


### PR DESCRIPTION
Cleanup needed before removing the data file

Fixes #1904 