### PR TITLE
Pass down encrypt-key handling across command validators

### DIFF
--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -171,12 +171,7 @@ func urlJoinPath(url1, url2 string) string {
 }
 
 // url2Stat returns stat info for URL.
-func url2Stat(urlStr string) (client Client, content *clientContent, err *probe.Error) {
-	return url2StatWithMetadata(urlStr, false, nil)
-}
-
-// url2Stat returns stat info for URL.
-func url2StatWithMetadata(urlStr string, isFetchMeta bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *clientContent, err *probe.Error) {
+func url2Stat(urlStr string, isFetchMeta bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *clientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -105,9 +105,8 @@ EXAMPLES:
    8. Copy a local folder with space separated characters to Amazon S3 cloud storage.
       $ {{.HelpName}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
 
-  10. Copy a folder with encrypted objects recursively from Amazon S3 to Minio cloud storage.
-      $ {{.HelpName}} --recursive --encrypt-key "s3/documents/a/b/c=32byteslongsecretkeymustbegiven1,myminio/documents/=32byteslongsecretkeymustbegiven2" 's3/documents/' myminio/documents/
-
+   9. Copy a folder with encrypted objects recursively from Amazon S3 to Minio cloud storage.
+      $ {{.HelpName}} --recursive --encrypt-key "s3/documents/=32byteslongsecretkeymustbegiven1,myminio/documents/=32byteslongsecretkeymustbegiven2" s3/documents/ myminio/documents/
 `,
 }
 
@@ -223,6 +222,7 @@ func doPrepareCopyURLs(session *sessionV8, trapCh <-chan bool, cancelCopy contex
 	encryptKeys := session.Header.CommandStringFlags["encrypt-key"]
 	encKeyDB, err := parseAndValidateEncryptionKeys(encryptKeys)
 	fatalIf(err, "Unable to parse encryption keys.")
+
 	// Create a session data file to store the processed URLs.
 	dataFP := session.NewDataWriter()
 
@@ -429,9 +429,12 @@ loop:
 
 // mainCopy is the entry point for cp command.
 func mainCopy(ctx *cli.Context) error {
+	// Parse encryption keys per command.
+	encKeyDB, err := getEncKeys(ctx)
+	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(ctx)
+	checkCopySyntax(ctx, encKeyDB)
 
 	// Additional command speific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -108,7 +108,7 @@ func (d diffMessage) JSON() string {
 	return string(diffJSONBytes)
 }
 
-func checkDiffSyntax(ctx *cli.Context) {
+func checkDiffSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	if len(ctx.Args()) != 2 {
 		cli.ShowCommandHelpAndExit(ctx, "diff", 1) // last argument is exit code
 	}
@@ -124,7 +124,7 @@ func checkDiffSyntax(ctx *cli.Context) {
 	// Diff only works between two directories, verify them below.
 
 	// Verify if firstURL is accessible.
-	_, firstContent, err := url2Stat(firstURL)
+	_, firstContent, err := url2Stat(firstURL, false, encKeyDB)
 	if err != nil {
 		fatalIf(err.Trace(firstURL), fmt.Sprintf("Unable to stat '%s'.", firstURL))
 	}
@@ -135,7 +135,7 @@ func checkDiffSyntax(ctx *cli.Context) {
 	}
 
 	// Verify if secondURL is accessible.
-	_, secondContent, err := url2Stat(secondURL)
+	_, secondContent, err := url2Stat(secondURL, false, encKeyDB)
 	if err != nil {
 		fatalIf(err.Trace(secondURL), fmt.Sprintf("Unable to stat '%s'.", secondURL))
 	}
@@ -189,9 +189,12 @@ func doDiffMain(firstURL, secondURL string) error {
 
 // mainDiff main for 'diff'.
 func mainDiff(ctx *cli.Context) error {
+	// Parse encryption keys per command.
+	encKeyDB, err := getEncKeys(ctx)
+	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check 'diff' cli arguments.
-	checkDiffSyntax(ctx)
+	checkDiffSyntax(ctx, encKeyDB)
 
 	// Additional command specific theme customization.
 	console.SetColor("DiffMessage", color.New(color.FgGreen, color.Bold))

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -158,7 +158,7 @@ EXAMPLES:
 }
 
 // checkFindSyntax - validate the passed arguments
-func checkFindSyntax(ctx *cli.Context) {
+func checkFindSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	args := ctx.Args()
 	if !args.Present() {
 		args = []string{"./"} // No args just default to present directory.
@@ -174,7 +174,7 @@ func checkFindSyntax(ctx *cli.Context) {
 
 	// Extract input URLs and validate.
 	for _, url := range args {
-		_, _, err := url2Stat(url)
+		_, _, err := url2Stat(url, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, false) {
 			// Bucket name empty is a valid error for 'find myminio' unless we are using watch, treat it as such.
 			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !ctx.Bool("watch") {
@@ -216,7 +216,11 @@ func mainFind(ctx *cli.Context) error {
 	console.SetColor("Find", color.New(color.FgGreen, color.Bold))
 	console.SetColor("FindExecErr", color.New(color.FgRed, color.Italic, color.Bold))
 
-	checkFindSyntax(ctx)
+	// Parse encryption keys per command.
+	encKeyDB, err := getEncKeys(ctx)
+	fatalIf(err, "Unable to parse encryption keys.")
+
+	checkFindSyntax(ctx, encKeyDB)
 
 	args := ctx.Args()
 	if !args.Present() {

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -35,6 +35,10 @@ var (
 			Name:  "incomplete, I",
 			Usage: "List incomplete uploads.",
 		},
+		cli.StringFlag{
+			Name:  "encrypt-key",
+			Usage: "Encrypt/Decrypt (using server-side encryption)",
+		},
 	}
 )
 
@@ -91,8 +95,12 @@ func checkListSyntax(ctx *cli.Context) {
 	URLs := ctx.Args()
 	isIncomplete := ctx.Bool("incomplete")
 
+	// Parse encryption keys per command.
+	encKeyDB, err := getEncKeys(ctx)
+	fatalIf(err, "Unable to parse encryption keys.")
+
 	for _, url := range URLs {
-		_, _, err := url2Stat(url)
+		_, _, err := url2Stat(url, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			// Bucket name empty is a valid error for 'ls myminio',
 			// treat it as such.

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -31,7 +31,7 @@ import (
 //   mirror(d1..., d2) -> []mirror(d1/f, d2/d1/f)
 
 // checkMirrorSyntax(URLs []string)
-func checkMirrorSyntax(ctx *cli.Context) {
+func checkMirrorSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	if len(ctx.Args()) != 2 {
 		cli.ShowCommandHelpAndExit(ctx, "mirror", 1) // last argument is exit code.
 	}
@@ -49,7 +49,7 @@ func checkMirrorSyntax(ctx *cli.Context) {
 
 	/****** Generic rules *******/
 	if !ctx.Bool("watch") {
-		_, srcContent, err := url2Stat(srcURL)
+		_, srcContent, err := url2Stat(srcURL, false, encKeyDB)
 		// incomplete uploads are not necessary for copy operation, no need to verify for them.
 		isIncomplete := false
 		if err != nil && !isURLPrefixExists(srcURL, isIncomplete) {

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -104,23 +104,19 @@ func checkPipeSyntax(ctx *cli.Context) {
 
 // mainPipe is the main entry point for pipe command.
 func mainPipe(ctx *cli.Context) error {
+	// Parse encryption keys per command.
+	encKeyDB, err := getEncKeys(ctx)
+	fatalIf(err, "Unable to parse encryption keys.")
 
 	// validate pipe input arguments.
 	checkPipeSyntax(ctx)
 
 	if len(ctx.Args()) == 0 {
-		err := pipe("", nil)
+		err = pipe("", nil)
 		fatalIf(err.Trace("stdout"), "Unable to write to one or more targets.")
 	} else {
 		// extract URLs.
 		URLs := ctx.Args()
-		sseKeys := os.Getenv("MC_ENCRYPT_KEY")
-		if key := ctx.String("encrypt-key"); key != "" {
-			sseKeys = key
-		}
-
-		encKeyDB, err := parseAndValidateEncryptionKeys(sseKeys)
-		fatalIf(err, "Unable to parse encryption keys.")
 		err = pipe(URLs[0], encKeyDB)
 		fatalIf(err.Trace(URLs[0]), "Unable to write to one or more targets.")
 	}

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -67,7 +67,7 @@ EXAMPLES:
 }
 
 // checkShareDownloadSyntax - validate command-line args.
-func checkShareDownloadSyntax(ctx *cli.Context) {
+func checkShareDownloadSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	args := ctx.Args()
 	if !args.Present() {
 		cli.ShowCommandHelpAndExit(ctx, "download", 1) // last argument is exit code.
@@ -94,7 +94,7 @@ func checkShareDownloadSyntax(ctx *cli.Context) {
 	isRecursive := ctx.Bool("recursive")
 	if !isRecursive {
 		for _, url := range ctx.Args() {
-			_, _, err := url2Stat(url)
+			_, _, err := url2Stat(url, false, encKeyDB)
 			if err != nil {
 				fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 			}
@@ -193,9 +193,12 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 
 // main for share download.
 func mainShareDownload(ctx *cli.Context) error {
+	// Parse encryption keys per command.
+	encKeyDB, err := getEncKeys(ctx)
+	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check input arguments.
-	checkShareDownloadSyntax(ctx)
+	checkShareDownloadSyntax(ctx, encKeyDB)
 
 	// Initialize share config folder.
 	initShareConfig()

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -144,7 +144,7 @@ func doStat(clnt Client, isRecursive bool, targetAlias, targetURL string, encKey
 			continue
 		}
 		url := targetAlias + getKey(content)
-		_, stat, err := url2StatWithMetadata(url, true, encKeyDB)
+		_, stat, err := url2Stat(url, true, encKeyDB)
 		if err != nil {
 			stat = content
 		}

--- a/vendor/github.com/minio/minio-go/api-compose-object.go
+++ b/vendor/github.com/minio/minio-go/api-compose-object.go
@@ -455,7 +455,7 @@ func (c Client) ComposeObjectWithProgress(dst DestinationInfo, srcs []SourceInfo
 	for i, src := range srcs {
 		h := src.Headers
 		if src.encryption != nil {
-			src.encryption.Marshal(h)
+			encrypt.SSECopy(src.encryption).Marshal(h)
 		}
 		// Add destination encryption headers
 		if dst.encryption != nil {
@@ -480,7 +480,7 @@ func (c Client) ComposeObjectWithProgress(dst DestinationInfo, srcs []SourceInfo
 				return err
 			}
 			if progress != nil {
-				io.CopyN(ioutil.Discard, progress, start+end-1)
+				io.CopyN(ioutil.Discard, progress, end-start+1)
 			}
 			objParts = append(objParts, complPart)
 			partIndex++

--- a/vendor/github.com/minio/minio-go/api.go
+++ b/vendor/github.com/minio/minio-go/api.go
@@ -99,7 +99,7 @@ type Options struct {
 // Global constants.
 const (
 	libraryName    = "minio-go"
-	libraryVersion = "v6.0.5"
+	libraryVersion = "v6.0.6"
 )
 
 // User Agent should always following the below style.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -56,46 +56,46 @@
 			"revisionTime": "2015-10-24T22:24:27-07:00"
 		},
 		{
-			"checksumSHA1": "qmCEhMpDtl8rzdoxAlK9pz/rkek=",
+			"checksumSHA1": "PiGm5X1m6ZVCHxE6tua2tlCYg5I=",
 			"path": "github.com/minio/minio-go",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "Qsj+6JPmJ8R5rFNQSHqRb8xAwOw=",
 			"path": "github.com/minio/minio-go/pkg/credentials",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "Md5pOKYfoKtrG7xNvs2FtiDPfDc=",
 			"path": "github.com/minio/minio-go/pkg/encrypt",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "6D/qMFV+e39L+6aeT+Seq1guohM=",
 			"path": "github.com/minio/minio-go/pkg/policy",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "bbWjcrOQsV57qK+BSsrNAsI+Q/o=",
 			"path": "github.com/minio/minio-go/pkg/s3signer",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "xrJThFwwkVrJdwd5iYFHqfx4wRY=",
 			"path": "github.com/minio/minio-go/pkg/s3utils",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "Wt8ej+rZXTdNBR9Xyw1eGo3Iq5o=",
 			"path": "github.com/minio/minio-go/pkg/set",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "f44ca5490afab26b1b2988eb870b20c5183817b0",
+			"revisionTime": "2018-07-11T12:25:12Z"
 		},
 		{
 			"checksumSHA1": "MEC+K9aTG+8tfPjnJ4qj2Y+kc4s=",


### PR DESCRIPTION
Currently even if the command supports encrypted objects,
the syntax verification would fail on them in certain
cases. Since syntax validation of source/targets doesn't
use the parsed encrypt key pairs.  This PR fixes this
behavior.