### PR TITLE
Ignore errors during mirror

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -290,9 +290,11 @@ func (mj *mirrorJob) startStatus() {
 				// Print in new line and adjust to top so that we
 				// don't print over the ongoing progress bar.
 				if sURLs.SourceContent != nil {
-					errorIf(sURLs.Error.Trace(sURLs.SourceContent.URL.String()),
-						fmt.Sprintf("Failed to copy `%s`.", sURLs.SourceContent.URL.String()))
-					os.Exit(1)
+					if !isErrIgnored(sURLs.Error) {
+						errorIf(sURLs.Error.Trace(sURLs.SourceContent.URL.String()),
+							fmt.Sprintf("Failed to copy `%s`.", sURLs.SourceContent.URL.String()))
+						os.Exit(1)
+					}
 				} else {
 					// When sURLs.SourceContent is nil, we know that we have an error related to removing
 					errorIf(sURLs.Error.Trace(sURLs.TargetContent.URL.String()),


### PR DESCRIPTION
S3 lists 1000 objects in batches, but once this batch is being
processed to be copied over there is no way to lock across the
entire batch for mirroring. Due to this we introduce a scenario
when objects might have been deleted in parallel from another
application.

In such a scenario simply ignore such objects and proceed to
copy other files.

Fixes #2537