### PR TITLE
fix: append xattr to metadata only if metadata requested

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -978,12 +978,19 @@ func (f *fsClient) Stat(isIncomplete, isFetchMeta bool) (content *clientContent,
 	content.Metadata = map[string]string{
 		"Content-Type": guessURLContentType(f.PathURL.Path),
 	}
-	path := f.PathURL.String()
-	metaData, pErr := getAllXattrs(path)
-	if pErr != nil {
-		return content, nil
+	// isFetchMeta is true only in the case of mc stat command which lists any extended attributes
+	// present for this object.
+	if isFetchMeta {
+		path := f.PathURL.String()
+		metaData, pErr := getAllXattrs(path)
+		if pErr != nil {
+			return content, nil
+		}
+		for k, v := range metaData {
+			content.Metadata[k] = v
+		}
 	}
-	content.Metadata = metaData
+
 	return content, nil
 }
 


### PR DESCRIPTION
```mc cp ~/Downloads/testfile myminio/bucket1``` fails if the local file has extended attributes set. 

```
➜  mc git:(master) mc cp ~/Downloads/xattrfile myminio/bucket23
mc: <ERROR> Failed to copy `/home/kris/Downloads/xattrfile`. Put http://192.168.1.157:9000/bucket23/xattrfile: net/http: invalid header field value "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00blah" for key X-Amz-Meta-User.custom2
mc: <ERROR> Session safely terminated. To resume session `mc session resume TsLpSnbx`
```
Stat() implementation for FS should append the extended attributes to metadata only if isFetchMeta is set to true.