### PR TITLE
cat: Ignore Stat() error and pass to Get()

### DIFF
--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -92,7 +92,7 @@ func catURL(sourceURL string) *probe.Error {
 		if client.GetURL().Type == objectStorage {
 			size = content.Size
 		}
-		if reader, err = getSourceStream(sourceURL); err != nil {
+		if reader, err = getSourceStreamFromURL(sourceURL); err != nil {
 			return err.Trace(sourceURL)
 		}
 	}

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -83,13 +83,13 @@ func catURL(sourceURL string) *probe.Error {
 		reader = os.Stdin
 	default:
 		var err *probe.Error
+		// Try to stat the object, the purpose is to extract the
+		// size of S3 object so we can check if the size of the
+		// downloaded object is equal to the original one. FS files
+		// are ignored since some of them have zero size though they
+		// have contents like files under /proc.
 		client, content, err := url2Stat(sourceURL)
-		if err != nil {
-			return err.Trace(sourceURL)
-		}
-		// Ignore size for filesystem objects since os.Stat() would not
-		// return proper size all the time, for example with /proc files.
-		if client.GetURL().Type == objectStorage {
+		if err == nil && client.GetURL().Type == objectStorage {
 			size = content.Size
 		}
 		if reader, err = getSourceStreamFromURL(sourceURL); err != nil {

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -449,9 +449,8 @@ func (f *fsClient) Copy(source string, size int64, progress io.Reader) *probe.Er
 	return nil
 }
 
-// get - get wrapper returning reader and additional metadata if any.
-// currently only returns metadata.
-func (f *fsClient) get() (io.Reader, map[string][]string, *probe.Error) {
+// get - get wrapper returning object reader.
+func (f *fsClient) get() (io.Reader, *probe.Error) {
 	tmppath := f.PathURL.Path
 	// Golang strips trailing / if you clean(..) or
 	// EvalSymlinks(..). Adding '.' prevents it from doing so.
@@ -463,21 +462,18 @@ func (f *fsClient) get() (io.Reader, map[string][]string, *probe.Error) {
 	_, e := filepath.EvalSymlinks(tmppath)
 	if e != nil {
 		err := f.toClientError(e, f.PathURL.Path)
-		return nil, nil, err.Trace(f.PathURL.Path)
+		return nil, err.Trace(f.PathURL.Path)
 	}
 	fileData, e := os.Open(f.PathURL.Path)
 	if e != nil {
 		err := f.toClientError(e, f.PathURL.Path)
-		return nil, nil, err.Trace(f.PathURL.Path)
+		return nil, err.Trace(f.PathURL.Path)
 	}
-	metadata := map[string][]string{
-		"Content-Type": {guessURLContentType(f.PathURL.Path)},
-	}
-	return fileData, metadata, nil
+	return fileData, nil
 }
 
 // Get returns reader and any additional metadata.
-func (f *fsClient) Get() (io.Reader, map[string][]string, *probe.Error) {
+func (f *fsClient) Get() (io.Reader, *probe.Error) {
 	return f.get()
 }
 
@@ -1021,6 +1017,9 @@ func (f *fsClient) Stat(isIncomplete bool) (content *clientContent, err *probe.E
 	content.Size = st.Size()
 	content.Time = st.ModTime()
 	content.Type = st.Mode()
+	content.Metadata = map[string][]string{
+		"Content-Type": {guessURLContentType(f.PathURL.Path)},
+	}
 	return content, nil
 }
 

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -274,7 +274,7 @@ func (s *TestSuite) TestGet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, _, err = fsClient.Get()
+	reader, err = fsClient.Get()
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	_, e = io.Copy(&results, reader)
@@ -302,7 +302,7 @@ func (s *TestSuite) TestGetRange(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, _, err = fsClient.Get()
+	reader, err = fsClient.Get()
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	buf := make([]byte, 5)

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -497,40 +497,27 @@ func (c *s3Client) Watch(params watchParams) (*watchObject, *probe.Error) {
 }
 
 // Get - get object with metadata.
-func (c *s3Client) Get() (io.Reader, map[string][]string, *probe.Error) {
+func (c *s3Client) Get() (io.Reader, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	reader, e := c.api.GetObject(bucket, object)
 	if e != nil {
 		errResponse := minio.ToErrorResponse(e)
 		if errResponse.Code == "NoSuchBucket" {
-			return nil, nil, probe.NewError(BucketDoesNotExist{
+			return nil, probe.NewError(BucketDoesNotExist{
 				Bucket: bucket,
 			})
 		}
 		if errResponse.Code == "InvalidBucketName" {
-			return nil, nil, probe.NewError(BucketInvalid{
+			return nil, probe.NewError(BucketInvalid{
 				Bucket: bucket,
 			})
 		}
 		if errResponse.Code == "NoSuchKey" || errResponse.Code == "InvalidArgument" {
-			return nil, nil, probe.NewError(ObjectMissing{})
+			return nil, probe.NewError(ObjectMissing{})
 		}
-		return nil, nil, probe.NewError(e)
+		return nil, probe.NewError(e)
 	}
-	objInfo, e := reader.Stat()
-	if e != nil {
-		errResponse := minio.ToErrorResponse(e)
-		if errResponse.Code == "AccessDenied" {
-			return nil, nil, probe.NewError(PathInsufficientPermission{Path: c.targetURL.String()})
-		}
-		if errResponse.Code == "NoSuchKey" || errResponse.Code == "InvalidArgument" {
-			return nil, nil, probe.NewError(ObjectMissing{})
-		}
-		return nil, nil, probe.NewError(e)
-	}
-	metadata := objInfo.Metadata
-	metadata.Set("Content-Type", objInfo.ContentType)
-	return reader, metadata, nil
+	return reader, nil
 }
 
 // Copy - copy object
@@ -849,6 +836,7 @@ func (c *s3Client) Stat(isIncomplete bool) (*clientContent, *probe.Error) {
 		bucketMetadata := &clientContent{}
 		bucketMetadata.URL = *c.targetURL
 		bucketMetadata.Type = os.ModeDir
+		bucketMetadata.Metadata = map[string][]string{}
 
 		return bucketMetadata, nil
 	}
@@ -872,12 +860,14 @@ func (c *s3Client) Stat(isIncomplete bool) (*clientContent, *probe.Error) {
 				objectMetadata.Time = objectMultipartInfo.Initiated
 				objectMetadata.Size = objectMultipartInfo.Size
 				objectMetadata.Type = os.FileMode(0664)
+				objectMetadata.Metadata = map[string][]string{}
 				return objectMetadata, nil
 			}
 
 			if strings.HasSuffix(objectMultipartInfo.Key, string(c.targetURL.Separator)) {
 				objectMetadata.URL = *c.targetURL
 				objectMetadata.Type = os.ModeDir
+				objectMetadata.Metadata = map[string][]string{}
 				return objectMetadata, nil
 			}
 		}
@@ -894,12 +884,14 @@ func (c *s3Client) Stat(isIncomplete bool) (*clientContent, *probe.Error) {
 			objectMetadata.Time = objectStat.LastModified
 			objectMetadata.Size = objectStat.Size
 			objectMetadata.Type = os.FileMode(0664)
+			objectMetadata.Metadata = map[string][]string{}
 			return objectMetadata, nil
 		}
 
 		if strings.HasSuffix(objectStat.Key, string(c.targetURL.Separator)) {
 			objectMetadata.URL = *c.targetURL
 			objectMetadata.Type = os.ModeDir
+			objectMetadata.Metadata = map[string][]string{}
 			return objectMetadata, nil
 		}
 	}
@@ -928,6 +920,11 @@ func (c *s3Client) Stat(isIncomplete bool) (*clientContent, *probe.Error) {
 	objectMetadata.Time = objectStat.LastModified
 	objectMetadata.Size = objectStat.Size
 	objectMetadata.Type = os.FileMode(0664)
+
+	metadata := objectStat.Metadata
+	metadata.Set("Content-Type", objectStat.ContentType)
+	objectMetadata.Metadata = metadata
+
 	return objectMetadata, nil
 }
 

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -229,7 +229,7 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(object.data)))
 
-	reader, _, err = s3c.Get()
+	reader, err = s3c.Get()
 	c.Assert(err, IsNil)
 	var buffer bytes.Buffer
 	{

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -54,7 +54,7 @@ type Client interface {
 	Copy(source string, size int64, progress io.Reader) *probe.Error
 
 	// I/O operations with metadata.
-	Get() (reader io.Reader, metadata map[string][]string, err *probe.Error)
+	Get() (reader io.Reader, err *probe.Error)
 	Put(reader io.Reader, size int64, metadata map[string][]string, progress io.Reader) (n int64, err *probe.Error)
 
 	// I/O operations with expiration
@@ -73,11 +73,12 @@ type Client interface {
 
 // Content container for content metadata
 type clientContent struct {
-	URL  clientURL
-	Time time.Time
-	Size int64
-	Type os.FileMode
-	Err  *probe.Error
+	URL      clientURL
+	Time     time.Time
+	Size     int64
+	Type     os.FileMode
+	Metadata map[string][]string
+	Err      *probe.Error
 }
 
 // Config - see http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -68,7 +68,7 @@ func pipe(targetURL string) *probe.Error {
 	// Stream from stdin to multiple objects until EOF.
 	// Ignore size, since os.Stat() would not return proper size all the time
 	// for local filesystem for example /proc files.
-	_, err := putTargetStream(targetURL, os.Stdin, -1)
+	_, err := putTargetStreamWithURL(targetURL, os.Stdin, -1)
 	// TODO: See if this check is necessary.
 	switch e := err.ToGoError().(type) {
 	case *os.PathError:


### PR DESCRIPTION
client-s3.Get() calls Stat() method because Get() is supposed to return
object metadata. This PR makes a change in client interface so metadata
is returned in Stat() method. This is beneficial for us to avoid calling
HEAD method in S3 when run `mc cat`

Fixes #2156 


