### PR TITLE
Remove error statement in mc mirror

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -590,7 +590,7 @@ func (mj *mirrorJob) mirror(ctx context.Context, cancelMirror context.CancelFunc
 				PathInsufficientPermission, ObjectOnGlacier:
 				errorIf(err, "Unable to perform a mirror action.")
 				continue
-			case deleteNotAllowedErr, overwriteNotAllowedErr:
+			case overwriteNotAllowedErr:
 				errorIf(err, "Unable to perform a mirror action.")
 				continue
 			}

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -178,10 +178,6 @@ func deltaSourceTarget(sourceURL, targetURL string, isFake, isOverwrite, isRemov
 			}
 		case differInSecond:
 			if !isRemove && !isFake {
-				// Object removal not allowed if --remove is not set.
-				URLsCh <- URLs{
-					Error: errDeleteNotAllowed(diffMsg.SecondURL),
-				}
 				continue
 			}
 			URLsCh <- URLs{

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -103,13 +103,6 @@ var errOverWriteNotAllowed = func(URL string) *probe.Error {
 	return probe.NewError(overwriteNotAllowedErr(errors.New(msg)))
 }
 
-type deleteNotAllowedErr error
-
-var errDeleteNotAllowed = func(URL string) *probe.Error {
-	msg := "Delete not allowed for `" + URL + "`. Use `--remove` to override this behavior."
-	return probe.NewError(deleteNotAllowedErr(errors.New(msg)))
-}
-
 type sourceIsDirErr error
 
 var errSourceIsDir = func(URL string) *probe.Error {


### PR DESCRIPTION
mc mirror complains about extra file in destination.
Having extra files is not an error so error statement is removed
Fixes: #2470