### PR TITLE
Makefile: Create bin directory if it doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ pkg-list:
 # Builds minio and installs it to $GOPATH/bin.
 install: build
 	@echo "Installing mc binary to '$(GOPATH)/bin/mc'"
-	@cp $(PWD)/mc $(GOPATH)/bin/mc
+	@mkdir -p $(GOPATH)/bin && cp $(PWD)/mc $(GOPATH)/bin/mc
 	@echo "Installation successful. To learn more, try \"mc --help\"."
 
 clean:


### PR DESCRIPTION
Copy of minio binary to $GOPATH/bin folder fails if the bin directory doesn't exist. It needs to be created if it doesn't exist. Fix similar to the one in https://github.com/minio/minio/pull/6050 