### PR TITLE
Disallow copying/mirroring a folder into itself

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -272,3 +272,20 @@ func getSSEKey(resource string, encKeys []prefixSSEPair) string {
 	}
 	return ""
 }
+
+// Return true if target url is a part of a source url such as:
+// alias/bucket/ and alias/bucket/dir/, however
+func isURLContains(srcURL, tgtURL, sep string) bool {
+	// Add a separator to source url if not found
+	if !strings.HasSuffix(srcURL, sep) {
+		srcURL += sep
+	}
+	if !strings.HasSuffix(tgtURL, sep) {
+		tgtURL += sep
+	}
+	// Check if we are going to copy a directory into itself
+	if strings.HasPrefix(tgtURL, srcURL) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
As unix cp command complains when you copy a directory into itself,
(such as `cp -r ~/Desktop/ ~/Desktop/sub/`), mc will follow the
same behavior with this commit.

The main reason is that copy or mirror command can be unpredictable
with this style of copy.

Example:

```

$ mc ls -r myminio/testbucket/
[2018-09-25 19:28:17 CET]     8B dir/object
[2018-09-25 19:28:40 CET]     8B object

$ mc -q cp -r myminio/testbucket/ myminio/testbucket/dir/
`myminio/testbucket/dir/object` -> `myminio/testbucket/dir/dir/object`
`myminio/testbucket/object` -> `myminio/testbucket/dir/object`

```

We can notice that `myminio/testbucket/dir/object` is both source and target
in the copy operation. The last copy operation that will occur will rule the
result of the total copy operation and `myminio/testbucket/dir/dir/object`
will have a different content in each copy operation.

Due to the unpredictability mentionned above, we will disallow copying or
mirroring a folder into itself.


Fixes #6519