### PR TITLE
Use client-fs_other on OpenBSD

### DIFF
--- a/cmd/client-fs_other.go
+++ b/cmd/client-fs_other.go
@@ -1,4 +1,4 @@
-// +build solaris
+// +build solaris openbsd
 
 /*
  * Minio Client (C) 2015, 2016, 2017 Minio, Inc.


### PR DESCRIPTION
Minio and mc work fine on OpenBSD, just need to use client-fs_other there. Let me know if this needs vendor/syscall support but that's far more than i can do/test :)