### PR TITLE
Add Region in config.json file (#2570)

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -128,7 +128,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			options := minio.Options{
 				Creds:        creds,
 				Secure:       useTLS,
-				Region:       "",
+				Region:       config.Region,
 				BucketLookup: config.Lookup,
 			}
 			api, e = minio.NewWithOptions(hostName, &options)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -96,6 +96,7 @@ type Config struct {
 	AccessKey   string
 	SecretKey   string
 	Signature   string
+	Region      string
 	HostURL     string
 	AppName     string
 	AppVersion  string

--- a/cmd/config-v9.go
+++ b/cmd/config-v9.go
@@ -42,6 +42,7 @@ type hostConfigV9 struct {
 	SecretKey string `json:"secretKey"`
 	API       string `json:"api"`
 	Lookup    string `json:"lookup"`
+	Region    string `json:"region"`
 }
 
 // configV8 config version.

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -29,8 +29,8 @@ var (
 	mbFlags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "region",
-			Value: "us-east-1",
-			Usage: "Specify bucket region. Defaults to `us-east-1`.",
+			Value: "",
+			Usage: "Specify bucket region. Default is in configuration file.",
 		},
 		cli.BoolFlag{
 			Name:  "ignore-existing, p",

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -143,6 +143,7 @@ func newS3Config(urlStr string, hostCfg *hostConfigV9) *Config {
 		s3Config.Signature = hostCfg.API
 	}
 	s3Config.Lookup = getLookupType(hostCfg.Lookup)
+	s3Config.Region = hostCfg.Region
 	return s3Config
 }
 


### PR DESCRIPTION
If not set in config.json, default is still `us-east-1`.