### PR TITLE
fix: Correct some cp/mirror help indentations

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -64,9 +64,9 @@ USAGE:
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
-	{{end}}
+  {{end}}
 ENVIRONMENT VARIABLES:
-	MC_MULTIPART_THREADS: To set number of multipart threads. By default it is 4.
+  MC_MULTIPART_THREADS: To set number of multipart threads. By default it is 4.
 
 EXAMPLES:
    1. Copy a list of objects from local file system to Amazon S3 cloud storage.

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -78,9 +78,9 @@ USAGE:
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
-	{{end}}
+  {{end}}
 ENVIRONMENT VARIABLES:
-	MC_MULTIPART_THREADS: To set number of multipart threads. By default it is 4.
+  MC_MULTIPART_THREADS: To set number of multipart threads. By default it is 4.
 
 EXAMPLES:
    1. Mirror a bucket recursively from Minio cloud storage to a bucket on Amazon S3 cloud storage.


### PR DESCRIPTION
Before
```
17:59 $ mc cp -h                                                                                    
NAME:                                                       
  mc cp - Copy files and objects.
                                                                                        
USAGE:                        
  mc cp [FLAGS] SOURCE [SOURCE...] TARGET
                                                                                     
FLAGS:                                                               
  --recursive, -r  Copy recursively.
                   --parallel value, -p value       Number of copies in parallel (default: 1)
                   --config-folder value, -C value  Path to configuration folder. (default: "/home/vadmeste/.mc")
                   --quiet, -q                      Disable progress bar display.
                   --no-color                       Disable color theme.
                   --json                           Enable JSON formatted output.
                   --debug                          Enable debug output.
                   --insecure                       Disable SSL certificate verification.
                   --help, -h                       Show help.
```

After:
```
17:59 $ mc cp -h                                                                                    
NAME:                                                       
  mc cp - Copy files and objects.
                                                                                        
USAGE:                        
  mc cp [FLAGS] SOURCE [SOURCE...] TARGET
                                                                                     
FLAGS:                                                               
  --recursive, -r                  Copy recursively.
  --parallel value, -p value       Number of copies in parallel (default: 1)
  --config-folder value, -C value  Path to configuration folder. (default: "/home/vadmeste/.mc")
  --quiet, -q                      Disable progress bar display.
  --no-color                       Disable color theme.
```