### PR TITLE
Add storage-class support

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -608,6 +608,10 @@ func (c *s3Client) Put(ctx context.Context, reader io.Reader, size int64, metada
 		delete(metadata, "Content-Language")
 	}
 
+	storageClass, ok := metadata["X-Amz-Storage-Class"]
+	if ok {
+		delete(metadata, "X-Amz-Storage-Class")
+	}
 	if bucket == "" {
 		return 0, probe.NewError(BucketNameEmpty{})
 	}
@@ -620,6 +624,7 @@ func (c *s3Client) Put(ctx context.Context, reader io.Reader, size int64, metada
 		ContentDisposition: contentDisposition,
 		ContentEncoding:    contentEncoding,
 		ContentLanguage:    contentLanguage,
+		StorageClass:       strings.ToUpper(storageClass),
 	}
 	n, e := c.api.PutObjectWithContext(ctx, bucket, object, reader, size, opts)
 	if e != nil {

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -164,6 +164,12 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader)
 		if err != nil {
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}
+		// Get metadata from target content as well
+		if urls.TargetContent.Metadata != nil {
+			for k, v := range urls.TargetContent.Metadata {
+				metadata[k] = v
+			}
+		}
 		_, err = putTargetStream(ctx, targetAlias, targetURL.String(), reader, length, metadata, progress)
 		if err != nil {
 			return urls.WithError(err.Trace(targetURL.String()))

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -352,16 +352,25 @@ USAGE:
    mc cp [FLAGS] SOURCE [SOURCE...] TARGET
    
 FLAGS:
-  --help, -h                       Show help.
-  --recursive, -r		   Copy recursively.
+  --recursive, -r                    Copy recursively.
+  --storage-class value, -sc value   Set storage class for object.
+  --help, -h                         Show help.
 ```
 
-*Example: Copy a text file to to an object storage.*
+*Example: Copy a text file to an object storage.*
 
 ```sh
 mc cp myobject.txt play/mybucket
 myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
 ```
+
+*Example: Copy a text file to an object storage and assign storage-class `REDUCED_REDUNDANCY` to the uploaded object.*
+
+```sh
+mc cp --storage-class REDUCED_REDUNDANCY myobject.txt play/mybucket
+myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
+```
+
 <a name="rm"></a>
 ### Command `rm` - Remove Buckets and Objects
 Use `rm` command to remove file or bucket
@@ -495,12 +504,13 @@ USAGE:
    mc mirror [FLAGS] SOURCE TARGET
 
 FLAGS:
-  --help, -h                       Show help.
-  --force			   Force overwrite of an existing target(s).
-  --fake			   Perform a fake mirror operation.
-  --watch, -w                      Watch and mirror for changes.
-  --remove			   Remove extraneous file(s) on target.
-``` 
+  --help, -h                          Show help.
+  --force                             Force overwrite of an existing target(s).
+  --fake                              Perform a fake mirror operation.
+  --watch, -w                         Watch and mirror for changes.
+  --remove                            Remove extraneous file(s) on target.
+  --storage-class value, --sc value   Set storage class for object.
+```
 
 *Example: Mirror a local directory to 'mybucket' on https://play.minio.io:9000.*
 


### PR DESCRIPTION
This PR adds storage-class support for mc cp and mirror command. Storage class
values are passed via the `-storage-class` or `--sc` flag.

Fixes #1859