### PR TITLE
Vendorize new changes from minio-go

### DIFF
--- a/vendor/github.com/minio/minio-go/api-compose-object.go
+++ b/vendor/github.com/minio/minio-go/api-compose-object.go
@@ -309,7 +309,7 @@ func (c Client) uploadPartCopy(bucket, object, uploadID string, partNumber int,
 // server-side copying operations.
 func (c Client) ComposeObject(dst DestinationInfo, srcs []SourceInfo) error {
 	if len(srcs) < 1 || len(srcs) > maxPartsCount {
-		return ErrInvalidArgument("There must be as least one and upto 10000 source objects.")
+		return ErrInvalidArgument("There must be as least one and up to 10000 source objects.")
 	}
 
 	srcSizes := make([]int64, len(srcs))

--- a/vendor/github.com/minio/minio-go/api-presigned.go
+++ b/vendor/github.com/minio/minio-go/api-presigned.go
@@ -84,17 +84,33 @@ func (c Client) presignURL(method string, bucketName string, objectName string, 
 }
 
 // PresignedGetObject - Returns a presigned URL to access an object
-// without credentials. Expires maximum is 7days - ie. 604800 and
-// minimum is 1. Additionally you can override a set of response
-// headers using the query parameters.
+// data without credentials. URL can have a maximum expiry of
+// upto 7days or a minimum of 1sec. Additionally you can override
+// a set of response headers using the query parameters.
 func (c Client) PresignedGetObject(bucketName string, objectName string, expires time.Duration, reqParams url.Values) (u *url.URL, err error) {
 	return c.presignURL("GET", bucketName, objectName, expires, reqParams)
 }
 
-// PresignedPutObject - Returns a presigned URL to upload an object without credentials.
-// Expires maximum is 7days - ie. 604800 and minimum is 1.
+// PresignedHeadObject - Returns a presigned URL to access object
+// metadata without credentials. URL can have a maximum expiry of
+// upto 7days or a minimum of 1sec. Additionally you can override
+// a set of response headers using the query parameters.
+func (c Client) PresignedHeadObject(bucketName string, objectName string, expires time.Duration, reqParams url.Values) (u *url.URL, err error) {
+	return c.presignURL("HEAD", bucketName, objectName, expires, reqParams)
+}
+
+// PresignedPutObject - Returns a presigned URL to upload an object
+// without credentials. URL can have a maximum expiry of upto 7days
+// or a minimum of 1sec.
 func (c Client) PresignedPutObject(bucketName string, objectName string, expires time.Duration) (u *url.URL, err error) {
 	return c.presignURL("PUT", bucketName, objectName, expires, nil)
+}
+
+// Presign - returns a presigned URL for any http method of your choice
+// along with custom request params. URL can have a maximum expiry of
+// upto 7days or a minimum of 1sec.
+func (c Client) Presign(method string, bucketName string, objectName string, expires time.Duration, reqParams url.Values) (u *url.URL, err error) {
+	return c.presignURL(method, bucketName, objectName, expires, reqParams)
 }
 
 // PresignedPostPolicy - Returns POST urlString, form data to upload an object.

--- a/vendor/github.com/minio/minio-go/api-put-object-common.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-common.go
@@ -17,7 +17,6 @@
 package minio
 
 import (
-	"hash"
 	"io"
 	"math"
 	"os"
@@ -74,28 +73,6 @@ func optimalPartInfo(objectSize int64) (totalPartsCount int, partSize int64, las
 	// Last part size.
 	lastPartSize = objectSize - int64(totalPartsCount-1)*partSize
 	return totalPartsCount, partSize, lastPartSize, nil
-}
-
-// hashCopyN - Calculates chosen hashes up to partSize amount of bytes.
-func hashCopyN(hashAlgorithms map[string]hash.Hash, hashSums map[string][]byte, writer io.Writer, reader io.Reader, partSize int64) (size int64, err error) {
-	hashWriter := writer
-	for _, v := range hashAlgorithms {
-		hashWriter = io.MultiWriter(hashWriter, v)
-	}
-
-	// Copies to input at writer.
-	size, err = io.CopyN(hashWriter, reader, partSize)
-	if err != nil {
-		// If not EOF return error right here.
-		if err != io.EOF {
-			return 0, err
-		}
-	}
-
-	for k, v := range hashAlgorithms {
-		hashSums[k] = v.Sum(nil)
-	}
-	return size, err
 }
 
 // getUploadID - fetch upload id if already present for an object name

--- a/vendor/github.com/minio/minio-go/api-put-object-encrypted.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-encrypted.go
@@ -42,5 +42,5 @@ func (c Client) PutEncryptedObject(bucketName, objectName string, reader io.Read
 	metadata[amzHeaderKey] = []string{encryptMaterials.GetKey()}
 	metadata[amzHeaderMatDesc] = []string{encryptMaterials.GetDesc()}
 
-	return c.putObjectMultipart(bucketName, objectName, encryptMaterials, -1, metadata, progress)
+	return c.putObjectMultipartStreamNoLength(bucketName, objectName, encryptMaterials, metadata, progress)
 }

--- a/vendor/github.com/minio/minio-go/api-put-object-streaming.go
+++ b/vendor/github.com/minio/minio-go/api-put-object-streaming.go
@@ -153,7 +153,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 
 	// Receive each part number from the channel allowing three parallel uploads.
 	for w := 1; w <= totalWorkers; w++ {
-		go func() {
+		go func(partSize int64) {
 			// Each worker will draw from the part channel and upload in parallel.
 			for uploadReq := range uploadPartsCh {
 
@@ -197,7 +197,7 @@ func (c Client) putObjectMultipartStreamFromReadAt(bucketName, objectName string
 					Error:   nil,
 				}
 			}
-		}()
+		}(partSize)
 	}
 
 	// Gather the responses as they occur and update any

--- a/vendor/github.com/minio/minio-go/api-put-object.go
+++ b/vendor/github.com/minio/minio-go/api-put-object.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -180,6 +181,7 @@ func (c Client) PutObjectWithProgress(bucketName, objectName string, reader io.R
 	if err != nil {
 		return 0, err
 	}
+
 	return c.putObjectCommon(bucketName, objectName, reader, size, metadata, progress)
 }
 
@@ -203,7 +205,7 @@ func (c Client) putObjectCommon(bucketName, objectName string, reader io.Reader,
 	}
 
 	if size < 0 {
-		return c.putObjectMultipartStreamNoLength(bucketName, objectName, reader, size, metadata, progress)
+		return c.putObjectMultipartStreamNoLength(bucketName, objectName, reader, metadata, progress)
 	}
 
 	if size < minPartSize {
@@ -214,8 +216,8 @@ func (c Client) putObjectCommon(bucketName, objectName string, reader io.Reader,
 	return c.putObjectMultipartStream(bucketName, objectName, reader, size, metadata, progress)
 }
 
-func (c Client) putObjectMultipartStreamNoLength(bucketName, objectName string, reader io.Reader, size int64,
-	metadata map[string][]string, progress io.Reader) (n int64, err error) {
+func (c Client) putObjectMultipartStreamNoLength(bucketName, objectName string, reader io.Reader, metadata map[string][]string,
+	progress io.Reader) (n int64, err error) {
 	// Input validation.
 	if err = s3utils.CheckValidBucketName(bucketName); err != nil {
 		return 0, err
@@ -232,7 +234,7 @@ func (c Client) putObjectMultipartStreamNoLength(bucketName, objectName string, 
 	var complMultipartUpload completeMultipartUpload
 
 	// Calculate the optimal parts info for a given size.
-	totalPartsCount, partSize, _, err := optimalPartInfo(size)
+	totalPartsCount, partSize, _, err := optimalPartInfo(-1)
 	if err != nil {
 		return 0, err
 	}
@@ -252,57 +254,47 @@ func (c Client) putObjectMultipartStreamNoLength(bucketName, objectName string, 
 	// Part number always starts with '1'.
 	partNumber := 1
 
-	// Initialize a temporary buffer.
-	tmpBuffer := new(bytes.Buffer)
-
 	// Initialize parts uploaded map.
 	partsInfo := make(map[int]ObjectPart)
 
+	// Create a buffer.
+	buf := make([]byte, partSize)
+	defer debug.FreeOSMemory()
+
 	for partNumber <= totalPartsCount {
-		// Calculates hash sums while copying partSize bytes into tmpBuffer.
-		prtSize, rErr := io.CopyN(tmpBuffer, reader, partSize)
-		if rErr != nil && rErr != io.EOF {
+		length, rErr := io.ReadFull(reader, buf)
+		if rErr == io.EOF {
+			break
+		}
+		if rErr != nil && rErr != io.ErrUnexpectedEOF {
 			return 0, rErr
 		}
 
-		var reader io.Reader
 		// Update progress reader appropriately to the latest offset
 		// as we read from the source.
-		reader = newHook(tmpBuffer, progress)
+		rd := newHook(bytes.NewReader(buf[:length]), progress)
 
 		// Proceed to upload the part.
 		var objPart ObjectPart
-		objPart, err = c.uploadPart(bucketName, objectName, uploadID, reader, partNumber,
-			nil, nil, prtSize, metadata)
+		objPart, err = c.uploadPart(bucketName, objectName, uploadID, rd, partNumber,
+			nil, nil, int64(length), metadata)
 		if err != nil {
-			// Reset the temporary buffer upon any error.
-			tmpBuffer.Reset()
 			return totalUploadedSize, err
 		}
 
 		// Save successfully uploaded part metadata.
 		partsInfo[partNumber] = objPart
 
-		// Reset the temporary buffer.
-		tmpBuffer.Reset()
-
 		// Save successfully uploaded size.
-		totalUploadedSize += prtSize
+		totalUploadedSize += int64(length)
 
 		// Increment part number.
 		partNumber++
 
 		// For unknown size, Read EOF we break away.
 		// We do not have to upload till totalPartsCount.
-		if size < 0 && rErr == io.EOF {
+		if rErr == io.EOF {
 			break
-		}
-	}
-
-	// Verify if we uploaded all the data.
-	if size > 0 {
-		if totalUploadedSize != size {
-			return totalUploadedSize, ErrUnexpectedEOF(totalUploadedSize, size, bucketName, objectName)
 		}
 	}
 

--- a/vendor/github.com/minio/minio-go/api.go
+++ b/vendor/github.com/minio/minio-go/api.go
@@ -87,7 +87,7 @@ type Client struct {
 // Global constants.
 const (
 	libraryName    = "minio-go"
-	libraryVersion = "3.0.0"
+	libraryVersion = "3.0.2"
 )
 
 // User Agent should always following the below style.
@@ -190,6 +190,31 @@ func redirectHeaders(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
+// getRegionFromURL - parse region from URL if present.
+func getRegionFromURL(u url.URL) (region string) {
+	region = ""
+	if s3utils.IsGoogleEndpoint(u) {
+		return
+	} else if s3utils.IsAmazonChinaEndpoint(u) {
+		// For china specifically we need to set everything to
+		// cn-north-1 for now, there is no easier way until AWS S3
+		// provides a cleaner compatible API across "us-east-1" and
+		// China region.
+		return "cn-north-1"
+	} else if s3utils.IsAmazonGovCloudEndpoint(u) {
+		// For us-gov specifically we need to set everything to
+		// us-gov-west-1 for now, there is no easier way until AWS S3
+		// provides a cleaner compatible API across "us-east-1" and
+		// Gov cloud region.
+		return "us-gov-west-1"
+	}
+	parts := s3utils.AmazonS3Host.FindStringSubmatch(u.Host)
+	if len(parts) > 1 {
+		region = parts[1]
+	}
+	return region
+}
+
 func privateNew(endpoint string, creds *credentials.Credentials, secure bool, region string) (*Client, error) {
 	// construct endpoint.
 	endpointURL, err := getEndpointURL(endpoint, secure)
@@ -216,6 +241,9 @@ func privateNew(endpoint string, creds *credentials.Credentials, secure bool, re
 	}
 
 	// Sets custom region, if region is empty bucket location cache is used automatically.
+	if region == "" {
+		region = getRegionFromURL(clnt.endpointURL)
+	}
 	clnt.region = region
 
 	// Instantiate bucket location cache.
@@ -494,7 +522,7 @@ func (c Client) executeMethod(method string, metadata requestMetadata) (res *htt
 	// Blank indentifier is kept here on purpose since 'range' without
 	// blank identifiers is only supported since go1.4
 	// https://golang.org/doc/go1.4#forrange.
-	for _ = range c.newRetryTimer(MaxRetry, DefaultRetryUnit, DefaultRetryCap, MaxJitter, doneCh) {
+	for range c.newRetryTimer(MaxRetry, DefaultRetryUnit, DefaultRetryCap, MaxJitter, doneCh) {
 		// Retry executes the following function body if request has an
 		// error until maxRetries have been exhausted, retry attempts are
 		// performed after waiting for a given period of time in a
@@ -562,9 +590,14 @@ func (c Client) executeMethod(method string, metadata requestMetadata) (res *htt
 		// Additionally we should only retry if bucketLocation and custom
 		// region is empty.
 		if metadata.bucketLocation == "" && c.region == "" {
-			if res.StatusCode == http.StatusBadRequest && errResponse.Region != "" {
-				c.bucketLocCache.Set(metadata.bucketName, errResponse.Region)
-				continue // Retry.
+			if errResponse.Code == "AuthorizationHeaderMalformed" || errResponse.Code == "InvalidRegion" {
+				if metadata.bucketName != "" && errResponse.Region != "" {
+					// Gather Cached location only if bucketName is present.
+					if _, cachedLocationError := c.bucketLocCache.Get(metadata.bucketName); cachedLocationError != false {
+						c.bucketLocCache.Set(metadata.bucketName, errResponse.Region)
+						continue // Retry.
+					}
+				}
 			}
 		}
 

--- a/vendor/github.com/minio/minio-go/bucket-cache.go
+++ b/vendor/github.com/minio/minio-go/bucket-cache.go
@@ -91,20 +91,6 @@ func (c Client) getBucketLocation(bucketName string) (string, error) {
 		return c.region, nil
 	}
 
-	if s3utils.IsAmazonChinaEndpoint(c.endpointURL) {
-		// For china specifically we need to set everything to
-		// cn-north-1 for now, there is no easier way until AWS S3
-		// provides a cleaner compatible API across "us-east-1" and
-		// China region.
-		return "cn-north-1", nil
-	} else if s3utils.IsAmazonGovCloudEndpoint(c.endpointURL) {
-		// For us-gov specifically we need to set everything to
-		// us-gov-west-1 for now, there is no easier way until AWS S3
-		// provides a cleaner compatible API across "us-east-1" and
-		// Gov cloud region.
-		return "us-gov-west-1", nil
-	}
-
 	if location, ok := c.bucketLocCache.Get(bucketName); ok {
 		return location, nil
 	}

--- a/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v2.go
+++ b/vendor/github.com/minio/minio-go/pkg/s3signer/request-signature-v2.go
@@ -42,9 +42,7 @@ const (
 func encodeURL2Path(u *url.URL) (path string) {
 	// Encode URL path.
 	if isS3, _ := filepath.Match("*.s3*.amazonaws.com", u.Host); isS3 {
-		hostSplits := strings.SplitN(u.Host, ".", 4)
-		// First element is the bucket name.
-		bucketName := hostSplits[0]
+		bucketName := u.Host[:strings.LastIndex(u.Host, ".s3")]
 		path = "/" + bucketName
 		path += u.Path
 		path = s3utils.EncodePath(path)

--- a/vendor/github.com/minio/minio-go/pkg/s3utils/utils.go
+++ b/vendor/github.com/minio/minio-go/pkg/s3utils/utils.go
@@ -80,6 +80,9 @@ func IsVirtualHostSupported(endpointURL url.URL, bucketName string) bool {
 	return IsAmazonEndpoint(endpointURL) || IsGoogleEndpoint(endpointURL)
 }
 
+// AmazonS3Host - regular expression used to determine if an arg is s3 host.
+var AmazonS3Host = regexp.MustCompile("^s3[.-]?(.*?)\\.amazonaws\\.com$")
+
 // IsAmazonEndpoint - Match if it is exactly Amazon S3 endpoint.
 func IsAmazonEndpoint(endpointURL url.URL) bool {
 	if IsAmazonChinaEndpoint(endpointURL) {
@@ -88,7 +91,7 @@ func IsAmazonEndpoint(endpointURL url.URL) bool {
 	if IsAmazonGovCloudEndpoint(endpointURL) {
 		return true
 	}
-	return endpointURL.Host == "s3.amazonaws.com"
+	return AmazonS3Host.MatchString(endpointURL.Host)
 }
 
 // IsAmazonGovCloudEndpoint - Match if it is exactly Amazon S3 GovCloud endpoint.
@@ -205,7 +208,7 @@ func EncodePath(pathName string) string {
 // We support '.' with bucket names but we fallback to using path
 // style requests instead for such buckets.
 var (
-	validBucketName       = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9\.\-]{1,61}[A-Za-z0-9]$`)
+	validBucketName       = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9\.\-\_\:]{1,61}[A-Za-z0-9]$`)
 	validBucketNameStrict = regexp.MustCompile(`^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$`)
 	ipAddress             = regexp.MustCompile(`^(\d+\.){3}\d+$`)
 )
@@ -240,14 +243,13 @@ func checkBucketNameCommon(bucketName string, strict bool) (err error) {
 }
 
 // CheckValidBucketName - checks if we have a valid input bucket name.
-// This is a non stricter version.
-// - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
 func CheckValidBucketName(bucketName string) (err error) {
 	return checkBucketNameCommon(bucketName, false)
 }
 
 // CheckValidBucketNameStrict - checks if we have a valid input bucket name.
 // This is a stricter version.
+// - http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html
 func CheckValidBucketNameStrict(bucketName string) (err error) {
 	return checkBucketNameCommon(bucketName, true)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -56,46 +56,46 @@
 			"revisionTime": "2015-10-24T22:24:27-07:00"
 		},
 		{
-			"checksumSHA1": "kt6l2msHWGAEV05BQXnrUZT2VVk=",
+			"checksumSHA1": "RoElkV9hrX7Zd8YivXD+JOJOumA=",
 			"path": "github.com/minio/minio-go",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
 			"checksumSHA1": "5juljGXPkBWENR2Os7dlnPQER48=",
 			"path": "github.com/minio/minio-go/pkg/credentials",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
 			"checksumSHA1": "pggIpSePizRBQ7ybhB0CuaSQydw=",
 			"path": "github.com/minio/minio-go/pkg/encrypt",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
 			"checksumSHA1": "3tl2ehmod/EzXE9o9WJ5HM2AQPE=",
 			"path": "github.com/minio/minio-go/pkg/policy",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
-			"checksumSHA1": "D0xhhwUuAF5ZBTnIvW59jumQze4=",
+			"checksumSHA1": "ENjhnv4qjgfc3/v6nJhLNR4COOQ=",
 			"path": "github.com/minio/minio-go/pkg/s3signer",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
-			"checksumSHA1": "XTEUN/pAWAusSXT3yn6UznCl3iA=",
+			"checksumSHA1": "jWv8ONT9vgsX6MAMfCWHsyJtmHU=",
 			"path": "github.com/minio/minio-go/pkg/s3utils",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
 			"checksumSHA1": "maUy+dbN6VfTTnfErrAW2lLit1w=",
 			"path": "github.com/minio/minio-go/pkg/set",
-			"revision": "7f5b94fbf3f451a6872ec96236cb3099fc0b313d",
-			"revisionTime": "2017-07-25T01:23:14Z"
+			"revision": "84539d76271caeffb7a1d5f058bd83c6449f8145",
+			"revisionTime": "2017-09-01T08:51:27Z"
 		},
 		{
 			"checksumSHA1": "Z00ntXYcYqK9CjXD+tVgGwIZL1o=",


### PR DESCRIPTION
This PR brings in changes for

- PutObjectStream with no content-length is heavily
  optimized so `mc pipe` will not run out of memory
  for large uploads.
- Fixes a bug in Signature v2 for HTTP requests.
- Support us-gov-west-1 region as well.
- Auto region handling is inside minio-go now.