### PR TITLE
Add Docker release files for mc

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,9 @@
+FROM alpine:3.5
+
+RUN \
+    apk add --no-cache ca-certificates && \
+    apk add --no-cache --virtual .build-deps curl && \
+    curl https://dl.minio.io/client/mc/release/linux-amd64/mc > /usr/bin/mc && \
+    chmod +x /usr/bin/mc && apk del .build-deps
+
+ENTRYPOINT ["mc"]

--- a/Dockerfile.release.aarch64
+++ b/Dockerfile.release.aarch64
@@ -1,0 +1,9 @@
+FROM resin/aarch64-alpine:3.5
+
+RUN \
+    apk add --no-cache ca-certificates && \
+    apk add --no-cache --virtual .build-deps curl && \
+    curl https://dl.minio.io/client/mc/release/linux-arm64/mc > /usr/bin/mc && \
+    chmod +x /usr/bin/mc && apk del .build-deps
+    
+ENTRYPOINT ["mc"]

--- a/Dockerfile.release.armhf
+++ b/Dockerfile.release.armhf
@@ -1,0 +1,9 @@
+FROM resin/armhf-alpine:3.5
+
+RUN \
+    apk add --no-cache ca-certificates && \
+    apk add --no-cache --virtual .build-deps curl && \
+    curl https://dl.minio.io/client/mc/release/linux-arm/mc > /usr/bin/mc && \
+    chmod +x /usr/bin/mc && apk del .build-deps
+    
+ENTRYPOINT ["mc"]


### PR DESCRIPTION
These Dockerfile(s) will be used for `mc` release images for various platforms. 

Statically built binary is downloaded from dl.minio.io website and used in the docker image