### PR TITLE
add encrypt option to cp, mirror and cat commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ share    Generate URL for sharing.
 cp       Copy files and objects.
 mirror   Mirror buckets and folders.
 find     Finds files which match the given set of parameters.
+stat     Stat contents of objects and folders.
 diff     List objects with size difference or missing between two folders or buckets.
 rm       Remove files and objects.
 events   Manage object notifications.

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -315,7 +315,7 @@ func (f *fsClient) put(reader io.Reader, size int64, metadata map[string][]strin
 }
 
 // Put - create a new file with metadata.
-func (f *fsClient) Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader) (int64, *probe.Error) {
+func (f *fsClient) Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sseKey string) (int64, *probe.Error) {
 	return f.put(reader, size, nil, progress)
 }
 
@@ -368,7 +368,7 @@ func createFile(fpath string) (io.WriteCloser, error) {
 }
 
 // Copy - copy data from source to destination
-func (f *fsClient) Copy(source string, size int64, progress io.Reader) *probe.Error {
+func (f *fsClient) Copy(source string, size int64, progress io.Reader, srcSSEKey, tgtSSEKey string) *probe.Error {
 	// Don't use f.Get() f.Put() directly. Instead use readFile and createFile
 	destination := f.PathURL.Path
 	if destination == source { // Cannot copy file into itself
@@ -434,7 +434,7 @@ func (f *fsClient) get() (io.Reader, *probe.Error) {
 }
 
 // Get returns reader and any additional metadata.
-func (f *fsClient) Get() (io.Reader, *probe.Error) {
+func (f *fsClient) Get(sseKey string) (io.Reader, *probe.Error) {
 	return f.get()
 }
 
@@ -968,7 +968,7 @@ func (f *fsClient) SetAccess(access string) *probe.Error {
 }
 
 // Stat - get metadata from path.
-func (f *fsClient) Stat(isIncomplete, isFetchMeta bool) (content *clientContent, err *probe.Error) {
+func (f *fsClient) Stat(isIncomplete, isFetchMeta bool, sseKey string) (content *clientContent, err *probe.Error) {
 	st, err := f.fsStat(isIncomplete)
 	if err != nil {
 		return nil, err.Trace(f.PathURL.String())

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -45,7 +45,7 @@ func (s *TestSuite) TestList(c *C) {
 	var n int64
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -56,7 +56,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -84,7 +84,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -144,7 +144,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -210,7 +210,7 @@ func (s *TestSuite) TestStatBucket(c *C) {
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1", true)
 	c.Assert(err, IsNil)
-	_, err = fsClient.Stat(false, false)
+	_, err = fsClient.Stat(false, false, "")
 	c.Assert(err, IsNil)
 }
 
@@ -251,7 +251,7 @@ func (s *TestSuite) TestPut(c *C) {
 	var n int64
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 }
@@ -271,11 +271,11 @@ func (s *TestSuite) TestGet(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, err = fsClient.Get()
+	reader, err = fsClient.Get("")
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	_, e = io.Copy(&results, reader)
@@ -299,11 +299,11 @@ func (s *TestSuite) TestGetRange(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, err = fsClient.Get()
+	reader, err = fsClient.Get("")
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	buf := make([]byte, 5)
@@ -330,11 +330,11 @@ func (s *TestSuite) TestStatObject(c *C) {
 	reader := bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(dataLen), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	content, err := fsClient.Stat(false, false)
+	content, err := fsClient.Stat(false, false, "")
 	c.Assert(err, IsNil)
 	c.Assert(content.Size, Equals, int64(dataLen))
 }
@@ -356,10 +356,10 @@ func (s *TestSuite) TestCopy(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClientSource.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	err = fsClientTarget.Copy(sourcePath, int64(len(data)), nil)
+	err = fsClientTarget.Copy(sourcePath, int64(len(data)), nil, "", "")
 	c.Assert(err, IsNil)
 }

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -222,11 +222,11 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	reader = bytes.NewReader(object.data)
 	n, err := s3c.Put(context.Background(), reader, int64(len(object.data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil)
+	}, nil, "")
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(object.data)))
 
-	reader, err = s3c.Get()
+	reader, err = s3c.Get("")
 	c.Assert(err, IsNil)
 	var buffer bytes.Buffer
 	{

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -172,16 +172,19 @@ func urlJoinPath(url1, url2 string) string {
 
 // url2Stat returns stat info for URL.
 func url2Stat(urlStr string) (client Client, content *clientContent, err *probe.Error) {
-	return url2StatWithMetadata(urlStr, false)
+	return url2StatWithMetadata(urlStr, false, nil)
 }
 
 // url2Stat returns stat info for URL.
-func url2StatWithMetadata(urlStr string, isFetchMeta bool) (client Client, content *clientContent, err *probe.Error) {
+func url2StatWithMetadata(urlStr string, isFetchMeta bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *clientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}
-	content, err = client.Stat(false, isFetchMeta)
+	alias, _ := url2Alias(urlStr)
+	sseKey := getSSEKey(urlStr, encKeyDB[alias])
+
+	content, err = client.Stat(false, isFetchMeta, sseKey)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -44,7 +44,7 @@ const defaultMultipartThreadsNum = 4
 // Client - client interface
 type Client interface {
 	// Common operations
-	Stat(isIncomplete, isFetchMeta bool) (content *clientContent, err *probe.Error)
+	Stat(isIncomplete, isFetchMeta bool, sseKey string) (content *clientContent, err *probe.Error)
 	List(isRecursive, isIncomplete bool, showDir DirOpt) <-chan *clientContent
 
 	// Bucket operations
@@ -56,11 +56,11 @@ type Client interface {
 	SetAccess(access string) *probe.Error
 
 	// I/O operations
-	Copy(source string, size int64, progress io.Reader) *probe.Error
+	Copy(source string, size int64, progress io.Reader, srcSSEKey, tgtSSEKey string) *probe.Error
 
 	// I/O operations with metadata.
-	Get() (reader io.Reader, err *probe.Error)
-	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader) (n int64, err *probe.Error)
+	Get(sseKey string) (reader io.Reader, err *probe.Error)
+	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sseKey string) (n int64, err *probe.Error)
 
 	// I/O operations with expiration
 	ShareDownload(expires time.Duration) (string, *probe.Error)

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -67,28 +67,29 @@ func isAliasURLDir(aliasURL string) bool {
 }
 
 // getSourceStreamFromURL gets a reader from URL.
-func getSourceStreamFromURL(urlStr string) (reader io.Reader, err *probe.Error) {
+func getSourceStreamFromURL(urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.Reader, err *probe.Error) {
 	alias, urlStrFull, _, err := expandAlias(urlStr)
 	if err != nil {
 		return nil, err.Trace(urlStr)
 	}
-	reader, _, err = getSourceStream(alias, urlStrFull, false)
+	sseKey := getSSEKey(urlStr, encKeyDB[alias])
+	reader, _, err = getSourceStream(alias, urlStrFull, false, sseKey)
 	return reader, err
 }
 
 // getSourceStream gets a reader from URL.
-func getSourceStream(alias string, urlStr string, fetchStat bool) (reader io.Reader, metadata map[string]string, err *probe.Error) {
+func getSourceStream(alias string, urlStr string, fetchStat bool, sseKey string) (reader io.Reader, metadata map[string]string, err *probe.Error) {
 	sourceClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
-	reader, err = sourceClnt.Get()
+	reader, err = sourceClnt.Get(sseKey)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
 	metadata = map[string]string{}
 	if fetchStat {
-		st, err := sourceClnt.Stat(false, true)
+		st, err := sourceClnt.Stat(false, true, sseKey)
 		if err != nil {
 			return nil, nil, err.Trace(alias, urlStr)
 		}
@@ -103,12 +104,12 @@ func getSourceStream(alias string, urlStr string, fetchStat bool) (reader io.Rea
 }
 
 // putTargetStream writes to URL from Reader.
-func putTargetStream(ctx context.Context, alias string, urlStr string, reader io.Reader, size int64, metadata map[string]string, progress io.Reader) (int64, *probe.Error) {
+func putTargetStream(ctx context.Context, alias string, urlStr string, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sseKey string) (int64, *probe.Error) {
 	targetClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
 		return 0, err.Trace(alias, urlStr)
 	}
-	n, err := targetClnt.Put(ctx, reader, size, metadata, progress)
+	n, err := targetClnt.Put(ctx, reader, size, metadata, progress, sseKey)
 	if err != nil {
 		return n, err.Trace(alias, urlStr)
 	}
@@ -116,7 +117,7 @@ func putTargetStream(ctx context.Context, alias string, urlStr string, reader io
 }
 
 // putTargetStreamWithURL writes to URL from reader. If length=-1, read until EOF.
-func putTargetStreamWithURL(urlStr string, reader io.Reader, size int64) (int64, *probe.Error) {
+func putTargetStreamWithURL(urlStr string, reader io.Reader, size int64, sseKey string) (int64, *probe.Error) {
 	alias, urlStrFull, _, err := expandAlias(urlStr)
 	if err != nil {
 		return 0, err.Trace(alias, urlStr)
@@ -125,16 +126,16 @@ func putTargetStreamWithURL(urlStr string, reader io.Reader, size int64) (int64,
 	metadata := map[string]string{
 		"Content-Type": contentType,
 	}
-	return putTargetStream(context.Background(), alias, urlStrFull, reader, size, metadata, nil)
+	return putTargetStream(context.Background(), alias, urlStrFull, reader, size, metadata, nil, sseKey)
 }
 
 // copySourceToTargetURL copies to targetURL from source.
-func copySourceToTargetURL(alias string, urlStr string, source string, size int64, progress io.Reader) *probe.Error {
+func copySourceToTargetURL(alias string, urlStr string, source string, size int64, progress io.Reader, srcSSEKey, tgtSSEKey string) *probe.Error {
 	targetClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
 		return err.Trace(alias, urlStr)
 	}
-	err = targetClnt.Copy(source, size, progress)
+	err = targetClnt.Copy(source, size, progress, srcSSEKey, tgtSSEKey)
 	if err != nil {
 		return err.Trace(alias, urlStr)
 	}
@@ -150,17 +151,16 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader)
 	targetAlias := urls.TargetAlias
 	targetURL := urls.TargetContent.URL
 	length := urls.SourceContent.Size
-
 	// Optimize for server side copy if the host is same.
 	if sourceAlias == targetAlias {
 		sourcePath := filepath.ToSlash(sourceURL.Path)
-		err := copySourceToTargetURL(targetAlias, targetURL.String(), sourcePath, length, progress)
+		err := copySourceToTargetURL(targetAlias, targetURL.String(), sourcePath, length, progress, urls.SrcSSEKey, urls.TgtSSEKey)
 		if err != nil {
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}
 	} else {
 		// Proceed with regular stream copy.
-		reader, metadata, err := getSourceStream(sourceAlias, sourceURL.String(), true)
+		reader, metadata, err := getSourceStream(sourceAlias, sourceURL.String(), true, urls.SrcSSEKey)
 		if err != nil {
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}
@@ -170,7 +170,12 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader)
 				metadata[k] = v
 			}
 		}
-		_, err = putTargetStream(ctx, targetAlias, targetURL.String(), reader, length, metadata, progress)
+		if urls.SrcSSEKey != "" {
+			delete(metadata, "X-Amz-Server-Side-Encryption-Customer-Algorithm")
+			delete(metadata, "X-Amz-Server-Side-Encryption-Customer-Key-Md5")
+		}
+
+		_, err = putTargetStream(ctx, targetAlias, targetURL.String(), reader, length, metadata, progress, urls.TgtSSEKey)
 		if err != nil {
 			return urls.WithError(err.Trace(targetURL.String()))
 		}

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -164,7 +164,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 		return "", err
 	}
 
-	if _, err = s3Client.Stat(false, false); err != nil {
+	if _, err = s3Client.Stat(false, false, ""); err != nil {
 		switch err.ToGoError().(type) {
 		case BucketDoesNotExist:
 			// Bucket doesn't exist, means signature probing worked V4.
@@ -175,7 +175,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 			if err != nil {
 				return "", err
 			}
-			if _, err = s3Client.Stat(false, false); err != nil {
+			if _, err = s3Client.Stat(false, false, ""); err != nil {
 				switch err.ToGoError().(type) {
 				case BucketDoesNotExist:
 					// Bucket doesn't exist, means signature probing worked with V2.

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -53,6 +53,10 @@ var (
 			Name:  "storage-class, sc",
 			Usage: "Set storage class for object",
 		},
+		cli.StringFlag{
+			Name:  "encrypt-key",
+			Usage: "Encrypt/Decrypt objects (using server-side encryption)",
+		},
 	}
 )
 
@@ -72,6 +76,9 @@ USAGE:
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
+
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY: List of comma delimited prefix=secret values
 
 EXAMPLES:
    1. Copy a list of objects from local file system to Amazon S3 cloud storage.
@@ -97,6 +104,9 @@ EXAMPLES:
 
    8. Copy a local folder with space separated characters to Amazon S3 cloud storage.
       $ {{.HelpName}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
+
+  10. Copy a folder with encrypted objects recursively from Amazon S3 to Minio cloud storage.
+      $ {{.HelpName}} --recursive --encrypt-key "s3/documents/a/b/c=32byteslongsecretkeymustbegiven1,myminio/documents/=32byteslongsecretkeymustbegiven2" 's3/documents/' myminio/documents/
 
 `,
 }
@@ -210,7 +220,9 @@ func doPrepareCopyURLs(session *sessionV8, trapCh <-chan bool, cancelCopy contex
 
 	olderThan := session.Header.CommandIntFlags["older-than"]
 	newerThan := session.Header.CommandIntFlags["newer-than"]
-
+	encryptKeys := session.Header.CommandStringFlags["encrypt-key"]
+	encKeyDB, err := parseEncryptionKeys(encryptKeys)
+	fatalIf(err, "Unable to parse encryption keys")
 	// Create a session data file to store the processed URLs.
 	dataFP := session.NewDataWriter()
 
@@ -218,8 +230,7 @@ func doPrepareCopyURLs(session *sessionV8, trapCh <-chan bool, cancelCopy contex
 	if !globalQuiet && !globalJSON { // set up progress bar
 		scanBar = scanBarFactory()
 	}
-
-	URLsCh := prepareCopyURLs(sourceURLs, targetURL, isRecursive)
+	URLsCh := prepareCopyURLs(sourceURLs, targetURL, isRecursive, encKeyDB)
 	done := false
 	for !done {
 		select {
@@ -420,6 +431,10 @@ func mainCopy(ctx *cli.Context) error {
 	olderThan := ctx.Int("older-than")
 	newerThan := ctx.Int("newer-than")
 	storageClass := ctx.String("storage-class")
+	sseKeys := os.Getenv("MC_ENCRYPT_KEY")
+	if key := ctx.String("encrypt-key"); key != "" {
+		sseKeys = key
+	}
 
 	session := newSessionV8()
 	session.Header.CommandType = "cp"
@@ -427,6 +442,7 @@ func mainCopy(ctx *cli.Context) error {
 	session.Header.CommandIntFlags["older-than"] = olderThan
 	session.Header.CommandIntFlags["newer-than"] = newerThan
 	session.Header.CommandStringFlags["storage-class"] = storageClass
+	session.Header.CommandStringFlags["encrypt-key"] = sseKeys
 
 	var e error
 	if session.Header.RootPath, e = os.Getwd(); e != nil {

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -448,7 +448,7 @@ func getShareURL(path string) string {
 	clnt, err := newClientFromAlias(targetAlias, targetURLFull)
 	fatalIf(err.Trace(targetAlias, targetURLFull), "Unable to initialize client instance from alias.")
 
-	content, err := clnt.Stat(false, false)
+	content, err := clnt.Stat(false, false, "")
 	fatalIf(err.Trace(targetURLFull, targetAlias), "Unable to lookup file/object.")
 
 	// Skip if its a directory.

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -132,7 +132,7 @@ func mainList(ctx *cli.Context) error {
 		fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
 
 		var st *clientContent
-		if st, err = clnt.Stat(isIncomplete, false); err != nil {
+		if st, err = clnt.Stat(isIncomplete, false, ""); err != nil {
 			switch err.ToGoError().(type) {
 			case BucketNameEmpty:
 			// For aliases like ``mc ls s3`` it's acceptable to receive BucketNameEmpty error.

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -127,7 +127,7 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 	// Channel which will receive objects whose URLs need to be shared
 	objectsCh := make(chan *clientContent)
 
-	content, err := clnt.Stat(isIncomplete, isFetchMeta)
+	content, err := clnt.Stat(isIncomplete, isFetchMeta, "")
 	if err != nil {
 		return err.Trace(clnt.GetURL().String())
 	}

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 
 	"github.com/fatih/color"
@@ -30,6 +31,10 @@ var (
 		cli.BoolFlag{
 			Name:  "recursive, r",
 			Usage: "Stat recursively.",
+		},
+		cli.StringFlag{
+			Name:  "encrypt-key",
+			Usage: "Encrypt/Decrypt (using server-side encryption)",
 		},
 	}
 )
@@ -50,6 +55,10 @@ USAGE:
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
+
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY: List of comma delimited prefix=secret values
+
 EXAMPLES:
    1. Stat all contents of mybucket on Amazon S3 cloud storage.
       $ {{.HelpName}} s3/mybucket/
@@ -59,6 +68,9 @@ EXAMPLES:
 
    3. Stat files recursively on a local filesystem on Microsoft Windows.
       $ {{.HelpName}} --recursive C:\Users\Worf\
+   
+   4. Stat files which are encrypted on the server side
+      $ {{.HelpName}} --encrypt-key "s3/ferenginar=32byteslongsecretkeymustbegiven1" s3/ferenginar/klingon_opera_aktuh_maylotah.ogg
 `,
 }
 
@@ -77,7 +89,6 @@ func checkStatSyntax(ctx *cli.Context) {
 	// extract URLs.
 	URLs := ctx.Args()
 	isIncomplete := false
-
 	for _, url := range URLs {
 		_, _, err := url2Stat(url)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
@@ -109,6 +120,14 @@ func mainStat(ctx *cli.Context) error {
 		args = []string{"."}
 	}
 
+	sseKeys := os.Getenv("MC_ENCRYPT_KEY")
+	if key := ctx.String("encrypt-key"); key != "" {
+		sseKeys = key
+	}
+
+	encKeyDB, err := parseEncryptionKeys(sseKeys)
+	fatalIf(err, "Unable to parse encryption keys")
+
 	var cErr error
 	for _, targetURL := range args {
 		var clnt Client
@@ -116,7 +135,7 @@ func mainStat(ctx *cli.Context) error {
 		fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
 
 		targetAlias, _, _ := mustExpandAlias(targetURL)
-		return doStat(clnt, isRecursive, targetAlias, targetURL)
+		return doStat(clnt, isRecursive, targetAlias, targetURL, encKeyDB)
 	}
 	return cErr
 

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -110,7 +110,7 @@ func parseStat(targetAlias string, c *clientContent) statMessage {
 }
 
 // doStat - list all entities inside a folder.
-func doStat(clnt Client, isRecursive bool, targetAlias, targetURL string) error {
+func doStat(clnt Client, isRecursive bool, targetAlias, targetURL string, encKeyDB map[string][]prefixSSEPair) error {
 
 	prefixPath := clnt.GetURL().Path
 	separator := string(clnt.GetURL().Separator)
@@ -144,7 +144,7 @@ func doStat(clnt Client, isRecursive bool, targetAlias, targetURL string) error 
 			continue
 		}
 		url := targetAlias + getKey(content)
-		_, stat, err := url2StatWithMetadata(url, true)
+		_, stat, err := url2StatWithMetadata(url, true, encKeyDB)
 		if err != nil {
 			stat = content
 		}

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -26,6 +26,9 @@ type URLs struct {
 	TargetContent *clientContent
 	TotalCount    int64
 	TotalSize     int64
+	encKeyDB      map[string][]prefixSSEPair
+	SrcSSEKey     string
+	TgtSSEKey     string
 	Error         *probe.Error `json:"-"`
 }
 

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -317,12 +317,23 @@ USAGE:
 
 FLAGS:
   --help, -h                       Show help.
+  --encrypt-key value              Decrypt object (using server-side encryption)
+
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY:                 List of comma delimited prefix=secret values
 ```
 
 *Example: Display the contents of a text file `myobject.txt`*
 
 ```sh
 mc cat play/mybucket/myobject.txt
+Hello Minio!!
+```
+
+*Example: Display the contents of a server encrypted object `myencryptedobject.txt`*
+
+```sh
+mc cat --encrypt-key "play/mybucket=32byteslongsecretkeymustbegiven1" play/mybucket/myencryptedobject.txt
 Hello Minio!!
 ```
 <a name="pipe"></a>
@@ -334,7 +345,11 @@ USAGE:
    mc pipe [FLAGS] [TARGET]
 
 FLAGS:
-  --help, -h					Help of pipe.
+  --help, -h			Help of pipe.
+  --encrypt-key value           Encrypt object (using server-side encryption)
+
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY:              List of comma delimited prefix=secret values
 ```
 
 *Example: Stream MySQL database dump to Amazon S3 directly.*
@@ -355,6 +370,10 @@ FLAGS:
   --recursive, -r                    Copy recursively.
   --storage-class value, -sc value   Set storage class for object.
   --help, -h                         Show help.
+  --encrypt-key value                Encrypt/Decrypt objects (using server-side encryption)
+
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY:                 List of comma delimited prefix=secret values
 ```
 
 *Example: Copy a text file to an object storage.*
@@ -371,6 +390,20 @@ mc cp --storage-class REDUCED_REDUNDANCY myobject.txt play/mybucket
 myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
 ```
 
+*Example: Copy a server-side encrypted file to an object storage.*
+
+```sh
+mc cp --recursive --encrypt-key "s3/documents/=32byteslongsecretkeymustbegiven1 , myminio/documents/=32byteslongsecretkeymustbegiven2" s3/documents/myobject.txt myminio/documents/
+myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
+```
+
+*Example: Perform key-rotation on a server-side encrypted object*
+
+```sh
+mc cp --encrypt-key 'myminio1/mybucket=32byteslongsecretkeymustgenerate , myminio2/mybucket/=32byteslongsecretkeymustgenerat1' myminio1/mybucket/encryptedobject myminio2/mybucket/encryptedobject
+encryptedobject:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
+```
+Notice that two different aliases myminio1 and myminio2 are used for the same endpoint to provide the old secretkey and the newly rotated key.
 <a name="rm"></a>
 ### Command `rm` - Remove Buckets and Objects
 Use `rm` command to remove file or bucket
@@ -388,12 +421,23 @@ FLAGS:
   --fake			   Perform a fake remove operation.
   --stdin			   Read object list from STDIN.
   --older-than value               Remove objects older than N days. (default: 0)
+  --encrypt-key value              Encrypt/Decrypt objects (using server-side encryption)
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY:                 List of comma delimited prefix=secret values
+
+
 ```
 
 *Example: Remove a single object.*
 
 ```sh
 mc rm play/mybucket/myobject.txt
+Removed ‘play/mybucket/myobject.txt’.
+```
+*Example: Remove an encrypted object.*
+
+```sh
+mc rm --encrypt-key "play/mybucket=32byteslongsecretkeymustbegiven1" play/mybucket/myobject.txt
 Removed ‘play/mybucket/myobject.txt’.
 ```
 
@@ -510,7 +554,11 @@ FLAGS:
   --watch, -w                         Watch and mirror for changes.
   --remove                            Remove extraneous file(s) on target.
   --storage-class value, --sc value   Set storage class for object.
-```
+  --encrypt-key value                 Encrypt/Decrypt objects (using server-side encryption)
+
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY:                    List of comma delimited prefix=secret values
+``` 
 
 *Example: Mirror a local directory to 'mybucket' on https://play.minio.io:9000.*
 
@@ -813,7 +861,10 @@ USAGE:
 FLAGS:
   --help, -h                       Show help.
   --recursive, -r                  Stat recursively.
+  --encrypt-key value              Encrypt/Decrypt (using server-side encryption)
 
+ENVIRONMENT VARIABLES:
+   MC_ENCRYPT_KEY:                 List of comma delimited prefix=secret values
 ```
 
 *Example: Display information on a bucket named "mybucket" on https://play.minio.io:9000.*
@@ -825,6 +876,22 @@ Name      : mybucket/
 Date      : 2018-02-06 18:06:51 PST
 Size      : 0B
 Type      : folder
+```
+
+*Example: Display information on an encrypted object "myobject" in "mybucket" on https://play.minio.io:9000.*
+
+
+```sh
+mc stat play/mybucket/myobject --encrypt-key "play/mybucket=32byteslongsecretkeymustbegiven1"
+Name      : myobject
+Date      : 2018-03-02 11:47:13 PST 
+Size      : 132B   
+ETag      : d03ba22cd78282b7aef705bf31b8cded 
+Type      : file 
+Metadata  :
+  Content-Type                                   : application/octet-stream 
+  X-Amz-Server-Side-Encryption-Customer-Key-Md5  : 4xSRdYsabg+s2nlsHKhgnw== 
+  X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256 
 ```
 
 *Example: Display information on objects contained in the bucket named "mybucket" on https://play.minio.io:9000.*


### PR DESCRIPTION
This fixes #2074
 Add --encrypt-key flags for cp, mirror, cat,pipe and stat commands to pass server side encryption keys. Alternately, encryption keys can be specified by MC_ENCRYPT_KEY env variable.

The  --enctrypt-key flag accepts a list of alias/object-prefix=sse-key pairs delimited by spaces. When present, sse headers are added to the request for server side encryption/decryption as the case may be.

e.g. 
```
export MC_ENCRYPT_KEY="play/images=32byteslongsecretkeymustbegiven1 s3/testbucket=32byteslongsecretkeymustbegiven2"
```