### PR TITLE
fix: Disable localization to enforce bytewise sorting in functional tests

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -32,6 +32,9 @@
 #
 ################################################################################
 
+# Force bytewise sorting for CLI tools
+LANG=C
+
 if [ -n "$MINT_MODE" ]; then
     if [ -z "${MINT_DATA_DIR+x}" ]; then
         echo "MINT_DATA_DIR not defined"


### PR DESCRIPTION
Functional tests is not passing in my laptop due to a weird sorting of ls output. Set LANG=C means consider ASCII order and will fix the problem.