### PR TITLE
fix for prefix based rm

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1438,7 +1438,7 @@ func (c *s3Client) listRecursiveInRoutineDirOpt(contentCh chan *clientContent, d
 			return
 		}
 		buckets = append(buckets, minio.BucketInfo{Name: bucket, CreationDate: content.Time})
-	} else if strings.HasSuffix(object, string(c.targetURL.Separator)) {
+	} else {
 		// Get stat of given object is a directory.
 		isIncomplete := false
 		isFetchMeta := false


### PR DESCRIPTION
Fixes: #2341 

mc rm --r with prefix not terminated by / doesn't get deleted.
example: mc rm --r --force --older-than=10 play/test/prefix