### PR TITLE
mb: Add -p flag to ignore existing bucket/dir

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -942,7 +942,10 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan *clientContent) {
 }
 
 // MakeBucket - create a new bucket.
-func (f *fsClient) MakeBucket(region string) *probe.Error {
+func (f *fsClient) MakeBucket(region string, ignoreExisting bool) *probe.Error {
+	// TODO: ignoreExisting has no effect currently. In the future, we want
+	// to call os.Mkdir() when ignoredExisting is disabled and os.MkdirAll()
+	// otherwise.
 	e := os.MkdirAll(f.PathURL.Path, 0777)
 	if e != nil {
 		return probe.NewError(e)

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -193,7 +193,7 @@ func (s *TestSuite) TestPutBucket(c *C) {
 	bucketPath := filepath.Join(root, "bucket")
 	fsClient, err := fsNew(bucketPath)
 	c.Assert(err, IsNil)
-	err = fsClient.MakeBucket("us-east-1")
+	err = fsClient.MakeBucket("us-east-1", true)
 	c.Assert(err, IsNil)
 }
 
@@ -207,7 +207,7 @@ func (s *TestSuite) TestStatBucket(c *C) {
 
 	fsClient, err := fsNew(bucketPath)
 	c.Assert(err, IsNil)
-	err = fsClient.MakeBucket("us-east-1")
+	err = fsClient.MakeBucket("us-east-1", true)
 	c.Assert(err, IsNil)
 	_, err = fsClient.Stat(false)
 	c.Assert(err, IsNil)
@@ -222,7 +222,7 @@ func (s *TestSuite) TestBucketACLFails(c *C) {
 	bucketPath := filepath.Join(root, "bucket")
 	fsClient, err := fsNew(bucketPath)
 	c.Assert(err, IsNil)
-	err = fsClient.MakeBucket("us-east-1")
+	err = fsClient.MakeBucket("us-east-1", true)
 	c.Assert(err, IsNil)
 
 	// On windows setting permissions is not supported.

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -174,7 +174,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err := s3New(conf)
 	c.Assert(err, IsNil)
 
-	err = s3c.MakeBucket("us-east-1")
+	err = s3c.MakeBucket("us-east-1", true)
 	c.Assert(err, IsNil)
 
 	conf.HostURL = server.URL + string(s3c.GetURL().Separator)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -43,7 +43,7 @@ type Client interface {
 	List(isRecursive, isIncomplete bool, showDir DirOpt) <-chan *clientContent
 
 	// Bucket operations
-	MakeBucket(region string) *probe.Error
+	MakeBucket(region string, ignoreExisting bool) *probe.Error
 
 	// Access policy operations.
 	GetAccess() (access string, error *probe.Error)

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -32,6 +32,10 @@ var (
 			Value: "us-east-1",
 			Usage: "Specify bucket region. Defaults to `us-east-1`.",
 		},
+		cli.BoolFlag{
+			Name:  "ignore-existing, p",
+			Usage: "Ignore if bucket/directory already exists",
+		},
 	}
 )
 
@@ -108,6 +112,7 @@ func mainMakeBucket(ctx *cli.Context) error {
 
 	// Save region.
 	region := ctx.String("region")
+	ignoreExisting := ctx.Bool("p")
 
 	var cErr error
 	for i := range ctx.Args() {
@@ -121,7 +126,7 @@ func mainMakeBucket(ctx *cli.Context) error {
 		}
 
 		// Make bucket.
-		err = clnt.MakeBucket(region)
+		err = clnt.MakeBucket(region, ignoreExisting)
 		if err != nil {
 			errorIf(err.Trace(targetURL), "Unable to make bucket `"+targetURL+"`.")
 			cErr = exitStatus(globalErrorExitStatus)

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -578,7 +578,7 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context) *probe.Error {
 
 			if d.Diff == differInFirst {
 				// Bucket only exists in the source, create the same bucket in the destination
-				err := newDstClt.MakeBucket(ctx.String("region"))
+				err := newDstClt.MakeBucket(ctx.String("region"), false)
 				if err != nil {
 					mj.mirrorErr = err
 					errorIf(err, "Cannot created bucket in `"+newTgtURL+"`")


### PR DESCRIPTION
If a remote directory/bucket exists, -p will still make mb cmd
happy if the target already exists.

Fixes #2115 