### PR TITLE
'mc admin config setkeys' command support changes

### DIFF
--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -82,7 +82,7 @@ func mainAdminConfigGet(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Call get config API
 	c, e := client.GetConfig()

--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -82,7 +82,7 @@ func mainAdminConfigGet(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Call get config API
 	c, e := client.GetConfig()

--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -103,7 +103,7 @@ func mainAdminConfigSet(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Call get config API
 	fatalIf(probe.NewError(client.SetConfig(os.Stdin)), "Cannot set server configuration file.")

--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -103,7 +103,7 @@ func mainAdminConfigSet(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Call get config API
 	fatalIf(probe.NewError(client.SetConfig(os.Stdin)), "Cannot set server configuration file.")

--- a/cmd/admin-config-setkeys.go
+++ b/cmd/admin-config-setkeys.go
@@ -39,7 +39,7 @@ var adminConfigSetKeysCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET
+  {{.HelpName}} TARGET [key1=value1 key2=value2 ...]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
@@ -73,12 +73,11 @@ func (u configSetKeysMessage) String() (msg string) {
 		if s.ErrSet {
 			// An error occurred when setting the new config
 			msg += console.Colorize("SetKeysConfigFailure",
-				fmt.Sprintf("Failed to apply the new configuration to `%s` (%s).", s.Name, s.ErrMsg))
+				fmt.Sprintf("Failed to apply the new configuration to `%s` (%s).\n", s.Name, s.ErrMsg))
 		} else {
 			msg += console.Colorize("SetKeysConfigSuccess",
-				fmt.Sprintf("New configuration applied to `%s` successfully.", s.Name))
+				fmt.Sprintf("New configuration applied to `%s` successfully.\n", s.Name))
 		}
-		msg += "\n"
 	}
 	// Print the general set config status
 	if u.setKeysConfigStatus {
@@ -125,7 +124,7 @@ func mainAdminConfigSetKeys(ctx *cli.Context) error {
 	allArgs := ctx.Args()
 	if len(allArgs) < 2 {
 		fatalIf(probe.NewError(errors.New(
-			"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "1- Invalid number of arguments\n")
+			"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "Invalid number of arguments\n")
 	}
 
 	aliasedURL := allArgs.Get(0)
@@ -134,18 +133,18 @@ func mainAdminConfigSetKeys(ctx *cli.Context) error {
 		argSplit := strings.SplitN(arg, "=", 2)
 		if strings.Index(arg, "{") == -1 && len(argSplit)%2 == 1 {
 			fatalIf(probe.NewError(errors.New(
-				"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "2- Invalid number of arguments\n")
+				"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "Invalid number of arguments\n")
 		}
 		argsMap[argSplit[0]] = argSplit[1]
 	}
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Call set config API
 	c, e := client.SetConfigKeys(argsMap)
-	fatalIf(probe.NewError(e), "Cannot set server configuration file.")
+	fatalIf(probe.NewError(e), "Cannot set server configuration.")
 
 	// Print set config result
 	printMsg(configSetKeysMessage{

--- a/cmd/admin-config-setkeys.go
+++ b/cmd/admin-config-setkeys.go
@@ -127,31 +127,17 @@ func mainAdminConfigSetKeys(ctx *cli.Context) error {
 		fatalIf(probe.NewError(errors.New(
 			"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "1- Invalid number of arguments\n")
 	}
-	fmt.Println("allArgs.Tail: ", allArgs.Tail())
 
 	aliasedURL := allArgs.Get(0)
 	argsMap := make(map[string]string)
-	// args := []string{}
 	for _, arg := range allArgs.Tail() {
-		fmt.Println("arg: ", arg)
-		// argKeyVal := strings.Replace(arg, "=", " ", -1)
-		// args = append(args, strings.Split(arg, "=")[0])
-		// args = append(args, strings.Split(arg, "=")[1])
 		argSplit := strings.SplitN(arg, "=", 2)
-		fmt.Println("argSplit =", argSplit)
-		fmt.Println("Length argSplit =", len(argSplit))
 		if strings.Index(arg, "{") == -1 && len(argSplit)%2 == 1 {
 			fatalIf(probe.NewError(errors.New(
 				"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "2- Invalid number of arguments\n")
 		}
 		argsMap[argSplit[0]] = argSplit[1]
 	}
-	fmt.Println("argsMap: ", argsMap)
-	lenArgs := len(argsMap)
-
-	fmt.Println("lenArgs: ", lenArgs)
-	fmt.Println("aliasedURL: ", aliasedURL)
-	fmt.Println("argsMap: ", argsMap)
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)

--- a/cmd/admin-config-setkeys.go
+++ b/cmd/admin-config-setkeys.go
@@ -1,0 +1,171 @@
+/*
+ * Minio Client (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/console"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio/pkg/madmin"
+)
+
+var adminConfigSetKeysCmd = cli.Command{
+	Name:   "setkeys",
+	Usage:  "Set partial Minio server/cluster configuration parameters using key/value pairs.",
+	Before: setGlobalsFromContext,
+	Action: mainAdminConfigSetKeys,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Set a single Minio server/cluster configuration entry.
+     $ {{.HelpName}} myminio 
+
+  2. Set two Minio server/cluster configuration entries.
+     $ {{.HelpName}} myminio logger.console.enabled=true logger.http.minio_one.enabled=true
+
+  3. Set multiple Minio server/cluster configuration entries.
+     $ {{.HelpName}} myminio logger.http.minio_one='{
+                "enabled": true,
+                "endpoint": "https://one.minio.io/logger/<some-jwt>"
+            }'
+`,
+}
+
+// configSetKeysMessage container to hold locks information.
+type configSetKeysMessage struct {
+	Status                   string `json:"status"`
+	setKeysConfigStatus      bool
+	SetKeysConfigNodeSummary []madmin.NodeSummary `json:"nodesSummary"`
+}
+
+// String colorized service status message.
+func (u configSetKeysMessage) String() (msg string) {
+	// For each node, print if set config was successful or not
+	for _, s := range u.SetKeysConfigNodeSummary {
+		if s.ErrSet {
+			// An error occurred when setting the new config
+			msg += console.Colorize("SetKeysConfigFailure",
+				fmt.Sprintf("Failed to apply the new configuration to `%s` (%s).", s.Name, s.ErrMsg))
+		} else {
+			msg += console.Colorize("SetKeysConfigSuccess",
+				fmt.Sprintf("New configuration applied to `%s` successfully.", s.Name))
+		}
+		msg += "\n"
+	}
+	// Print the general set config status
+	if u.setKeysConfigStatus {
+		msg += console.Colorize("SetKeysConfigSuccess",
+			"Setting new Minio configuration file has been successful.\n")
+	} else {
+		msg += console.Colorize("SetKeysConfigFailure",
+			"Setting new Minio configuration file has failed.\n")
+	}
+	return
+}
+
+// JSON jsonified service status Message message.
+func (u configSetKeysMessage) JSON() string {
+	if u.setKeysConfigStatus {
+		u.Status = "success"
+	} else {
+		u.Status = "error"
+	}
+	statusJSONBytes, e := json.Marshal(u)
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(statusJSONBytes)
+}
+
+// checkAdminConfigSetKeysSyntax - validate all the passed arguments
+func checkAdminConfigSetKeysSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 {
+		cli.ShowCommandHelpAndExit(ctx, "set", 1) // last argument is exit code
+	}
+}
+
+// main config setkeys function
+func mainAdminConfigSetKeys(ctx *cli.Context) error {
+
+	// Check command arguments
+	checkAdminConfigSetKeysSyntax(ctx)
+
+	// Set color preference of command outputs
+	console.SetColor("SetKeysConfigSuccess", color.New(color.FgGreen, color.Bold))
+	console.SetColor("SetKeysConfigFailure", color.New(color.FgRed, color.Bold))
+
+	// Get the alias parameter from cli
+	allArgs := ctx.Args()
+	if len(allArgs) < 2 {
+		fatalIf(probe.NewError(errors.New(
+			"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "1- Invalid number of arguments\n")
+	}
+	fmt.Println("allArgs.Tail: ", allArgs.Tail())
+
+	aliasedURL := allArgs.Get(0)
+	argsMap := make(map[string]string)
+	// args := []string{}
+	for _, arg := range allArgs.Tail() {
+		fmt.Println("arg: ", arg)
+		// argKeyVal := strings.Replace(arg, "=", " ", -1)
+		// args = append(args, strings.Split(arg, "=")[0])
+		// args = append(args, strings.Split(arg, "=")[1])
+		argSplit := strings.SplitN(arg, "=", 2)
+		fmt.Println("argSplit =", argSplit)
+		fmt.Println("Length argSplit =", len(argSplit))
+		if strings.Index(arg, "{") == -1 && len(argSplit)%2 == 1 {
+			fatalIf(probe.NewError(errors.New(
+				"Usage: mc admin config setkeys alias key1=value1 [key2=value2 key3.key4=value4 ...]")), "2- Invalid number of arguments\n")
+		}
+		argsMap[argSplit[0]] = argSplit[1]
+	}
+	fmt.Println("argsMap: ", argsMap)
+	lenArgs := len(argsMap)
+
+	fmt.Println("lenArgs: ", lenArgs)
+	fmt.Println("aliasedURL: ", aliasedURL)
+	fmt.Println("argsMap: ", argsMap)
+
+	// Create a new Minio Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Cannot get a configured admin connection.")
+
+	// Call get config API
+	c, e := client.SetConfigKeys(argsMap)
+	fatalIf(probe.NewError(e), "Cannot set server configuration file.")
+
+	// Print set config result
+	printMsg(configSetKeysMessage{
+		setKeysConfigStatus:      c.Status,
+		SetKeysConfigNodeSummary: c.NodeResults,
+	})
+
+	return nil
+}

--- a/cmd/admin-config-setkeys.go
+++ b/cmd/admin-config-setkeys.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * Minio Client (C) 2018 Minio, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Set a single Minio server/cluster configuration entry.
-     $ {{.HelpName}} myminio 
+     $ {{.HelpName}} myminio region=us-east-1
 
   2. Set two Minio server/cluster configuration entries.
      $ {{.HelpName}} myminio logger.console.enabled=true logger.http.minio_one.enabled=true
@@ -107,7 +107,7 @@ func (u configSetKeysMessage) JSON() string {
 // checkAdminConfigSetKeysSyntax - validate all the passed arguments
 func checkAdminConfigSetKeysSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) == 0 {
-		cli.ShowCommandHelpAndExit(ctx, "set", 1) // last argument is exit code
+		cli.ShowCommandHelpAndExit(ctx, "setkeys", 1) // last argument is exit code
 	}
 }
 
@@ -141,9 +141,9 @@ func mainAdminConfigSetKeys(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
-	// Call get config API
+	// Call set config API
 	c, e := client.SetConfigKeys(argsMap)
 	fatalIf(probe.NewError(e), "Cannot set server configuration file.")
 

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -16,7 +16,9 @@
 
 package cmd
 
-import "github.com/minio/cli"
+import (
+	"github.com/minio/cli"
+)
 
 var adminConfigCmd = cli.Command{
 	Name:   "config",

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -27,6 +27,7 @@ var adminConfigCmd = cli.Command{
 	Subcommands: []cli.Command{
 		adminConfigGetCmd,
 		adminConfigSetCmd,
+		adminConfigSetKeysCmd,
 	},
 	HideHelpCommand: true,
 }
@@ -35,5 +36,5 @@ var adminConfigCmd = cli.Command{
 func mainAdminConfig(ctx *cli.Context) error {
 	cli.ShowCommandHelp(ctx, ctx.Args().First())
 	return nil
-	// Sub-commands like "get", "set" have their own main.
+	// Sub-commands like "get", "set", "setkeys" have their own main.
 }

--- a/cmd/admin-credentials.go
+++ b/cmd/admin-credentials.go
@@ -71,7 +71,7 @@ func mainAdminCreds(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Change the credentials of the specified Minio server
 	e := client.SetCredentials(accessKey, secretKey)

--- a/cmd/admin-credentials.go
+++ b/cmd/admin-credentials.go
@@ -71,7 +71,7 @@ func mainAdminCreds(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Change the credentials of the specified Minio server
 	e := client.SetCredentials(accessKey, secretKey)

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -197,7 +197,7 @@ func mainAdminInfo(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Fetch info of all servers (cluster or single server)
 	serversInfo, e := client.ServerInfo()

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -197,7 +197,7 @@ func mainAdminInfo(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Fetch info of all servers (cluster or single server)
 	serversInfo, e := client.ServerInfo()

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -16,7 +16,9 @@
 
 package cmd
 
-import "github.com/minio/cli"
+import (
+	"github.com/minio/cli"
+)
 
 var (
 	adminFlags = []cli.Flag{}

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -87,7 +87,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Restart the specified Minio server
 	fatalIf(probe.NewError(client.ServiceSendAction(

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -87,7 +87,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Restart the specified Minio server
 	fatalIf(probe.NewError(client.ServiceSendAction(

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -109,7 +109,7 @@ func mainAdminServiceStatus(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Fetch the service status of the specified Minio server
 	st, e := client.ServiceStatus()

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -109,7 +109,7 @@ func mainAdminServiceStatus(ctx *cli.Context) error {
 
 	// Create a new Minio Admin Client
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Fetch the service status of the specified Minio server
 	st, e := client.ServiceStatus()

--- a/cmd/admin-service-stop.go
+++ b/cmd/admin-service-stop.go
@@ -87,7 +87,7 @@ func mainAdminServiceStop(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin client.")
+	fatalIf(err, errFailedAdminClient.Error())
 
 	// Stop the specified Minio server
 	pErr := client.ServiceSendAction(madmin.ServiceActionValueStop)

--- a/cmd/admin-service-stop.go
+++ b/cmd/admin-service-stop.go
@@ -87,7 +87,7 @@ func mainAdminServiceStop(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Cannot get a configured admin connection.")
+	fatalIf(err, "Cannot get a configured admin client.")
 
 	// Stop the specified Minio server
 	pErr := client.ServiceSendAction(madmin.ServiceActionValueStop)

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -18,12 +18,16 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/mc/pkg/probe"
 )
+
+// Commoon error messages
+var errFailedAdminClient = errors.New("Cannot get a configured admin client.")
 
 // causeMessage container for golang error messages
 type causeMessage struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,7 +15,6 @@
 			"revisionTime": "2018-06-22T17:58:04Z"
 		},
 		{
-<<<<<<< HEAD
 			"checksumSHA1": "mKIXx1kDwmVmdIpZ3pJtRBuUKso=",
 			"path": "github.com/coreos/etcd/pkg/pathutil",
 			"revision": "8f6348a97d483316c5039d6bbc2f66ba2c00e1d0",
@@ -46,8 +45,6 @@
 			"revisionTime": "2018-01-08T23:09:05Z"
 		},
 		{
-=======
->>>>>>> Adds missing dependencies
 			"path": "github.com/dustin/go-humanize",
 			"revision": "1c212aae1d02984808182b98b0da7a3e07e4c770",
 			"revisionTime": "2015-08-09T13:14:05-07:00"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -217,7 +217,6 @@
 			"revisionTime": "2018-06-21T18:09:58Z"
 		},
 		{
-<<<<<<< HEAD
 			"checksumSHA1": "Tk+aXpWRuTQhURlO79bd7YogcU0=",
 			"path": "github.com/tidwall/match",
 			"revision": "1731857f09b1f38450e2c12409748407822dc6be",
@@ -230,8 +229,6 @@
 			"revisionTime": "2018-06-28T10:27:55Z"
 		},
 		{
-=======
->>>>>>> Adds missing dependencies
 			"checksumSHA1": "a25Kbna+fLQPeKt0z+hcreYzXdU=",
 			"path": "golang.org/x/crypto/argon2",
 			"revision": "182114d582623c1caa54f73de9c7224e23a48487",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,6 +15,7 @@
 			"revisionTime": "2018-06-22T17:58:04Z"
 		},
 		{
+<<<<<<< HEAD
 			"checksumSHA1": "mKIXx1kDwmVmdIpZ3pJtRBuUKso=",
 			"path": "github.com/coreos/etcd/pkg/pathutil",
 			"revision": "8f6348a97d483316c5039d6bbc2f66ba2c00e1d0",
@@ -45,6 +46,8 @@
 			"revisionTime": "2018-01-08T23:09:05Z"
 		},
 		{
+=======
+>>>>>>> Adds missing dependencies
 			"path": "github.com/dustin/go-humanize",
 			"revision": "1c212aae1d02984808182b98b0da7a3e07e4c770",
 			"revisionTime": "2015-08-09T13:14:05-07:00"
@@ -217,6 +220,7 @@
 			"revisionTime": "2018-06-21T18:09:58Z"
 		},
 		{
+<<<<<<< HEAD
 			"checksumSHA1": "Tk+aXpWRuTQhURlO79bd7YogcU0=",
 			"path": "github.com/tidwall/match",
 			"revision": "1731857f09b1f38450e2c12409748407822dc6be",
@@ -229,6 +233,8 @@
 			"revisionTime": "2018-06-28T10:27:55Z"
 		},
 		{
+=======
+>>>>>>> Adds missing dependencies
 			"checksumSHA1": "a25Kbna+fLQPeKt0z+hcreYzXdU=",
 			"path": "golang.org/x/crypto/argon2",
 			"revision": "182114d582623c1caa54f73de9c7224e23a48487",


### PR DESCRIPTION
Fixes #2509 
This PR, `mc admin config setkeys` command support changes, will work together with minio server side PR minio/minio#6113. So, they have to be considered together since most of the input validation code is on the minio server side.