### PR TITLE
stat: fix output to show bucket in stat listing

### DIFF
--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -100,7 +100,7 @@ func parseStat(targetAlias string, c *clientContent) statMessage {
 		return "file"
 	}()
 	content.Size = c.Size
-	content.Key = targetAlias + getKey(c)
+	content.Key = getKey(c)
 	content.Metadata = c.Metadata
 	content.ETag = strings.TrimPrefix(c.ETag, "\"")
 	content.ETag = strings.TrimSuffix(content.ETag, "\"")
@@ -111,24 +111,7 @@ func parseStat(targetAlias string, c *clientContent) statMessage {
 
 // doStat - list all entities inside a folder.
 func doStat(clnt Client, isRecursive bool, targetAlias, targetURL string) error {
-	if !isRecursive || !isAliasURLDir(targetURL) {
-		isIncomplete := false
-		fetchMeta := true
-		if st, err := clnt.Stat(isIncomplete, fetchMeta); err != nil {
-			switch err.ToGoError().(type) {
-			default:
-				fatalIf(err.Trace(targetURL), "Unable to initialize `"+targetURL+"`.")
-			}
-		} else {
-			st := parseStat(targetAlias, st)
-			if !globalJSON {
-				printStat(st)
-			} else {
-				console.Println(st.JSON())
-			}
-			return nil
-		}
-	}
+
 	if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 		targetURL = targetURL + string(clnt.GetURL().Separator)
 	}
@@ -167,16 +150,20 @@ func doStat(clnt Client, isRecursive bool, targetAlias, targetURL string) error 
 			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
 			continue
 		}
+		url := targetAlias + getKey(content)
+		if !isAliasURLDir(targetURL) {
+			url = content.URL.Path
+		}
+		_, stat, err := url2StatWithMetadata(url, true)
+		if err != nil {
+			stat = content
+		}
 		// Convert any os specific delimiters to "/".
-		contentURL := filepath.ToSlash(content.URL.Path)
+		contentURL := filepath.ToSlash(stat.URL.Path)
 		prefixPath = filepath.ToSlash(prefixPath)
 		// Trim prefix path from the content path.
 		contentURL = strings.TrimPrefix(contentURL, prefixPath)
-		content.URL.Path = contentURL
-		_, stat, err := url2StatWithMetadata(targetURL+getKey(content), true)
-		if err != nil {
-			continue
-		}
+		stat.URL.Path = contentURL
 		if stat != prevStat {
 			st := parseStat(targetAlias, stat)
 			if !globalJSON {


### PR DESCRIPTION
Fixes : #2339 
Show stat of all buckets at site level, and mimic
mc ls behavior in stat output.