### PR TITLE
Improved Error Msg For Bucket Names that Contain non-LOWERCASE chars (#2134)

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -746,7 +746,7 @@ func isValidBucketName(bucketName string) *probe.Error {
 		return probe.NewError(errors.New("Bucket name should be more than 3 characters and less than 64 characters"))
 	}
 	if !validBucketName.MatchString(bucketName) {
-		return probe.NewError(errors.New("Bucket name can contain alphabet, '-' and numbers, but first character should be an alphabet or number"))
+		return probe.NewError(errors.New("Bucket names can only contain lowercase alpha characters `a-z`, numbers '0-9', or '-'. First/last character cannot be a '-'"))
 	}
 	return nil
 }


### PR DESCRIPTION

Improved the error message for various `mc` commands where the user specifies a path or url and the bucket name in that path contains non-lowercase characters.

More specifically, this applies when the path refers to a backend that is an S3 object store and is going through the S3-client. If the backend is a normal/local file system that follows a different path.  

The change is in the function isValidBucketName in cmd/client-s3.go. This routine is invoked when validating the path for `mb` command (as noted in the problem description) but is also used to validate the bucket name for other `mc` commands (eg: `mc events`). 

Examples: 
Scotts-MacBook-Pro-2:mc scott$ mc mb myminio/GoPro
mc: <ERROR> Unable to make bucket `myminio/GoPro`. Bucket names can contain lowercase alpha characters `a-z`, numbers '0-9', and '-'. First character cannot be a '-'
Scotts-MacBook-Pro-2:mc scott$ mc events list myminio/GoPro
mc: <ERROR> Cannot enable notification on the specified bucket. Bucket names can contain lowercase alpha characters `a-z`, numbers '0-9', and '-'. First character cannot be a '-'
Scotts-MacBook-Pro-2:mc scott$ 

Note: some `mc` commands (such as `ls` and `share`) will report other errors in this same case... We may need to look at these cases as well for consistency.

Scotts-MacBook-Pro-2:mc scott$ mc ls myminio/GoPro
mc: <ERROR> Unable to stat `myminio/GoPro`. Bucket name contains invalid characters.
Scotts-MacBook-Pro-2:mc scott$ mc share download myminio/GoPro
mc: <ERROR> Unable to stat `myminio/GoPro`. Bucket name contains invalid characters.
Scotts-MacBook-Pro-2:mc scott$ 



