### PR TITLE
Allow multipart threads to be configured via environment variable

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -58,7 +58,10 @@ USAGE:
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
-  {{end}}
+	{{end}}
+ENVIRONMENT VARIABLES:
+	DEFAULT_MULTIPART_THREADS: To set number of multipart threads. By default it is 3.
+
 EXAMPLES:
    1. Copy a list of objects from local file system to Amazon S3 cloud storage.
       $ {{.HelpName}} Music/*.ogg s3/jukebox/

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -78,7 +78,10 @@ USAGE:
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
-  {{end}}
+	{{end}}
+ENVIRONMENT VARIABLES:
+	DEFAULT_MULTIPART_THREADS: To set number of multipart threads. By default it is 3.
+
 EXAMPLES:
    1. Mirror a bucket recursively from Minio cloud storage to a bucket on Amazon S3 cloud storage.
       $ {{.HelpName}} play/photos/2014 s3/backup-photos


### PR DESCRIPTION
Fixes #1974. 

Allow number of threads used by mc/cp operations for large uploads to be configurable by allowing a new environment variable DEFAULT_MULTIPART_THREADS that can be set by the user before starting a large upload operation. The companion PR for minio-go is https://github.com/minio/minio-go/pull/794