### PR TITLE
Fix: mc rm to error when nonempty directory is deleted

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -141,7 +141,7 @@ func removeSingle(url string, isIncomplete bool, isFake bool, older int) error {
 		errorIf(pErr.Trace(url), "Invalid argument `"+url+"`.")
 		return exitStatus(globalErrorExitStatus) // End of journey.
 	}
-	isFetchMeta := false
+	isFetchMeta := true
 	content, pErr := clnt.Stat(isIncomplete, isFetchMeta)
 	if pErr != nil {
 		errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")


### PR DESCRIPTION
Fixes #2242. 

When mc rm removes a single object, stat it on the server to see if it exists before proceeding with remove operation.