### PR TITLE
mirror with --watch should copy and exit for s3 endpoints

### DIFF
--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -73,8 +73,8 @@ func (p *ParallelManager) addWorker() {
 	go func() {
 		for {
 			// Wait for jobs
-			fn := <-p.queueCh
-			if fn == nil {
+			fn, ok := <-p.queueCh
+			if !ok {
 				// No more tasks, quit
 				p.wg.Done()
 				return


### PR DESCRIPTION
Current code wouldn't exit unless we press CTRL+C
even if the endpoints do not support --watch, this PR
fixes this behavior.