### PR TITLE
Quit calculating difference for any listing error

### DIFF
--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -98,14 +98,12 @@ func difference(sourceClnt, targetClnt Client, sourceURL, targetURL string, isRe
 
 			if !srcEOF && srcCtnt.Err != nil {
 				diffCh <- diffMessage{Error: srcCtnt.Err.Trace(sourceURL, targetURL)}
-				srcCtnt, srcOk = <-srcCh
-				continue
+				return
 			}
 
 			if !tgtEOF && tgtCtnt.Err != nil {
 				diffCh <- diffMessage{Error: tgtCtnt.Err.Trace(sourceURL, targetURL)}
-				tgtCtnt, tgtOk = <-tgtCh
-				continue
+				return
 			}
 
 			// If source doesn't have objects anymore, comparison becomes obvious

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -581,15 +581,14 @@ func (mj *mirrorJob) mirror(ctx context.Context, cancelMirror context.CancelFunc
 			switch err.ToGoError().(type) {
 			case BrokenSymlink, TooManyLevelsSymlink, PathNotFound,
 				PathInsufficientPermission, ObjectOnGlacier:
+				errorIf(err, "Unable to perform a mirror action.")
 				continue
 			case deleteNotAllowedErr, overwriteNotAllowedErr:
 				errorIf(err, "Unable to perform a mirror action.")
 				continue
 			}
-
 			return err.Trace()
 		}
-
 	}
 }
 

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -117,7 +117,7 @@ func deltaSourceTarget(sourceURL, targetURL string, isFake, isOverwrite, isRemov
 		if diffMsg.Error != nil {
 			// Send all errors through the channel
 			URLsCh <- URLs{Error: diffMsg.Error}
-			continue
+			return
 		}
 
 		srcSuffix := strings.TrimPrefix(diffMsg.FirstURL, sourceURL)


### PR DESCRIPTION
If we have any listing problem, we should stop comparing difference
between source & target lists because it is already so hard to know
what mc should do next. So, let's inform users and let them deal 
with the problem.

Fixes #2439 