### PR TITLE
Provide richer information for admin-heal

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -101,9 +101,10 @@ type healMessage struct {
 
 // String colorized service status message.
 func (u healMessage) String() string {
-	allOfflineTmpl := "isn't healed since %d disks were offline"
-	allHealedTmpl := "is healed on all %d disks"
-	someHealedTmpl := "is healed on %d disks while %d disks were offline"
+	healMsg := make(map[madmin.HealState]string)
+	healMsg[madmin.HealNone] = "isn't healed since all disks needing heal were offline"
+	healMsg[madmin.HealPartial] = "is healed on some disks while others were offline"
+	healMsg[madmin.HealOK] = "is healed on all disks needing heal"
 
 	msg := ""
 	if u.Object != nil {
@@ -112,15 +113,7 @@ func (u healMessage) String() string {
 		msg = fmt.Sprintf("Upload %s/%s/%s ", u.Bucket, u.Upload.Key, u.Upload.UploadID)
 	}
 
-	healed, offline := u.Result.HealedCount, u.Result.OfflineCount
-	switch {
-	case healed == 0:
-		msg += fmt.Sprintf(allOfflineTmpl, offline)
-	case offline == 0:
-		msg += fmt.Sprintf(allHealedTmpl, healed)
-	case healed > 0 && offline > 0:
-		msg += fmt.Sprintf(someHealedTmpl, healed, offline)
-	}
+	msg += healMsg[u.Result.State]
 
 	return console.Colorize("Heal", msg)
 }

--- a/vendor/github.com/minio/minio/pkg/madmin/API.md
+++ b/vendor/github.com/minio/minio/pkg/madmin/API.md
@@ -245,6 +245,18 @@ __Example__
 ### HealObject(bucket, object string, isDryRun bool) (HealResult, error)
 If object is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the object is not healed, but heal object request is validated by the server. e.g, if the object exists, if object name is valid etc.
 
+| Param  | Type  | Description  |
+|---|---|---|
+|`h.State` | _HealState_ | Represents the result of heal operation. It could be one of `HealNone`, `HealPartial` or `HealOK`. |
+
+
+| Value | Description |
+|---|---|
+|`HealNone` | Object/Upload wasn't healed on any of the disks |
+|`HealPartial` | Object/Upload was healed on some of the disks needing heal |
+| `HealOK` | Object/Upload was healed on all the disks needing heal |
+
+
 __Example__
 
 ``` go
@@ -326,6 +338,17 @@ __Example__
 <a name="HealUpload"></a>
 ### HealUpload(bucket, object, uploadID string, isDryRun bool) (HealResult, error)
 If upload is successfully healed returns nil, otherwise returns error indicating the reason for failure. If isDryRun is true, then the upload is not healed, but heal upload request is validated by the server. e.g, if the upload exists, if upload name is valid etc.
+
+| Param  | Type  | Description  |
+|---|---|---|
+|`h.State` | _HealState_ | Represents the result of heal operation. It could be one of `HealNone`, `HealPartial` or `HealOK`. |
+
+
+| Value | Description |
+|---|---|
+| `HealNone` | Object/Upload wasn't healed on any of the disks |
+| `HealPartial` | Object/Upload was healed on some of the disks needing heal |
+| `HealOK` | Object/Upload was healed on all the disks needing heal |
 
 ``` go
     isDryRun = false

--- a/vendor/github.com/minio/minio/pkg/madmin/heal-commands.go
+++ b/vendor/github.com/minio/minio/pkg/madmin/heal-commands.go
@@ -494,9 +494,20 @@ func (adm *AdminClient) HealUpload(bucket, object, uploadID string, dryrun bool)
 
 // HealResult - represents result of heal-object admin API.
 type HealResult struct {
-	HealedCount  int // number of disks that were healed.
-	OfflineCount int // number of disks that needed healing but were offline.
+	State HealState `json:"state"`
 }
+
+// HealState - different states of heal operation
+type HealState int
+
+const (
+	// HealNone - none of the disks healed
+	HealNone HealState = iota
+	// HealPartial - some disks were healed, others were offline
+	HealPartial
+	// HealOK - all disks were healed
+	HealOK
+)
 
 // HealObject - Heal the given object.
 func (adm *AdminClient) HealObject(bucket, object string, dryrun bool) (HealResult, error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -80,10 +80,10 @@
 			"revisionTime": "2016-08-18T00:31:20Z"
 		},
 		{
-			"checksumSHA1": "KLEdjpItmkn1LDY/2xTQHSzebnU=",
+			"checksumSHA1": "MA9d5V2q5fzX9/fYCMVaMgXC2TQ=",
 			"path": "github.com/minio/minio/pkg/madmin",
-			"revision": "522b307ea67ed04f68fcbf98b67549532a6ac424",
-			"revisionTime": "2017-04-03T11:36:28Z"
+			"revision": "18bfe5cba663193b40bcaf4003ba0abbdfb1a37a",
+			"revisionTime": "2017-04-15T00:21:57Z"
 		},
 		{
 			"path": "github.com/minio/minio/pkg/probe",


### PR DESCRIPTION
This change vendorizes pkg/madmin where admin heal REST API provides
specifics of the result of an heal operation. It returns one of
 `HealOK` - completely healed,
 `HealPartial` - heal was successful on some disks,
`HealNone` - heal didn't happen since all disks needing heal were offline.

This is presented to `mc admin heal` users.

Fixes #2129 