### PR TITLE
Fix cp crash when resuming from session

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -338,9 +338,19 @@ func doCopySession(session *sessionV8) error {
 					gracefulStop()
 					return
 				}
+
+				if e := urlScanner.Err(); e != nil {
+					// Error while reading. quit immediately
+					gracefulStop()
+					return
+				}
+
 				var cpURLs URLs
 				// Unmarshal copyURLs from each line.
-				json.Unmarshal([]byte(urlScanner.Text()), &cpURLs)
+				if e := json.Unmarshal([]byte(urlScanner.Text()), &cpURLs); e != nil {
+					errorIf(probe.NewError(e), "Unable to unmarshal %s", urlScanner.Text())
+					continue
+				}
 
 				// Save total count.
 				cpURLs.TotalCount = session.Header.TotalObjects


### PR DESCRIPTION
We should make sure to handle errors properly
when reading from the session and also parsing.

Current master ignores all these situations
which leads to crash, this PR handles this to avoid
nil pointer crashes.