### PR TITLE
[WIP] Add support of objects encryption

### DIFF
--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -29,7 +29,12 @@ import (
 )
 
 var (
-	catFlags = []cli.Flag{}
+	catFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "encrypt-key",
+			Usage: "Encrypt data with the given key.",
+		},
+	}
 )
 
 // Display contents of a file.
@@ -75,7 +80,7 @@ func checkCatSyntax(ctx *cli.Context) {
 }
 
 // catURL displays contents of a URL to stdout.
-func catURL(sourceURL string) *probe.Error {
+func catURL(sourceURL string, encryptKey string) *probe.Error {
 	var reader io.Reader
 	size := int64(-1)
 	switch sourceURL {
@@ -92,7 +97,7 @@ func catURL(sourceURL string) *probe.Error {
 		if client.GetURL().Type == objectStorage {
 			size = content.Size
 		}
-		if reader, err = getSourceStream(sourceURL); err != nil {
+		if reader, err = getSourceStream(sourceURL, encryptKey); err != nil {
 			return err.Trace(sourceURL)
 		}
 	}
@@ -163,9 +168,11 @@ func mainCat(ctx *cli.Context) error {
 		}
 	}
 
+	encryptKey := ctx.String("encrypt-key")
+
 	// Convert arguments to URLs: expand alias, fix format.
 	for _, url := range args {
-		fatalIf(catURL(url).Trace(url), "Unable to read from `"+url+"`.")
+		fatalIf(catURL(url, encryptKey).Trace(url), "Unable to read from `"+url+"`.")
 	}
 	return nil
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -57,6 +57,12 @@ type Client interface {
 	Get() (reader io.Reader, metadata map[string][]string, err *probe.Error)
 	Put(reader io.Reader, size int64, metadata map[string][]string, progress io.Reader) (n int64, err *probe.Error)
 
+	// I/O operations with metadata.
+	CopyEnc(source string, size int64, key string, progress io.Reader) *probe.Error
+
+	GetEnc(key string) (reader io.Reader, metadata map[string][]string, err *probe.Error)
+	PutEnc(reader io.Reader, size int64, metadata map[string][]string, key string, progress io.Reader) (n int64, err *probe.Error)
+
 	// I/O operations with expiration
 	ShareDownload(expires time.Duration) (string, *probe.Error)
 	ShareUpload(bool, time.Duration, string) (string, map[string]string, *probe.Error)

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -218,7 +218,7 @@ func (mj *mirrorJob) doMirror(sURLs URLs) URLs {
 		TotalCount: sURLs.TotalCount,
 		TotalSize:  sURLs.TotalSize,
 	})
-	return uploadSourceToTargetURL(sURLs, mj.status)
+	return uploadSourceToTargetURL(sURLs, "", mj.status)
 }
 
 // Go routine to update progress status


### PR DESCRIPTION
This change is not complete yet.

Streaming encryption produces encrypted data with a length equals to the plain version of the data. We need streaming so mirroring can work effectively: mirroring needs to know the size of the source and target object size to compare and decide if it should mirror or not, but in some encryption algorithms like CBC, it is not the same (though close) so it would be difficult to decide if we should upload or not.

Streaming has its own disadvantages.. I am investigation..

Fixes #2074 