### PR TITLE
mirror: Add timestamp check similar to aws s3 sync

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -91,6 +91,8 @@ func (d diffMessage) String() string {
 		msg = console.Colorize("DiffType", "! "+d.SecondURL)
 	case differInSize:
 		msg = console.Colorize("DiffSize", "! "+d.SecondURL)
+	case differInTime:
+		msg = console.Colorize("DiffTime", "! "+d.SecondURL)
 	default:
 		fatalIf(errDummy().Trace(d.FirstURL, d.SecondURL),
 			"Unhandled difference between `"+d.FirstURL+"` and `"+d.SecondURL+"`.")
@@ -198,6 +200,7 @@ func mainDiff(ctx *cli.Context) error {
 	console.SetColor("DiffOnlyInSecond", color.New(color.FgGreen))
 	console.SetColor("DiffType", color.New(color.FgMagenta))
 	console.SetColor("DiffSize", color.New(color.FgYellow, color.Bold))
+	console.SetColor("DiffTime", color.New(color.FgYellow, color.Bold))
 
 	URLs := ctx.Args()
 	firstURL := URLs.Get(0)

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -108,7 +108,7 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 		case differInType:
 			URLsCh <- URLs{Error: errInvalidTarget(diffMsg.SecondURL)}
 			continue
-		case differInSize:
+		case differInSize, differInTime:
 			if !isForce && !isFake {
 				// Size differs and force not set
 				URLsCh <- URLs{Error: errOverWriteNotAllowed(diffMsg.SecondURL)}


### PR DESCRIPTION
Currently `mc mirror` requires source to be
uploaded only if the size is different than the
object on remote server. This PR adds support to
check for last modified time of the source object
as well such that we upload if there are timestamp
differences as well.

Fixes #2187