### PR TITLE
ui: consistenly use "flag" instead of "option" in error messages

### DIFF
--- a/cmd/admin-lock-clear.go
+++ b/cmd/admin-lock-clear.go
@@ -110,7 +110,7 @@ func checkAdminLockClearSyntax(ctx *cli.Context) {
 	}
 
 	fatalIf(errDummy().Trace(),
-		"Clearing locks requires --force option. This operation is "+
+		"Clearing locks requires --force flag. This operation is "+
 			"*IRREVERSIBLE*. Please review carefully before"+
 			" performing this *DANGEROUS* operation.")
 }

--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -127,7 +127,7 @@ func checkCopySyntaxTypeC(srcURLs []string, tgtURL string, isRecursive bool) {
 	}
 
 	if srcContent.Type.IsDir() && !isRecursive {
-		fatalIf(errInvalidArgument().Trace(srcURL), "To copy a folder requires --recursive option.")
+		fatalIf(errInvalidArgument().Trace(srcURL), "To copy a folder requires --recursive flag.")
 	}
 
 	// Check target.

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -158,7 +158,7 @@ func checkRmSyntax(ctx *cli.Context) {
 				"This operation results in site-wide removal of buckets and objects. If you are really sure, retry this command with ‘--dangerous’ and ‘--force’ flags.")
 		}
 		fatalIf(errDummy().Trace(),
-			"Removal requires --force option. This operation is *IRREVERSIBLE*. Please review carefully before performing this *DANGEROUS* operation.")
+			"Removal requires --force flag. This operation is *IRREVERSIBLE*. Please review carefully before performing this *DANGEROUS* operation.")
 	}
 	if (isRecursive || isStdin) && isNamespaceRemoval && !isDangerous {
 		fatalIf(errDummy().Trace(),

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -90,7 +90,7 @@ func checkShareDownloadSyntax(ctx *cli.Context) {
 		fatalIf(errDummy().Trace(expiry.String()), "Expiry cannot be larger than 7 days.")
 	}
 
-	// Validate if object exists only if the `--recursive` option was NOT specified
+	// Validate if object exists only if the `--recursive` flag was NOT specified
 	isRecursive := ctx.Bool("recursive")
 	if !isRecursive {
 		for _, url := range ctx.Args() {

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -101,7 +101,7 @@ func checkShareUploadSyntax(ctx *cli.Context) {
 		url := newClientURL(targetURL)
 		if strings.HasSuffix(targetURL, string(url.Separator)) && !isRecursive {
 			fatalIf(errInvalidArgument().Trace(targetURL),
-				"Use --recursive option to generate curl command for prefixes.")
+				"Use --recursive flag to generate curl command for prefixes.")
 		}
 	}
 }


### PR DESCRIPTION
Rename "option" to "flag" in error messages to make it consistent with mc help FLAGS subheading 