### PR TITLE
Pick a random bucket name when probing for signature version

### DIFF
--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -156,7 +156,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 		AccessKey: accessKey,
 		SecretKey: secretKey,
 		Signature: "s3v4",
-		HostURL:   urlJoinPath(url, "probe-bucket-sign"),
+		HostURL:   urlJoinPath(url, "probe-bucket-sign-"+newRandomID(32)),
 	}
 
 	s3Client, err := s3New(s3Config)


### PR DESCRIPTION
Probing buckets is a mechanism used to automatically detect supported
S3 signature version. However, it seems that probe-bucket-sign is already
used by someone, the thing that makes probing fails with 403 error. This
PR changes the code to pick a random bucket name when probing.