### PR TITLE
Improve lock error message when bucket is not specified

### DIFF
--- a/cmd/admin-lock-clear.go
+++ b/cmd/admin-lock-clear.go
@@ -105,6 +105,13 @@ func checkAdminLockClearSyntax(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "clear", 1)
 	}
 
+	// Check if a bucket is specified.
+	aliasedURL := filepath.ToSlash(ctx.Args().Get(0))
+	splits := splitStr(aliasedURL, "/", 3)
+	if splits[1] == "" {
+		fatalIf(errBucketNotSpecified().Trace(aliasedURL), "Cannot clear locks.")
+	}
+
 	if isForce := ctx.Bool("force"); isForce {
 		return
 	}
@@ -132,7 +139,6 @@ func mainAdminLockClear(ctx *cli.Context) error {
 	fatalIf(err, "Cannot get a configured admin connection.")
 
 	aliasedURL = filepath.ToSlash(aliasedURL)
-
 	splits := splitStr(aliasedURL, "/", 3)
 
 	// Clear locks related to a specified pair of bucket and prefix

--- a/cmd/admin-lock-list.go
+++ b/cmd/admin-lock-list.go
@@ -100,6 +100,13 @@ func checkAdminLockListSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) == 0 || len(ctx.Args()) > 2 {
 		cli.ShowCommandHelpAndExit(ctx, "list", 1) // last argument is exit code
 	}
+
+	// Check if a bucket is specified.
+	aliasedURL := filepath.ToSlash(ctx.Args().Get(0))
+	splits := splitStr(aliasedURL, "/", 3)
+	if splits[1] == "" {
+		fatalIf(errBucketNotSpecified().Trace(aliasedURL), "Cannot list locks.")
+	}
 }
 
 func mainAdminLockList(ctx *cli.Context) error {
@@ -119,7 +126,6 @@ func mainAdminLockList(ctx *cli.Context) error {
 	fatalIf(err, "Cannot get a configured admin connection.")
 
 	aliasedURL = filepath.ToSlash(aliasedURL)
-
 	splits := splitStr(aliasedURL, "/", 3)
 
 	// Fetch the lock info related to a specified pair of bucket and prefix

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -83,4 +83,8 @@ var (
 	errSourceTargetSame = func(URL string) *probe.Error {
 		return probe.NewError(errors.New("Source and target URL can not be same : " + URL)).Untrace()
 	}
+
+	errBucketNotSpecified = func() *probe.Error {
+		return probe.NewError(errors.New("This operation requires a " + "bucket to be specified.")).Untrace()
+	}
 )


### PR DESCRIPTION
Existing output:

```
$ /tmp/mc admin lock list myminio
mc: <ERROR> Cannot get lock status. The specified bucket is not valid.
$ /tmp/mc admin lock clear --force play
mc: <ERROR> Cannot clear the specified locks. The specified method is not allowed against this resource.

```

They are errors because no bucket is specified.

Modified output (due to this PR):
```
$ mc admin lock list play
mc: <ERROR> Cannot query locks. This operation requires a bucket to be specified.
$ mc admin lock clear --force play
mc: <ERROR> Cannot clear locks. This operation requires a bucket to be specified.
```

The problem error message was reported [here](https://github.com/minio/mc/pull/2350#pullrequestreview-87930846). 