### PR TITLE
config: Hosts listing cuts fields and adds '...'

### DIFF
--- a/cmd/config-host-list.go
+++ b/cmd/config-host-list.go
@@ -94,7 +94,12 @@ func printHosts(hosts ...hostMessage) {
 	}
 	for _, host := range hosts {
 		// Format properly for alignment based on alias length.
-		host.Alias = fmt.Sprintf("%-*.*s", maxAlias, maxAlias, host.Alias)
+		host.Alias = fmt.Sprintf("%-*.*s:", maxAlias, maxAlias, host.Alias)
+		if host.AccessKey == "" || host.SecretKey == "" {
+			host.AccessKey = ""
+			host.SecretKey = ""
+			host.API = ""
+		}
 		printMsg(host)
 	}
 }
@@ -115,12 +120,13 @@ func listHosts(alias string) {
 	if alias != "" {
 		if v, ok := conf.Hosts[alias]; ok {
 			printHosts(hostMessage{
-				op:        "list",
-				Alias:     alias,
-				URL:       v.URL,
-				AccessKey: v.AccessKey,
-				SecretKey: v.SecretKey,
-				API:       v.API,
+				op:          "list",
+				prettyPrint: false,
+				Alias:       alias,
+				URL:         v.URL,
+				AccessKey:   v.AccessKey,
+				SecretKey:   v.SecretKey,
+				API:         v.API,
 			})
 			return
 		}
@@ -130,12 +136,13 @@ func listHosts(alias string) {
 	var hosts []hostMessage
 	for k, v := range conf.Hosts {
 		hosts = append(hosts, hostMessage{
-			op:        "list",
-			Alias:     k,
-			URL:       v.URL,
-			AccessKey: v.AccessKey,
-			SecretKey: v.SecretKey,
-			API:       v.API,
+			op:          "list",
+			prettyPrint: true,
+			Alias:       k,
+			URL:         v.URL,
+			AccessKey:   v.AccessKey,
+			SecretKey:   v.SecretKey,
+			API:         v.API,
 		})
 	}
 

--- a/cmd/pretty-table.go
+++ b/cmd/pretty-table.go
@@ -1,0 +1,84 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/minio/mc/pkg/console"
+)
+
+// Field configuration: color theme and max content length
+type Field struct {
+	colorTheme string
+	maxLen     int
+}
+
+// PrettyTable - an easy struct to format a set of line
+type PrettyTable struct {
+	cols      []Field
+	separator string
+}
+
+// newPrettyTable - creates a new pretty table
+func newPrettyTable(separator string, cols ...Field) PrettyTable {
+	return PrettyTable{
+		cols:      cols,
+		separator: separator,
+	}
+}
+
+// buildRow - creates a string which represents a line table given
+// some fields contents.
+func (t PrettyTable) buildRow(contents ...string) (line string) {
+	dots := "..."
+
+	// totalColumns is the minimum of the number of fields config
+	// and the number of contents elements.
+	totalColumns := len(contents)
+	if len(t.cols) < totalColumns {
+		totalColumns = len(t.cols)
+	}
+
+	// Format fields and construct message
+	for i := 0; i < totalColumns; i++ {
+		// Default field format without pretty effect
+		fieldContent := ""
+		fieldFormat := "%s"
+		if t.cols[i].maxLen >= 0 {
+			// Override field format
+			fieldFormat = fmt.Sprintf("%%-%d.%ds", t.cols[i].maxLen, t.cols[i].maxLen)
+			// Cut field string and add '...' if length is greater than maxLen
+			if len(contents[i]) > t.cols[i].maxLen {
+				fieldContent = contents[i][:t.cols[i].maxLen-len(dots)] + dots
+			} else {
+				fieldContent = contents[i]
+			}
+		} else {
+			fieldContent = contents[i]
+		}
+
+		// Add separator if this is not the last column
+		if i < totalColumns-1 {
+			fieldFormat += t.separator
+		}
+
+		// Add the field to the resulted message
+		line += console.Colorize(t.cols[i].colorTheme, fmt.Sprintf(fieldFormat, fieldContent))
+	}
+	return
+}

--- a/cmd/pretty-table_test.go
+++ b/cmd/pretty-table_test.go
@@ -1,0 +1,51 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "testing"
+
+// TestPrettyTable - testing the behavior of the pretty table module
+func TestPrettyTable(t *testing.T) {
+
+	testCases := []struct {
+		sep         string
+		tf          []Field
+		contents    []string
+		expectedRow string
+	}{
+		// Test 1: empty parameter, empty table
+		{"", []Field{}, []string{}, ""},
+		// Test 2: one field, without any specific customization
+		{"", []Field{Field{"", -1}}, []string{"abcd"}, "abcd"},
+		// Test 3: one field, without 5 chars len
+		{"", []Field{Field{"", 5}}, []string{"my-long-field"}, "my..."},
+		// Test 4: one separator, one content
+		{" | ", []Field{Field{"", -1}}, []string{"abcd"}, "abcd"},
+		// Test 5: one separtor, multiple contents
+		{" | ", []Field{Field{"", -1}, Field{"", -1}, Field{"", -1}}, []string{"column1", "column2", "column3"}, "column1 | column2 | column3"},
+		// Test 6: multiple fields
+		{" | ", []Field{Field{"", 5}, Field{"", -1}}, []string{"144550032", "my long content that should not be cut"}, "14... | my long content that should not be cut"},
+	}
+
+	for idx, testCase := range testCases {
+		tb := newPrettyTable(testCase.sep, testCase.tf...)
+		row := tb.buildRow(testCase.contents...)
+		if row != testCase.expectedRow {
+			t.Fatalf("Test %d: generated row not matching, expected = `%s`, found = `%s`", idx+1, testCase.expectedRow, row)
+		}
+	}
+}


### PR DESCRIPTION
Fields's contents are cutted when the user lists
the configured aliases (mc config host list) 

New format:

  New host list format when listing several hosts
```
  myminiopublic :    http://localhost:9000
  myminios      :    https://minio1.duckdns.org:...  Q3AM3UQ867SPQQA43P2F  zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG  S3v4
  testazure     :    http://172.17.0.7:9000          myazureac             Gh5543wekitnifILbZam1KYY3TGlswRminio1...  S3v4
```
  
  New host list format when listing one host:
```
  azure :  http://localhost:9000  myazureac  Gh5543wekitnifILbZam1KYY3TGlswRminio1u7BJ86wekitnifILbZam1K==  S3v4

```