### PR TITLE
fix: Set quiet when term width is unavailable

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -64,6 +64,9 @@ var (
 )
 
 var (
+	// Terminal width
+	globalTermWidth int
+
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,12 +77,17 @@ func Main() {
 	probe.SetAppInfo("Release-Tag", ReleaseTag)
 	probe.SetAppInfo("Commit", ShortCommitID)
 
+	// Fetch terminal size, if not available, automatically
+	// set globalQuiet to true.
+	if w, e := pb.GetTerminalWidth(); e != nil {
+		globalQuiet = true
+	} else {
+		globalTermWidth = w
+	}
+
 	app := registerApp()
 	app.Before = registerBefore
 	app.ExtraInfo = func() map[string]string {
-		if _, e := pb.GetTerminalWidth(); e != nil {
-			globalQuiet = true
-		}
 		if globalDebug {
 			return getSystemData()
 		}

--- a/cmd/scan-bar.go
+++ b/cmd/scan-bar.go
@@ -20,10 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cheggaaa/pb"
 	"github.com/dustin/go-humanize"
 	"github.com/minio/mc/pkg/console"
-	"github.com/minio/minio/pkg/probe"
 )
 
 // fixateScanBar truncates or stretches text to fit within the terminal size.
@@ -46,14 +44,12 @@ type scanBarFunc func(string)
 // scanBarFactory returns a progress bar function to report URL scanning.
 func scanBarFactory() scanBarFunc {
 	fileCount := 0
-	termWidth, e := pb.GetTerminalWidth()
-	fatalIf(probe.NewError(e), "Unable to get terminal size. Please use --quiet option.")
 
 	// Cursor animate channel.
 	cursorCh := cursorAnimate()
 	return func(source string) {
 		scanPrefix := fmt.Sprintf("[%s] %s ", humanize.Comma(int64(fileCount)), string(<-cursorCh))
-		source = fixateScanBar(source, termWidth-len([]rune(scanPrefix)))
+		source = fixateScanBar(source, globalTermWidth-len([]rune(scanPrefix)))
 		barText := scanPrefix + source
 		console.PrintC("\r" + barText + "\r")
 		fileCount++


### PR DESCRIPTION
mc was asking the user to provide --quiet flag when terminal
width is not available for any reason. This PR tries to fetch
the terminal width at mc startup and automatically set quiet flag
when it fails to fetch the width.

Fixes #2172 