### PR TITLE
Rename the snap to minio-client

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: mc
+name: minio-client
 version: master
 summary: ls, cp, mkdir, mirror commands for filesystems and object storage.
 description: |
@@ -10,9 +10,10 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: devmode
 
 apps:
-  mc:
+  minio-client:
     command: mc
     plugs: [home, network, network-bind]
+    aliases: [mc]
 
 parts:
   mc:


### PR DESCRIPTION
In linux, mc is midnight commander.
In the traditional linux distro world, name conflicts are forbidden. Because we are trying to make this decentralized and self-serving, we need less strict rules. For this, we added the concept of aliases. Then the user can decide what application owns the mc name.

You could make a claim for the mc name, and keep it. But I think it would be less confusing for existing linux users to rename the snap and use mc as an alias.

I would love your feedback about this feature. Please let me know what do you think. Also, this needs somebody from your org to register the new name in build.snapcraft.io to get the continuous delivery working.