### PR TITLE
fix for mc find --ignore option

### DIFF
--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -270,6 +270,7 @@ func mainFind(ctx *cli.Context) error {
 		namePattern:   ctx.String("name"),
 		pathPattern:   ctx.String("path"),
 		regexPattern:  ctx.String("regex"),
+		ignorePattern: ctx.String("ignore"),
 		olderThan:     olderThan,
 		newerThan:     newerThan,
 		largerSize:    largerSize,


### PR DESCRIPTION
Added the missing line to make the  --ignore option in mc find work

Fixes #2487 