### PR TITLE
Improved experimental log of mc admin heal

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -49,7 +49,7 @@ var (
 var adminHealCmd = cli.Command{
 	Name:            "heal",
 	Usage:           "Manage heal tasks",
-	Before:          setGlobalsFromContext,
+	Before:          adminHealBefore,
 	Action:          mainAdminHeal,
 	Flags:           append(adminHealFlags, globalFlags...),
 	HideHelpCommand: true,
@@ -97,6 +97,12 @@ type healMessage struct {
 	Bucket string             `json:"bucket"`
 	Object *madmin.ObjectInfo `json:"object"`
 	Upload *madmin.UploadInfo `json:"upload"`
+}
+
+// adminHealBefore used to provide users with temporary warning message
+func adminHealBefore(ctx *cli.Context) error {
+	color.Yellow("\t *** mc admin heal is EXPERIMENTAL ***")
+	return setGlobalsFromContext(ctx)
 }
 
 // String colorized service status message.

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -16,10 +16,7 @@
 
 package cmd
 
-import (
-	"github.com/fatih/color"
-	"github.com/minio/cli"
-)
+import "github.com/minio/cli"
 
 var (
 	adminFlags = []cli.Flag{}
@@ -30,7 +27,7 @@ var adminCmd = cli.Command{
 	Usage:           "Manage Minio servers",
 	Action:          mainAdmin,
 	HideHelpCommand: true,
-	Before:          mainAdminBefore,
+	Before:          setGlobalsFromContext,
 	Flags:           append(adminFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		adminServiceCmd,
@@ -40,11 +37,6 @@ var adminCmd = cli.Command{
 		adminLockCmd,
 		adminHealCmd,
 	},
-}
-
-func mainAdminBefore(ctx *cli.Context) error {
-	color.Yellow("\t *** mc admin heal is EXPERIMENTAL ***")
-	return setGlobalsFromContext(ctx)
 }
 
 // mainAdmin is the handle for "mc admin" command.


### PR DESCRIPTION
"mc admin heal" is now the only command mc command which will result in the "mc admin heal is EXPERIMENTAL" text in yellow

Fixes #2219 