### PR TITLE
mirror/diff: Ignore errors during objectDifference.

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -180,7 +180,8 @@ func doDiffMain(firstURL, secondURL string) error {
 	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
-			break
+			// Ignore error and proceed to next object.
+			continue
 		}
 		printMsg(diffMsg)
 	}

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -99,7 +99,8 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to mirror objects.")
-			break
+			// Ignore error and proceed to next object.
+			continue
 		}
 		switch diffMsg.Diff {
 		case differInNone:


### PR DESCRIPTION
Files which are broken in symlink, not accessible
and unsupported should be ignored. We should proceed
to next object.

Fixes #2199