### PR TITLE
Implement select command for MC

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -95,6 +95,11 @@ func (f *fsClient) GetURL() clientURL {
 	return *f.PathURL
 }
 
+// Select replies a stream of query results.
+func (f *fsClient) Select(expression string) (<-chan []byte, *probe.Error) {
+	return nil, probe.NewError(APINotImplemented{})
+}
+
 // Watches for all fs events on an input path.
 func (f *fsClient) Watch(params watchParams) (*watchObject, *probe.Error) {
 	eventChan := make(chan EventInfo)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -58,6 +58,9 @@ type Client interface {
 	// I/O operations
 	Copy(source string, size int64, progress io.Reader, srcSSEKey, tgtSSEKey string) *probe.Error
 
+	// Runs select expression on object storage on specific files.
+	Select(expression string) (<-chan []byte, *probe.Error)
+
 	// I/O operations with metadata.
 	Get(sseKey string) (reader io.Reader, err *probe.Error)
 	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sseKey string) (n int64, err *probe.Error)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -277,6 +277,7 @@ func registerApp() *cli.App {
 	registerCmd(cpCmd)      // Copy objects and files from multiple sources to single destination.
 	registerCmd(mirrorCmd)  // Mirror objects and files from single source to multiple destinations.
 	registerCmd(findCmd)    // Find specific String patterns
+	registerCmd(selectCmd)  // Run select queries on a object or set of objects.
 	registerCmd(statCmd)    // Stat contents of a bucket/object
 	registerCmd(diffCmd)    // Computer differences between two files or folders.
 	registerCmd(rmCmd)      // Remove a file or bucket

--- a/cmd/select-main.go
+++ b/cmd/select-main.go
@@ -1,0 +1,112 @@
+/*
+ * Minio Client, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var (
+	selectFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "expression",
+			Usage: "SQL query expression.",
+		},
+	}
+)
+
+// Display contents of a file.
+var selectCmd = cli.Command{
+	Name:   "select",
+	Usage:  "Run select queries on objects.",
+	Action: mainSelect,
+	Before: setGlobalsFromContext,
+	Flags:  append(selectFlags, globalFlags...),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS] TARGET [TARGET...]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+   1. Run a query on a set of objects recursively on s3 account.
+      $ {{.HelpName}} --expression "select * from S3Object" s3/personalbucket/my-large-csvs/
+
+   2. Run a query on an object on minio account.
+      $ {{.HelpName}} --expression "select count(s.power) from S3Object" myminio/iot-devices/power-ratio.csv
+`,
+}
+
+func selectQl(targetURL, expression string) *probe.Error {
+	targetClnt, err := newClient(targetURL)
+	if err != nil {
+		return err.Trace(targetURL)
+	}
+	outputer, err := targetClnt.Select(expression)
+	if err != nil {
+		return err.Trace(targetURL, expression)
+	}
+	for event := range outputer {
+		os.Stdout.Write(event)
+	}
+
+	return nil
+}
+
+// check select input arguments.
+func checkSelectSyntax(ctx *cli.Context) {
+	if !ctx.Args().Present() {
+		cli.ShowCommandHelpAndExit(ctx, "select", 1) // last argument is exit code.
+	}
+}
+
+// mainSelect is the main entry point for select command.
+func mainSelect(ctx *cli.Context) error {
+
+	// validate select input arguments.
+	checkSelectSyntax(ctx)
+
+	// extract URLs.
+	URLs := ctx.Args()
+	for _, url := range URLs {
+		if !isAliasURLDir(url) {
+			errorIf(selectQl(url, ctx.String("expression")).Trace(url), "Unable to run select")
+			continue
+		}
+		targetAlias, targetURL, _ := mustExpandAlias(url)
+		clnt, err := newClientFromAlias(targetAlias, targetURL)
+		if err != nil {
+			errorIf(err.Trace(url), "Unable to initialize target `"+url+"`.")
+			continue
+		}
+		for content := range clnt.List(true, false, DirLast) {
+			if content.Err != nil {
+				errorIf(content.Err.Trace(url), "Unable to list on target `"+url+"`.")
+			}
+			errorIf(selectQl(targetAlias+content.URL.Path, ctx.String("expression")).Trace(content.URL.String()), "Unable to run select")
+		}
+	}
+
+	// Done.
+	return nil
+}

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -22,6 +22,7 @@ session  Manage saved sessions for cp command.
 config   Manage mc configuration file.
 update   Check for a new software update.
 version  Print version info.
+select   Use SQL Select statement to query an object.
 ```
 
 ## 1.  Download Minio Client
@@ -149,8 +150,8 @@ export MC_HOSTS_<alias>=https://<Access Key>:<Secret Key>@<YOUR-S3-ENDPOINT>
 Example:
 ```sh
 export MC_HOSTS_myalias=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG@play.minio.io:9000
-mc ls myalias 
-``` 
+mc ls myalias
+```
 ## 4. Test Your Setup
 `mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
@@ -251,6 +252,7 @@ Skip SSL certificate verification.
 | [**diff** - Diff buckets](#diff) |[**policy** - Set public policy on bucket or prefix](#policy)  |[**session** - Manage saved sessions](#session) |
 | [**config** - Manage config file](#config)  | [**watch** - Watch for events](#watch)  | [**events** - Manage events on your buckets](#events)  |
 | [**update** - Manage software updates](#update)  | [**version** - Show version](#version)  | [**stat** - Stat contents of objects and folders](#stat) |
+|[**select** - Use SQL query on object](#select) | |
 
 
 ###  Command `ls` - List Objects
@@ -860,6 +862,25 @@ mc version
 Version: 2016-04-01T00:22:11Z
 Release-tag: RELEASE.2016-04-01T00-22-11Z
 Commit-id: 12adf3be326f5b6610cdd1438f72dfd861597fce
+```
+<a name="select"></a>
+### Command `Select` - Query Object
+Display the results of the SQL Select Query on the object.
+
+```sh
+USAGE:
+  mc select [FLAGS]
+
+FLAGS:
+  --expression SQL Select query.
+  --help, -h   Show help.
+```
+
+ *Example: Query rows where the last name is James from an S3 Object.*
+
+```sh
+mc select --expression "select first_name,last_name from S3OBJECT where last_name = 'James'AND first_name = 'Lebron'" s3/mybucket/mycsv.csv
+Lebron James
 ```
 <a name="stat"></a>
 ### Command `stat` - Stat contents of objects and folders

--- a/vendor/github.com/minio/minio-go/api-compose-object.go
+++ b/vendor/github.com/minio/minio-go/api-compose-object.go
@@ -480,7 +480,7 @@ func (c Client) ComposeObjectWithProgress(dst DestinationInfo, srcs []SourceInfo
 				return err
 			}
 			if progress != nil {
-				io.CopyN(ioutil.Discard, progress, start+end-1)
+				io.CopyN(ioutil.Discard, progress, end-start+1)
 			}
 			objParts = append(objParts, complPart)
 			partIndex++

--- a/vendor/github.com/minio/minio-go/api-select.go
+++ b/vendor/github.com/minio/minio-go/api-select.go
@@ -1,0 +1,198 @@
+/*
+ * Minio Go Library for Amazon S3 Compatible Cloud Storage
+ * (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minio
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// CSVFileHeaderInfo -
+type CSVFileHeaderInfo string
+
+// Constants for file header info.
+const (
+	CSVFileHeaderInfoNone   CSVFileHeaderInfo = "NONE"
+	CSVFileHeaderInfoIgnore                   = "IGNORE"
+	CSVFileHeaderInfoUse                      = "USE"
+)
+
+// SelectCompressionType -
+type SelectCompressionType string
+
+// Constants for compression types under select API.
+const (
+	SelectCompressionNONE SelectCompressionType = "NONE"
+	SelectCompressionGZIP                       = "GZIP"
+)
+
+// CSVQuoteFields -
+type CSVQuoteFields string
+
+// Constants for csv quote styles.
+const (
+	CSVQuoteFieldsAlways   CSVQuoteFields = "Always"
+	CSVQuoteFieldsAsNeeded                = "AsNeeded"
+)
+
+// QueryExpressionType -
+type QueryExpressionType string
+
+// Constants for expression type.
+const (
+	QueryExpressionTypeSQL QueryExpressionType = "SQL"
+)
+
+// JSONType determines json input serialization type.
+type JSONType string
+
+// Constants for JSONTypes.
+const (
+	JSONDocumentType JSONType = "Document"
+	JSONStreamType            = "Stream"
+	JSONLinesType             = "Lines"
+)
+
+// ObjectSelectRequest - represents the input select body
+type ObjectSelectRequest struct {
+	XMLName            xml.Name `xml:"SelectRequest" json:"-"`
+	Expression         string
+	ExpressionType     QueryExpressionType
+	InputSerialization struct {
+		CompressionType SelectCompressionType
+		CSV             struct {
+			FileHeaderInfo       CSVFileHeaderInfo
+			RecordDelimiter      string
+			FieldDelimiter       string
+			QuoteCharacter       string
+			QuoteEscapeCharacter string
+			Comments             string
+		}
+		JSON struct {
+			Type JSONType
+		}
+	}
+	OutputSerialization struct {
+		CSV struct {
+			QuoteFields          CSVQuoteFields
+			RecordDelimiter      string
+			FieldDelimiter       string
+			QuoteCharacter       string
+			QuoteEscapeCharacter string
+		}
+		JSON struct {
+			RecordDelimiter string
+		}
+	}
+}
+
+// SelectObjectType -
+type SelectObjectType string
+
+// Constants for input data types.
+const (
+	SelectObjectTypeCSV  SelectObjectType = "CSV"
+	SelectObjectTypeJSON                  = "JSON"
+)
+
+// SelectObjectOptions -
+type SelectObjectOptions struct {
+	Type  SelectObjectType
+	Input struct {
+		RecordDelimiter string
+		FieldDelimiter  string
+		Comments        string
+	}
+	Output struct {
+		RecordDelimiter string
+		FieldDelimiter  string
+	}
+}
+
+// ToObjectSelectRequest - generate an object select request statement.
+func (opts SelectObjectOptions) ToObjectSelectRequest(expression string, compressionType SelectCompressionType) *ObjectSelectRequest {
+	osreq := &ObjectSelectRequest{
+		Expression:     expression,
+		ExpressionType: QueryExpressionTypeSQL,
+	}
+	osreq.InputSerialization.CompressionType = compressionType
+	if opts.Type == SelectObjectTypeCSV {
+		osreq.InputSerialization.CSV.FieldDelimiter = opts.Input.FieldDelimiter
+		osreq.InputSerialization.CSV.RecordDelimiter = opts.Input.RecordDelimiter
+		osreq.InputSerialization.CSV.Comments = opts.Input.Comments
+		// Only supports filed and record delimiter for now.
+		osreq.OutputSerialization.CSV.FieldDelimiter = opts.Output.FieldDelimiter
+		osreq.OutputSerialization.CSV.RecordDelimiter = opts.Output.RecordDelimiter
+	} else if opts.Type == SelectObjectTypeJSON {
+		// FIXME: Only supporting JSON document type for now.
+		osreq.InputSerialization.JSON.Type = JSONDocumentType
+		osreq.OutputSerialization.JSON.RecordDelimiter = opts.Output.RecordDelimiter
+	}
+	return osreq
+}
+
+// SelectObjectContent is a implementation of http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html AWS S3 API.
+func (c Client) SelectObjectContent(ctx context.Context, bucketName, objectName, expression string, opts SelectObjectOptions) (io.ReadCloser, error) {
+	objInfo, err := c.statObject(ctx, bucketName, objectName, StatObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var compressionType = SelectCompressionNONE
+	if strings.Contains(objInfo.ContentType, "gzip") {
+		compressionType = SelectCompressionGZIP
+	} else if strings.Contains(objInfo.ContentType, "text/csv") && opts.Type == "" {
+		opts.Type = SelectObjectTypeCSV
+	} else if strings.Contains(objInfo.ContentType, "json") && opts.Type == "" {
+		opts.Type = SelectObjectTypeJSON
+	}
+
+	selectReqBytes, err := xml.Marshal(opts.ToObjectSelectRequest(expression, compressionType))
+	if err != nil {
+		return nil, err
+	}
+
+	urlValues := make(url.Values)
+	urlValues.Set("select", "")
+	urlValues.Set("select-type", "2")
+
+	// Execute POST on bucket/object.
+	resp, err := c.executeMethod(ctx, "POST", requestMetadata{
+		bucketName:       bucketName,
+		objectName:       objectName,
+		queryValues:      urlValues,
+		contentMD5Base64: sumMD5Base64(selectReqBytes),
+		contentSHA256Hex: sum256Hex(selectReqBytes),
+		contentBody:      bytes.NewReader(selectReqBytes),
+		contentLength:    int64(len(selectReqBytes)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, httpRespToErrorResponse(resp, bucketName, "")
+	}
+
+	return resp.Body, nil
+}

--- a/vendor/github.com/minio/minio-go/api.go
+++ b/vendor/github.com/minio/minio-go/api.go
@@ -99,7 +99,7 @@ type Options struct {
 // Global constants.
 const (
 	libraryName    = "minio-go"
-	libraryVersion = "v6.0.5"
+	libraryVersion = "v6.0.6"
 )
 
 // User Agent should always following the below style.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -56,46 +56,46 @@
 			"revisionTime": "2015-10-24T22:24:27-07:00"
 		},
 		{
-			"checksumSHA1": "qmCEhMpDtl8rzdoxAlK9pz/rkek=",
+			"checksumSHA1": "c9BDrWE7dyV2w4mDDuxCHSgfWxE=",
 			"path": "github.com/minio/minio-go",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "Qsj+6JPmJ8R5rFNQSHqRb8xAwOw=",
 			"path": "github.com/minio/minio-go/pkg/credentials",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "Md5pOKYfoKtrG7xNvs2FtiDPfDc=",
 			"path": "github.com/minio/minio-go/pkg/encrypt",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "6D/qMFV+e39L+6aeT+Seq1guohM=",
 			"path": "github.com/minio/minio-go/pkg/policy",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "bbWjcrOQsV57qK+BSsrNAsI+Q/o=",
 			"path": "github.com/minio/minio-go/pkg/s3signer",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "xrJThFwwkVrJdwd5iYFHqfx4wRY=",
 			"path": "github.com/minio/minio-go/pkg/s3utils",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "Wt8ej+rZXTdNBR9Xyw1eGo3Iq5o=",
 			"path": "github.com/minio/minio-go/pkg/set",
-			"revision": "70799fe8dae6ecfb6c7d7e9e048fce27f23a1992",
-			"revisionTime": "2018-07-05T14:57:19Z"
+			"revision": "d68060bdebdee5f58c69a6d821b5b92a9eaf3e96",
+			"revisionTime": "2018-07-09T23:59:01Z"
 		},
 		{
 			"checksumSHA1": "MEC+K9aTG+8tfPjnJ4qj2Y+kc4s=",


### PR DESCRIPTION
MC support for the S3 Select command
Example command: mc select --expression "myQuery" s3/mybucket/my.csv
Does not currently support configurable query options through command line(e.g compression type, no headers ..), only default options are utilized right now
Requires the version of minio-go from this pull request:https://github.com/minio/minio-go/pull/1013