### PR TITLE
Fix display message when list and remove notifications are called

### DIFF
--- a/cmd/events-list.go
+++ b/cmd/events-list.go
@@ -122,7 +122,7 @@ func mainEventsList(ctx *cli.Context) error {
 	}
 
 	configs, err := s3Client.ListNotificationConfigs(arn)
-	fatalIf(err, "Cannot enable notification on the specified bucket.")
+	fatalIf(err, "Cannot list notifications on the specified bucket.")
 
 	for _, config := range configs {
 		printMsg(eventsListMessage{Events: config.Events,

--- a/cmd/events-remove.go
+++ b/cmd/events-remove.go
@@ -113,7 +113,7 @@ func mainEventsRemove(ctx *cli.Context) error {
 	}
 
 	err = s3Client.RemoveNotificationConfig(arn)
-	fatalIf(err, "Cannot enable notification on the specified bucket.")
+	fatalIf(err, "Cannot disable notification on the specified bucket.")
 	printMsg(eventsRemoveMessage{ARN: arn})
 
 	return nil


### PR DESCRIPTION
Message still says `Cannot enable notification on the specified bucket.` when list and remove notification on a bucket is called.