### PR TITLE
Do not exit mirroring for cannot delete/overwrite errors

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -578,7 +578,11 @@ func (mj *mirrorJob) mirror(ctx context.Context, cancelMirror context.CancelFunc
 			case BrokenSymlink, TooManyLevelsSymlink, PathNotFound,
 				PathInsufficientPermission, ObjectOnGlacier:
 				continue
+			case deleteNotAllowedErr, overwriteNotAllowedErr:
+				errorIf(err, "Unable to perform a mirror action")
+				continue
 			}
+
 			return err.Trace()
 		}
 

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -177,7 +177,6 @@ func deltaSourceTarget(sourceURL, targetURL string, isFake, isOverwrite, isRemov
 				TgtSSEKey:     tgtSSEKey,
 			}
 		case differInSecond:
-
 			if !isRemove && !isFake {
 				// Object removal not allowed if --remove is not set.
 				URLsCh <- URLs{

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * Minio Client (C) 2014, 2015, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,67 +24,109 @@ import (
 	"github.com/minio/mc/pkg/probe"
 )
 
-var (
-	errDummy = func() *probe.Error {
-		return probe.NewError(errors.New("")).Untrace()
-	}
+type dummyErr error
 
-	errInvalidArgument = func() *probe.Error {
-		return probe.NewError(errors.New("Invalid arguments provided, please refer " + "`mc <command> -h` for relevant documentation.")).Untrace()
-	}
+var errDummy = func() *probe.Error {
+	msg := ""
+	return probe.NewError(dummyErr(errors.New(msg))).Untrace()
+}
 
-	errUnrecognizedDiffType = func(diff differType) *probe.Error {
-		return probe.NewError(errors.New("Unrecognized diffType: " + diff.String() + " provided.")).Untrace()
-	}
+type invalidArgumentErr error
 
-	errInvalidAliasedURL = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Use `mc config host add mycloud " + URL + " ...` to add an alias. Use the alias for S3 operations.")).Untrace()
-	}
+var errInvalidArgument = func() *probe.Error {
+	msg := "Invalid arguments provided, please refer " + "`mc <command> -h` for relevant documentation."
+	return probe.NewError(invalidArgumentErr(errors.New(msg))).Untrace()
+}
 
-	errInvalidAlias = func(alias string) *probe.Error {
-		return probe.NewError(errors.New("Alias `" + alias + "` should have alphanumeric characters such as [helloWorld0, hello_World0, ...]"))
-	}
+type unrecognizedDiffTypeErr error
 
-	errInvalidURL = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("URL `" + URL + "` for minio client should be of the form scheme://host[:port]/ without resource component."))
-	}
+var errUnrecognizedDiffType = func(diff differType) *probe.Error {
+	msg := "Unrecognized diffType: " + diff.String() + " provided."
+	return probe.NewError(unrecognizedDiffTypeErr(errors.New(msg))).Untrace()
+}
 
-	errInvalidAPISignature = func(api, url string) *probe.Error {
-		msg := fmt.Sprintf(
-			"Unrecognized API signature %s for host %s. Valid options are `[%s]`",
-			api, url, strings.Join(validAPIs, ", "))
-		return probe.NewError(errors.New(msg))
-	}
+type invalidAliasedURLErr error
 
-	errNoMatchingHost = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("No matching host found for the given URL `" + URL + "`.")).Untrace()
-	}
+var errInvalidAliasedURL = func(URL string) *probe.Error {
+	msg := "Use `mc config host add mycloud " + URL + " ...` to add an alias. Use the alias for S3 operations."
+	return probe.NewError(invalidAliasedURLErr(errors.New(msg))).Untrace()
+}
 
-	errInvalidSource = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Invalid source `" + URL + "`.")).Untrace()
-	}
+type invalidAliasErr error
 
-	errInvalidTarget = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Invalid target `" + URL + "`.")).Untrace()
-	}
+var errInvalidAlias = func(alias string) *probe.Error {
+	msg := "Alias `" + alias + "` should have alphanumeric characters such as [helloWorld0, hello_World0, ...]"
+	return probe.NewError(invalidAliasErr(errors.New(msg)))
+}
 
-	errOverWriteNotAllowed = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Overwrite not allowed for `" + URL + "`. Use `--overwrite` to override this behavior."))
-	}
+type invalidURLErr error
 
-	errDeleteNotAllowed = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Delete not allowed for `" + URL + "`. Use `--remove` to override this behavior."))
-	}
+var errInvalidURL = func(URL string) *probe.Error {
+	msg := "URL `" + URL + "` for minio client should be of the form scheme://host[:port]/ without resource component."
+	return probe.NewError(invalidURLErr(errors.New(msg)))
+}
 
-	errSourceIsDir = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Source `" + URL + "` is a folder.")).Untrace()
-	}
+type invalidAPISignatureErr error
 
-	errSourceTargetSame = func(URL string) *probe.Error {
-		return probe.NewError(errors.New("Source and target URL can not be same : " + URL)).Untrace()
-	}
+var errInvalidAPISignature = func(api, url string) *probe.Error {
+	msg := fmt.Sprintf(
+		"Unrecognized API signature %s for host %s. Valid options are `[%s]`",
+		api, url, strings.Join(validAPIs, ", "))
+	return probe.NewError(invalidAPISignatureErr(errors.New(msg)))
+}
 
-	errBucketNotSpecified = func() *probe.Error {
-		return probe.NewError(errors.New("This operation requires a " + "bucket to be specified.")).Untrace()
-	}
-)
+type noMatchingHostErr error
+
+var errNoMatchingHost = func(URL string) *probe.Error {
+	msg := "No matching host found for the given URL `" + URL + "`."
+	return probe.NewError(noMatchingHostErr(errors.New(msg))).Untrace()
+}
+
+type invalidSourceErr error
+
+var errInvalidSource = func(URL string) *probe.Error {
+	msg := "Invalid source `" + URL + "`."
+	return probe.NewError(invalidSourceErr(errors.New(msg))).Untrace()
+}
+
+type invalidTargetErr error
+
+var errInvalidTarget = func(URL string) *probe.Error {
+	msg := "Invalid target `" + URL + "`."
+	return probe.NewError(invalidTargetErr(errors.New(msg))).Untrace()
+}
+
+type overwriteNotAllowedErr error
+
+var errOverWriteNotAllowed = func(URL string) *probe.Error {
+	msg := "Overwrite not allowed for `" + URL + "`. Use `--overwrite` to override this behavior."
+	return probe.NewError(overwriteNotAllowedErr(errors.New(msg)))
+}
+
+type deleteNotAllowedErr error
+
+var errDeleteNotAllowed = func(URL string) *probe.Error {
+	msg := "Delete not allowed for `" + URL + "`. Use `--remove` to override this behavior."
+	return probe.NewError(deleteNotAllowedErr(errors.New(msg)))
+}
+
+type sourceIsDirErr error
+
+var errSourceIsDir = func(URL string) *probe.Error {
+	msg := "Source `" + URL + "` is a folder."
+	return probe.NewError(sourceIsDirErr(errors.New(msg))).Untrace()
+}
+
+type sourceTargetSameErr error
+
+var errSourceTargetSame = func(URL string) *probe.Error {
+	msg := "Source and target URL can not be same : " + URL
+	return probe.NewError(sourceTargetSameErr(errors.New(msg))).Untrace()
+}
+
+type bucketNotSpecifiedErr error
+
+var errBucketNotSpecified = func() *probe.Error {
+	msg := "This operation requires a " + "bucket to be specified."
+	return probe.NewError(bucketNotSpecifiedErr(errors.New(msg))).Untrace()
+}


### PR DESCRIPTION
mc used to show a warning messages during mirroring when it
detects a need to overwrite or remove a remote object but no
flag is specified. This commit efeaf2ee721761ba4e801407fb382c5c0f42938a
changed this behavior but this commit will restablish
the old behavior.

Fixes #2414 