### PR TITLE
Update quiet flag usage to indicate it only turns off progress bar

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -36,7 +36,7 @@ var globalFlags = []cli.Flag{
 	},
 	cli.BoolFlag{
 		Name:  "quiet, q",
-		Usage: "Suppress chatty console output.",
+		Usage: "Disable progress bar display.",
 	},
 	cli.BoolFlag{
 		Name:  "no-color",


### PR DESCRIPTION
Current `quiet` flag description says `Suppress chatty console output.` which may be confusing for some users, given `quiet` is supposed to turn off the progress bar display only. 

This PR updates the flag description to indicate proper behaviour.

See: https://github.com/minio/mc/issues/2240