### PR TITLE
Change --insecure flag to --self-signed

### DIFF
--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -72,7 +72,7 @@ func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 
 			// Keep TLS config.
 			tlsConfig := &tls.Config{RootCAs: globalRootCAs}
-			if config.Insecure {
+			if config.SelfSigned {
 				tlsConfig.InsecureSkipVerify = true
 			}
 

--- a/cmd/client-s3-trace_v2.go
+++ b/cmd/client-s3-trace_v2.go
@@ -71,7 +71,7 @@ func (t traceV2) Response(resp *http.Response) (err error) {
 		console.Debug(string(respTrace))
 	}
 
-	if globalInsecure && resp.TLS != nil {
+	if globalSelfSigned && resp.TLS != nil {
 		dumpTLSCertificates(resp.TLS)
 	}
 

--- a/cmd/client-s3-trace_v4.go
+++ b/cmd/client-s3-trace_v4.go
@@ -80,7 +80,7 @@ func (t traceV4) Response(resp *http.Response) (err error) {
 		console.Debug(string(respTrace))
 	}
 
-	if globalInsecure && resp.TLS != nil {
+	if globalSelfSigned && resp.TLS != nil {
 		dumpTLSCertificates(resp.TLS)
 	}
 

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -136,7 +136,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 
 			// Keep TLS config.
 			tlsConfig := &tls.Config{RootCAs: globalRootCAs}
-			if config.Insecure {
+			if config.SelfSigned {
 				tlsConfig.InsecureSkipVerify = true
 			}
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -98,6 +98,6 @@ type Config struct {
 	AppVersion  string
 	AppComments []string
 	Debug       bool
-	Insecure    bool
+	SelfSigned  bool
 	Lookup      minio.BucketLookupType
 }

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -156,11 +156,11 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 	// Test s3 connection for API auto probe
 	s3Config := &Config{
 		// S3 connection parameters
-		Insecure:  globalInsecure,
-		AccessKey: accessKey,
-		SecretKey: secretKey,
-		Signature: "s3v4",
-		HostURL:   urlJoinPath(url, probeBucketName),
+		SelfSigned: globalSelfSigned,
+		AccessKey:  accessKey,
+		SecretKey:  secretKey,
+		Signature:  "s3v4",
+		HostURL:    urlJoinPath(url, probeBucketName),
 	}
 
 	s3Client, err := s3New(s3Config)

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -205,7 +205,7 @@ func doCopyFake(cpURLs URLs, pg Progress) URLs {
 }
 
 // doPrepareCopyURLs scans the source URL and prepares a list of objects for copying.
-func doPrepareCopyURLs(session *sessionV8, trapCh <-chan bool, cancelCopy context.CancelFunc) {
+func doPrepareCopyURLs(session *sessionV9, trapCh <-chan bool, cancelCopy context.CancelFunc) {
 	// Separate source and target. 'cp' can take only one target,
 	// but any number of sources.
 	sourceURLs := session.Header.CommandArgs[:len(session.Header.CommandArgs)-1]
@@ -290,7 +290,7 @@ func doPrepareCopyURLs(session *sessionV8, trapCh <-chan bool, cancelCopy contex
 	session.Save()
 }
 
-func doCopySession(session *sessionV8) error {
+func doCopySession(session *sessionV9) error {
 	trapCh := signalTrap(os.Interrupt, syscall.SIGTERM, syscall.SIGKILL)
 
 	ctx, cancelCopy := context.WithCancel(context.Background())
@@ -458,7 +458,7 @@ func mainCopy(ctx *cli.Context) error {
 		sseKeys = key
 	}
 
-	session := newSessionV8()
+	session := newSessionV9()
 	session.Header.CommandType = "cp"
 	session.Header.CommandBoolFlags["recursive"] = recursive
 	session.Header.CommandIntFlags["older-than"] = olderThan

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -52,6 +52,10 @@ var globalFlags = []cli.Flag{
 	},
 	cli.BoolFlag{
 		Name:  "insecure",
+		Usage: " (deprecated) Use self-signed instead",
+	},
+	cli.BoolFlag{
+		Name:  "self-signed",
 		Usage: "Disable SSL certificate verification.",
 	},
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -41,7 +41,7 @@ const (
 	// session config and shared urls related constants
 	globalSessionDir           = "session"
 	globalSharedURLsDataDir    = "share"
-	globalSessionConfigVersion = "8"
+	globalSessionConfigVersion = "9"
 
 	// Profile directory for dumping profiler outputs.
 	globalProfileDir = "profile"
@@ -51,11 +51,11 @@ const (
 )
 
 var (
-	globalQuiet    = false // Quiet flag set via command line
-	globalJSON     = false // Json flag set via command line
-	globalDebug    = false // Debug flag set via command line
-	globalNoColor  = false // No Color flag set via command line
-	globalInsecure = false // Insecure flag set via command line
+	globalQuiet      = false // Quiet flag set via command line
+	globalJSON       = false // Json flag set via command line
+	globalDebug      = false // Debug flag set via command line
+	globalNoColor    = false // No Color flag set via command line
+	globalSelfSigned = false // globalSelfSigned flag set via command line
 
 	// WHEN YOU ADD NEXT GLOBAL FLAG, MAKE SURE TO ALSO UPDATE SESSION CODE AND CODE BELOW.
 )
@@ -69,12 +69,12 @@ var (
 )
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
-func setGlobals(quiet, debug, json, noColor, insecure bool) {
+func setGlobals(quiet, debug, json, noColor, selfSigned bool) {
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
 	globalJSON = globalJSON || json
 	globalNoColor = globalNoColor || noColor
-	globalInsecure = globalInsecure || insecure
+	globalSelfSigned = globalSelfSigned || selfSigned
 
 	// Enable debug messages if requested.
 	if globalDebug {
@@ -93,7 +93,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	debug := ctx.IsSet("debug")
 	json := ctx.IsSet("json")
 	noColor := ctx.IsSet("no-color")
-	insecure := ctx.IsSet("insecure")
-	setGlobals(quiet, debug, json, noColor, insecure)
+	selfSigned := ctx.IsSet("insecure") || ctx.IsSet("self-signed")
+	setGlobals(quiet, debug, json, noColor, selfSigned)
 	return nil
 }

--- a/cmd/session-clear.go
+++ b/cmd/session-clear.go
@@ -90,7 +90,7 @@ func (c clearSessionMessage) JSON() string {
 
 // forceClear - Remove a saved session.
 // Used if --force flag is applied.
-func forceClear(sid string, session *sessionV8) {
+func forceClear(sid string, session *sessionV9) {
 	if session != nil {
 		if err := session.Delete().Trace(sid); err == nil {
 			// Force unnecesseray removal successful.
@@ -113,7 +113,7 @@ func clearSession(sid string, isForce bool) {
 		toRemove = append(toRemove, sid)
 	}
 	for _, sid := range toRemove {
-		session, err := loadSessionV8(sid)
+		session, err := loadSessionV9(sid)
 		if !isForce {
 			fatalIf(err.Trace(sid), "Unable to load session `"+sid+"`. Use --force flag to remove obsolete session files.")
 

--- a/cmd/session-list.go
+++ b/cmd/session-list.go
@@ -48,9 +48,9 @@ EXAMPLES:
 
 // listSessions list all current sessions.
 func listSessions() *probe.Error {
-	var bySessions []*sessionV8
+	var bySessions []*sessionV9
 	for _, sid := range getSessionIDs() {
-		session, err := loadSessionV8(sid)
+		session, err := loadSessionV9(sid)
 		if err != nil {
 			continue // Skip 'broken' session during listing
 		}

--- a/cmd/session-resume.go
+++ b/cmd/session-resume.go
@@ -53,14 +53,14 @@ EXAMPLES:
 }
 
 // bySessionWhen is a type for sorting session metadata by time.
-type bySessionWhen []*sessionV8
+type bySessionWhen []*sessionV9
 
 func (b bySessionWhen) Len() int           { return len(b) }
 func (b bySessionWhen) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b bySessionWhen) Less(i, j int) bool { return b[i].Header.When.Before(b[j].Header.When) }
 
 // sessionExecute - run a given session.
-func sessionExecute(s *sessionV8) {
+func sessionExecute(s *sessionV9) {
 	switch s.Header.CommandType {
 	case "cp":
 		doCopySession(s)
@@ -122,7 +122,7 @@ func mainSessionResume(ctx *cli.Context) error {
 
 // resumeSession - Resumes a session specified by sessionID.
 func resumeSession(sessionID string) {
-	s, err := loadSessionV8(sessionID)
+	s, err := loadSessionV9(sessionID)
 	fatalIf(err.Trace(sessionID), "Unable to load session.")
 	// Restore the state of global variables from this previous session.
 	s.restoreGlobals()

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -34,6 +34,9 @@ func migrateSession() {
 
 	// Migrate V7 to V8
 	migrateSessionV7ToV8()
+
+	// Migrate V8 to V9
+	migrateSessionV8ToV9()
 }
 
 // createSessionDir - create session directory.

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -35,7 +35,7 @@ func (s *TestSuite) TestSession(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(isSessionDirExists(), Equals, true)
 
-	session := newSessionV8()
+	session := newSessionV9()
 	c.Assert(session.Header.CommandArgs, IsNil)
 	c.Assert(len(session.SessionID), Equals, 8)
 	_, e := os.Stat(session.DataFP.Name())
@@ -45,7 +45,7 @@ func (s *TestSuite) TestSession(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(isSessionExists(session.SessionID), Equals, true)
 
-	savedSession, err := loadSessionV8(session.SessionID)
+	savedSession, err := loadSessionV9(session.SessionID)
 	c.Assert(err, IsNil)
 	c.Assert(session.SessionID, Equals, savedSession.SessionID)
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -134,7 +134,7 @@ func newS3Config(urlStr string, hostCfg *hostConfigV9) *Config {
 	s3Config.AppVersion = Version
 	s3Config.AppComments = []string{os.Args[0], runtime.GOOS, runtime.GOARCH}
 	s3Config.Debug = globalDebug
-	s3Config.Insecure = globalInsecure
+	s3Config.SelfSigned = globalSelfSigned
 
 	s3Config.HostURL = urlStr
 	if hostCfg != nil {

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -203,7 +203,7 @@ Quiet option suppress chatty console output.
 ### Option [--config-folder]
 Use this option to set a custom config path.
 
-### Option [ --insecure]
+### Option [ --self-signed]
 Skip SSL certificate verification.
 
 ## 7. Commands

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -238,7 +238,7 @@ Quiet option suppress chatty console output.
 ### Option [--config-folder]
 Use this option to set a custom config path.
 
-### Option [ --insecure]
+### Option [ --self-signed]
 Skip SSL certificate verification.
 
 ## 7. Commands

--- a/docs/zh_CN/minio-client-complete-guide.md
+++ b/docs/zh_CN/minio-client-complete-guide.md
@@ -227,7 +227,7 @@ mc --json ls play
 ### 参数 [--config-folder]
 这个参数参数自定义的配置文件路径。
 
-### 参数 [ --insecure]
+### 参数 [ --self-signed]
 跳过SSL证书验证。
 
 ## 7. 命令


### PR DESCRIPTION
Will still support `--insecure` as a legacy option. And continue supporting `--self-signed` from now

<b>Tests</b> - Both `./mc admin --self-signed info play` and `./mc admin --insecure info play` will work

Fixes #2542