### PR TITLE
Add exclude option to mirror command

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -174,7 +174,7 @@ func doDiffMain(firstURL, secondURL string) error {
 	}
 
 	// Diff first and second urls.
-	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL) {
+	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL, nil) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
 			// Ignore error and proceed to next object.

--- a/cmd/difference_test.go
+++ b/cmd/difference_test.go
@@ -1,0 +1,48 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+)
+
+var testCases = []struct {
+	pattern []string
+
+	object string
+
+	match bool
+}{
+	{nil, "testfile", false},
+	{[]string{"test*"}, "testfile", true},
+	{[]string{"file*"}, "file/abc/bcd/def", true},
+	{[]string{"*"}, "file/abc/bcd/def", true},
+	{[]string{""}, "file/abc/bcd/def", false},
+	{[]string{"abc*"}, "file/abc/bcd/def", false},
+	{[]string{"abc*", "*abc/*"}, "file/abc/bcd/def", true},
+	{[]string{"*.txt"}, "file/abc/bcd/def.txt", true},
+	{[]string{".*"}, ".sys", true},
+	{[]string{"*."}, ".sys.", true},
+}
+
+func TestExcludeOptions(t *testing.T) {
+	for _, test := range testCases {
+		if matchExcludeOptions(test.pattern, test.object) != test.match {
+			t.Fatalf("Unexpected result %t, with pattern %s and object %s \n", !test.match, test.pattern, test.object)
+		}
+	}
+}

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -66,7 +66,7 @@ func checkMirrorSyntax(ctx *cli.Context) {
 	}
 }
 
-func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, URLsCh chan<- URLs) {
+func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, excludeOptions []string, URLsCh chan<- URLs) {
 	// source and targets are always directories
 	sourceSeparator := string(newClientURL(sourceURL).Separator)
 	if !strings.HasSuffix(sourceURL, sourceSeparator) {
@@ -96,7 +96,7 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 	}
 
 	// List both source and target, compare and return values through channel.
-	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL) {
+	for diffMsg := range objectDifference(sourceClnt, targetClnt, sourceURL, targetURL, excludeOptions) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to mirror objects.")
 			// Ignore error and proceed to next object.
@@ -165,8 +165,8 @@ func deltaSourceTarget(sourceURL string, targetURL string, isForce bool, isFake 
 }
 
 // Prepares urls that need to be copied or removed based on requested options.
-func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool) <-chan URLs {
+func prepareMirrorURLs(sourceURL string, targetURL string, isForce bool, isFake bool, isRemove bool, excludeOptions []string) <-chan URLs {
 	URLsCh := make(chan URLs)
-	go deltaSourceTarget(sourceURL, targetURL, isForce, isFake, isRemove, URLsCh)
+	go deltaSourceTarget(sourceURL, targetURL, isForce, isFake, isRemove, excludeOptions, URLsCh)
 	return URLsCh
 }


### PR DESCRIPTION
Added exclude options to exclude unwanted system files in an ```mc mirror``` command.

Exclude option excludes the source files/objects that match the passed shell file name pattern.

Examples
```
mc mirror --exclude ".*" --exclude "*.temp" play/test ~/test
```
excludes all .* files and *.temp files

```
mc --quiet mirror --exclude ".*" ~/data/ play/test
```
excludes all .* files from being mirrored from the source to the target

Fixes #1903