### PR TITLE
Simplified build system and move to go1.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 - ARCH=x86_64
 
 go:
-- 1.9.1
+- 1.10.1
 
 script:
 - make test GOFLAGS="-race"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM golang:1.9-alpine
+FROM golang:1.10.1-alpine3.7
 
-WORKDIR /go/src/app
+MAINTAINER Minio Inc <dev@minio.io>
 
-COPY . /go/src/app
+ENV PATH $PATH:$GOPATH/bin
+ENV CGO_ENABLED 0
 
-RUN \
-	apk add --no-cache git && \
-	go-wrapper download && \
-	go-wrapper install -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
-	rm -rf /go/pkg /go/src && \
-	apk del git
+WORKDIR /go/src/github.com/minio/
+
+RUN  \
+     apk add --no-cache ca-certificates && \
+     apk add --no-cache --virtual .build-deps git && \
+     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
+     go get -v -d github.com/minio/mc && \
+     cd /go/src/github.com/minio/mc && \
+     go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)" && \
+     rm -rf /go/pkg /go/src /usr/local/go && apk del .build-deps
 
 ENTRYPOINT ["mc"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.7
+
+MAINTAINER Minio Inc <dev@minio.io>
 
 RUN \
     apk add --no-cache ca-certificates && \

--- a/Makefile
+++ b/Makefile
@@ -1,107 +1,100 @@
+PWD := $(shell pwd)
+GOPATH := $(shell go env GOPATH)
 LDFLAGS := $(shell go run buildscripts/gen-ldflags.go)
+
 BUILD_LDFLAGS := '$(LDFLAGS)'
 
-all: install
+all: build
 
 checks:
-	@echo "Checking deps"
-	@(env bash buildscripts/checkdeps.sh)
-	@echo "Checking project is in GOPATH"
-	@(env bash buildscripts/checkgopath.sh)
+	@echo "Checking dependencies"
+	@(env bash $(PWD)/buildscripts/checkdeps.sh)
+	@echo "Checking for project in GOPATH"
+	@(env bash $(PWD)/buildscripts/checkgopath.sh)
 
-getdeps: checks
-	@echo "Installing golint" && go get github.com/golang/lint/golint
-	@echo "Installing gocyclo" && go get github.com/fzipp/gocyclo
-	@echo "Installing deadcode" && go get github.com/remyoudompheng/go-misc/deadcode
-	@echo "Installing misspell" && go get github.com/client9/misspell/cmd/misspell
+getdeps:
+	@echo "Installing golint" && go get -u github.com/golang/lint/golint
+	@echo "Installing gocyclo" && go get -u github.com/fzipp/gocyclo
+	@echo "Installing deadcode" && go get -u github.com/remyoudompheng/go-misc/deadcode
+	@echo "Installing misspell" && go get -u github.com/client9/misspell/cmd/misspell
+	@echo "Installing ineffassign" && go get -u github.com/gordonklaus/ineffassign
 
-verifiers: vet fmt lint cyclo deadcode spelling
+verifiers: getdeps vet fmt lint cyclo deadcode spelling
 
 vet:
 	@echo "Running $@"
-	@go tool vet -all *.go
-	@go tool vet -all ./cmd
-	@go tool vet -all ./pkg
-	@go tool vet -shadow=true *.go
-	@go tool vet -shadow=true ./cmd
-	@go tool vet -shadow=true ./pkg
-
-spelling:
-	@${GOPATH}/bin/misspell *.go
-	@${GOPATH}/bin/misspell cmd/*
-	@${GOPATH}/bin/misspell pkg/**/*
+	@go tool vet -atomic -bool -copylocks -nilfunc -printf -shadow -rangeloops -unreachable -unsafeptr -unusedresult cmd
+	@go tool vet -atomic -bool -copylocks -nilfunc -printf -shadow -rangeloops -unreachable -unsafeptr -unusedresult pkg
 
 fmt:
 	@echo "Running $@"
-	@gofmt -d *.go
 	@gofmt -d cmd
 	@gofmt -d pkg
+
 lint:
 	@echo "Running $@"
-	@$(GOPATH)/bin/golint .
-	@$(GOPATH)/bin/golint github.com/minio/mc/cmd...
-	@$(GOPATH)/bin/golint github.com/minio/mc/pkg...
+	@${GOPATH}/bin/golint -set_exit_status github.com/minio/mc/cmd...
+	@${GOPATH}/bin/golint -set_exit_status github.com/minio/mc/pkg...
+
+ineffassign:
+	@echo "Running $@"
+	@${GOPATH}/bin/ineffassign .
 
 cyclo:
 	@echo "Running $@"
-	@$(GOPATH)/bin/gocyclo -over 40 cmd
-	@$(GOPATH)/bin/gocyclo -over 40 pkg
+	@${GOPATH}/bin/gocyclo -over 100 cmd
+	@${GOPATH}/bin/gocyclo -over 100 pkg
 
 deadcode:
 	@echo "Running $@"
-	@$(GOPATH)/bin/deadcode
+	@${GOPATH}/bin/deadcode -test $(shell go list ./...)
 
-build: getdeps verifiers
-	@echo "Running $@"
-	@go build -tags kqueue --ldflags $(BUILD_LDFLAGS)
+spelling:
+	@${GOPATH}/bin/misspell -error `find cmd/`
+	@${GOPATH}/bin/misspell -error `find pkg/`
+	@${GOPATH}/bin/misspell -error `find docs/`
 
-test: build
+# Builds minio, runs the verifiers then runs the tests.
+check: test
+test: verifiers build
 	@echo "Running unit tests"
-	@go test $(GOFLAGS) -tags kqueue github.com/minio/mc/cmd...
-	@go test $(GOFLAGS) -tags kqueue github.com/minio/mc/pkg...
+	@go test $(GOFLAGS) -tags kqueue ./...
 	@echo "Running functional tests"
 	@(env bash $(PWD)/functional-tests.sh)
 
-gomake-all: build
-	@echo "Installing mc at $(GOPATH)/bin/mc"
-	@cp -af mc $(GOPATH)/bin/mc
-	@mkdir -p $(HOME)/.mc
+coverage: build
+	@echo "Running all coverage for minio"
+	@(env bash $(PWD)/buildscripts/go-coverage.sh)
 
-coverage: getdeps verifiers
-	@echo "Running all coverage for mc"
-	@./buildscripts/go-coverage.sh
+# Builds minio locally.
+build: checks
+	@echo "Building minio binary to './mc'"
+	@CGO_ENABLED=0 go build -tags kqueue --ldflags $(BUILD_LDFLAGS) -o $(PWD)/mc
 
-pkg-validate-arg-%: ;
-ifndef PKG
-	$(error Usage: make $(@:pkg-validate-arg-%=pkg-%) PKG=pkg_name)
-endif
-
-pkg-add: pkg-validate-arg-add
+pkg-add:
 	@echo "Adding new package $(PKG)"
-	@$(GOPATH)/bin/govendor add $(PKG)
+	@${GOPATH}/bin/govendor add $(PKG)
 
-pkg-update: pkg-validate-arg-update
+pkg-update:
 	@echo "Updating new package $(PKG)"
-	@$(GOPATH)/bin/govendor update $(PKG)
+	@${GOPATH}/bin/govendor update $(PKG)
 
-pkg-remove: pkg-validate-arg-remove
+pkg-remove:
 	@echo "Remove new package $(PKG)"
-	@$(GOPATH)/bin/govendor remove $(PKG)
+	@${GOPATH}/bin/govendor remove $(PKG)
 
 pkg-list:
 	@$(GOPATH)/bin/govendor list
 
-install: gomake-all
-
-release: test
-	@MC_RELEASE=RELEASE ./buildscripts/build.sh
-
-experimental: verifiers
-	@MC_RELEASE=EXPERIMENTAL ./buildscripts/build.sh
+# Builds minio and installs it to $GOPATH/bin.
+install: build
+	@echo "Installing mc binary to '$(GOPATH)/bin/mc'"
+	@cp $(PWD)/mc $(GOPATH)/bin/mc
+	@echo "Installation successful. To learn more, try \"mc --help\"."
 
 clean:
 	@echo "Cleaning up all the generated files"
-	@rm -f cover.out
-	@rm -f mc
 	@find . -name '*.test' | xargs rm -fv
-	@rm -fr release
+	@rm -rvf mc
+	@rm -rvf build
+	@rm -rvf release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,12 @@ version: "{build}"
 # Operating system (build VM template)
 os: Windows Server 2012 R2
 
+# Platform.
+platform: x64
+
 clone_folder: c:\gopath\src\github.com\minio\mc
 
-# environment variables
+# Environment variables
 environment:
   GOPATH: c:\gopath
   GOROOT: c:\go
@@ -18,21 +21,35 @@ install:
   - go env
   - python --version
 
-# to run your custom scripts instead of automatic MSBuild
+# To run your custom scripts instead of automatic MSBuild
 build_script:
-  - go test -race github.com/minio/mc/cmd...
-  - go test -race github.com/minio/mc/pkg...
-  - go test -coverprofile=coverage.txt -covermode=atomic
+  # Compile
+  # We need to disable firewall - https://github.com/appveyor/ci/issues/1579#issuecomment-309830648
+  - ps: Disable-NetFirewallRule -DisplayName 'File and Printer Sharing (SMB-Out)'
+  - appveyor AddCompilationMessage "Starting Compile"
+  - cd c:\gopath\src\github.com\minio\mc
   - go run buildscripts/gen-ldflags.go > temp.txt
   - set /p BUILD_LDFLAGS=<temp.txt
   - go build -ldflags="%BUILD_LDFLAGS%" -o %GOPATH%\bin\mc.exe
-  - mc version
+  - appveyor AddCompilationMessage "Compile Success"
+
+# To run your custom scripts instead of automatic tests
+test_script:
+  # Unit tests
+  - ps: Add-AppveyorTest "Unit Tests" -Outcome Running
+  - mkdir build\coverage
+  - for /f "" %%G in ('go list github.com/minio/mc/...') do ( go test -v -race %%G )
+  - go test -v -coverprofile=build\coverage\coverage.txt -covermode=atomic github.com/minio/mc/cmd
+  - ps: Update-AppveyorTest "Unit Tests" -Outcome Passed
 
 after_test:
-  - bash <(curl -s https://codecov.io/bash)
-
-# to disable automatic tests
-test: off
+  - go tool cover -html=build\coverage\coverage.txt -o build\coverage\coverage.html
+  - ps: Push-AppveyorArtifact build\coverage\coverage.txt
+  - ps: Push-AppveyorArtifact build\coverage\coverage.html
+  # Upload coverage report.
+  - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+  - pip install codecov
+  - codecov -X gcov -f "build\coverage\coverage.txt"
 
 # to disable deployment
 deploy: off

--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -21,10 +21,15 @@ _init() {
 
     ## Minimum required versions for build dependencies
     GIT_VERSION="1.0"
-    GO_VERSION="1.9.1"
+    GO_VERSION="1.10.1"
     OSX_VERSION="10.8"
     KNAME=$(uname -s)
     ARCH=$(uname -m)
+    case "${KNAME}" in
+        SunOS )
+            ARCH=$(isainfo -k)
+            ;;
+    esac
 }
 
 ## FIXME:
@@ -88,68 +93,48 @@ assert_is_supported_arch() {
             return
             ;;
         *)
-            echo "ERROR"
-            echo "Arch '${ARCH}' not supported."
-            echo "Supported Arch: [x86_64, amd64, aarch64, arm*]"
+            echo "Arch '${ARCH}' is not supported. Supported Arch: [x86_64, amd64, aarch64, arm*]"
             exit 1
     esac
 }
 
 assert_is_supported_os() {
     case "${KNAME}" in
-        Linux | FreeBSD | OpenBSD | NetBSD | DragonFly )
+        Linux | FreeBSD | OpenBSD | NetBSD | DragonFly | SunOS )
             return
             ;;
         Darwin )
             osx_host_version=$(env sw_vers -productVersion)
             if ! check_minimum_version "${OSX_VERSION}" "${osx_host_version}"; then
-                echo "ERROR"
-                echo "OSX version '${osx_host_version}' not supported."
-                echo "Minimum supported version: ${OSX_VERSION}"
+                echo "OSX version '${osx_host_version}' is not supported. Minimum supported version: ${OSX_VERSION}"
                 exit 1
             fi
             return
             ;;
         *)
-            echo "ERROR"
-            echo "OS '${KNAME}' is not supported."
-            echo "Supported OS: [Linux, FreeBSD, OpenBSD, NetBSD, Darwin, DragonFly]"
+            echo "OS '${KNAME}' is not supported. Supported OS: [Linux, FreeBSD, OpenBSD, NetBSD, Darwin, DragonFly]"
             exit 1
     esac
 }
 
 assert_check_golang_env() {
     if ! which go >/dev/null 2>&1; then
-        echo "ERROR"
-        echo "Cannot find go binary in your PATH configuration, please refer to Go installation document at"
-        echo "https://docs.minio.io/docs/how-to-install-golang"
+        echo "Cannot find go binary in your PATH configuration, please refer to Go installation document at https://docs.minio.io/docs/how-to-install-golang"
         exit 1
     fi
 
     installed_go_version=$(go version | sed 's/^.* go\([0-9.]*\).*$/\1/')
     if ! check_minimum_version "${GO_VERSION}" "${installed_go_version}"; then
-        echo "ERROR"
-        echo "Go version '${installed_go_version}' not supported."
-        echo "Minimum supported version: ${GO_VERSION}"
+        echo "Go runtime version '${installed_go_version}' is unsupported. Minimum supported version: ${GO_VERSION} to compile."
         exit 1
     fi
-
-    if [ -z "${GOPATH}" ]; then
-        echo "ERROR"
-        echo "GOPATH environment variable missing, please refer to Go installation document"
-        echo "https://docs.minio.io/docs/how-to-install-golang"
-        exit 1
-    fi
-
 }
 
 assert_check_deps() {
     # support unusual Git versions such as: 2.7.4 (Apple Git-66)
     installed_git_version=$(git version | perl -ne '$_ =~ m/git version (.*?)( |$)/; print "$1\n";')
     if ! check_minimum_version "${GIT_VERSION}" "${installed_git_version}"; then
-        echo "ERROR"
-        echo "Git version '${installed_git_version}' not supported."
-        echo "Minimum supported version: ${GIT_VERSION}"
+        echo "Git version '${installed_git_version}' is not supported. Minimum supported version: ${GIT_VERSION}"
         exit 1
     fi
 }

--- a/buildscripts/checkgopath.sh
+++ b/buildscripts/checkgopath.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Minio Client, (C) 2015, 2016, 2017 Minio, Inc.
+# Minio Client, (C) 2015, 2016, 2017, 2018 Minio, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,27 +15,20 @@
 # limitations under the License.
 #
 
-_init() {
-
-    shopt -s extglob
-
-    # Fetch real paths instead of symlinks before comparing them
-    PWD=$(env pwd -P)
-    GOPATH=$(cd "$(go env GOPATH)" ; env pwd -P)
-}
-
 main() {
-    echo "Checking if project is at ${GOPATH}"
-    for mc in $(echo ${GOPATH} | tr ':' ' '); do
-        if [ ! -d ${mc}/src/github.com/minio/mc ]; then
-            echo "Project not found in ${mc}, please follow instructions provided at https://github.com/minio/mc/blob/master/CONTRIBUTING.md#setup-your-mc-github-repository" \
-                && exit 1
-        fi
-        if [ "x${mc}/src/github.com/minio/mc" != "x${PWD}" ]; then
-            echo "Build outside of ${mc}, two source checkouts found. Exiting." && exit 1
+    gopath=$(go env GOPATH)
+    IFS=':' read -r -a paths <<< "$gopath"
+    for path in "${paths[@]}"; do
+        mcpath="$path/src/github.com/minio/mc"
+        if [ -d "$mcpath" ]; then
+            if [ "$mcpath" -ef "$PWD" ]; then
+               exit 0
+            fi
         fi
     done
+
+    echo "Project not found in ${gopath}. Follow instructions at https://github.com/minio/mc/blob/master/CONTRIBUTING.md#setup-your-mc-github-repository"
+    exit 1
 }
 
-_init && main
-
+main

--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -1,7 +1,7 @@
 // +build ignore
 
 /*
- * Mc Client (C) 2014, 2015, 2016 Minio, Inc.
+ * Minio Client (C) 2014, 2015, 2016, 2017, 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildscripts/go-coverage.sh
+++ b/buildscripts/go-coverage.sh
@@ -3,7 +3,7 @@
 set -e
 echo "" > coverage.txt
 
-for d in $(go list ./... | grep -v vendor); do
+for d in $(go list ./...); do
     go test -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -111,31 +111,6 @@ type infoMessage struct {
 	*ServerInfo
 }
 
-func countOnlineDrives(drives []madmin.DriveInfo) int {
-	var i = 0
-	for _, drive := range drives {
-		if drive.State == madmin.DriveStateOk {
-			i++
-		}
-	}
-	return i
-}
-
-func countMissingDrives(drives []madmin.DriveInfo) int {
-	var i = 0
-	for _, drive := range drives {
-		switch drive.State {
-		case madmin.DriveStateOffline:
-			fallthrough
-		case madmin.DriveStateMissing:
-			fallthrough
-		case madmin.DriveStateCorrupt:
-			i++
-		}
-	}
-	return i
-}
-
 // String colorized service status message.
 func (u infoMessage) String() (msg string) {
 	defer func() {

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -34,15 +34,6 @@ func getCertsDir() (string, *probe.Error) {
 	return filepath.Join(p, globalMCCertsDir), nil
 }
 
-// mustGetCertsDir - return the full path of certs dir or empty string when an error occurs
-func mustGetCertsDir() string {
-	p, err := getCertsDir()
-	if err != nil {
-		return ""
-	}
-	return p
-}
-
 // isCertsDirExists - verify if certs directory exists.
 func isCertsDirExists() bool {
 	certsDir, err := getCertsDir()

--- a/cmd/config-old.go
+++ b/cmd/config-old.go
@@ -16,11 +16,6 @@
 
 package cmd
 
-import (
-	"github.com/minio/mc/pkg/probe"
-	"github.com/minio/minio/pkg/quick"
-)
-
 /////////////////// Config V1 ///////////////////
 type hostConfigV1 struct {
 	AccessKeyID     string
@@ -307,50 +302,6 @@ func (c *configV8) loadDefaults() {
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",
 	})
-}
-
-// loadConfigV8 - loads a new config.
-func loadConfigV8() (*configV8, *probe.Error) {
-	cfgMutex.RLock()
-	defer cfgMutex.RUnlock()
-
-	if !isMcConfigExists() {
-		return nil, errInvalidArgument().Trace()
-	}
-
-	// Initialize a new config loader.
-	qc, e := quick.New(newConfigV8())
-	if e != nil {
-		return nil, probe.NewError(e)
-	}
-
-	// Load config at configPath, fails if config is not
-	// accessible, malformed or version missing.
-	if e = qc.Load(mustGetMcConfigPath()); e != nil {
-		return nil, probe.NewError(e)
-	}
-
-	cfgV8 := qc.Data().(*configV8)
-
-	// Success.
-	return cfgV8, nil
-}
-
-// saveConfigV8 - saves an updated config.
-func saveConfigV8(cfgV8 *configV8) *probe.Error {
-	cfgMutex.Lock()
-	defer cfgMutex.Unlock()
-
-	qs, e := quick.New(cfgV8)
-	if e != nil {
-		return probe.NewError(e)
-	}
-
-	e = qs.Save(mustGetMcConfigPath())
-	if e != nil {
-		return probe.NewError(e).Trace(mustGetMcConfigPath())
-	}
-	return nil
 }
 
 /////////////////// Config V9 ///////////////////

--- a/cmd/mc_test.go
+++ b/cmd/mc_test.go
@@ -22,23 +22,15 @@ import (
 	"testing"
 	"time"
 
-	"net/http/httptest"
-
 	"github.com/hashicorp/go-version"
-	"github.com/minio/cli"
 	. "gopkg.in/check.v1"
 )
-
-var customConfigDir string
 
 func Test(t *testing.T) { TestingT(t) }
 
 type TestSuite struct{}
 
 var _ = Suite(&TestSuite{})
-
-var server *httptest.Server
-var app *cli.App
 
 func (s *TestSuite) SetUpSuite(c *C) {
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -17,9 +17,7 @@
 package cmd
 
 import (
-	"crypto/md5"
 	"crypto/tls"
-	"encoding/base64"
 	"errors"
 	"io"
 	"math/rand"
@@ -160,13 +158,6 @@ func getLookupType(l string) minio.BucketLookupType {
 		return minio.BucketLookupPath
 	}
 	return minio.BucketLookupAuto
-}
-
-// sumMD5Base64 calculate md5sum for an input byte array, returns base64 encoded.
-func sumMD5Base64(data []byte) string {
-	hash := md5.New()
-	hash.Write(data)
-	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }
 
 // struct representing object prefix and sse keys association.


### PR DESCRIPTION
minio server simplified its build system, this
change borrows the same technique to `mc` as well.

This PR fixes build messages and overall behavior
of our builds on travis and appveyor.