### PR TITLE
Fix: Remove local file during a mirror operation

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -230,7 +230,7 @@ func (mj *mirrorJob) doRemove(sURLs URLs) URLs {
 	targetWithAlias := filepath.Join(sURLs.TargetAlias, sURLs.TargetContent.URL.Path)
 
 	// Remove extraneous file/bucket on target.
-	err := probe.NewError(removeRecursive(targetWithAlias, isIncomplete, mj.isFake, 0, 0, sURLs.encKeyDB))
+	err := probe.NewError(removeSingle(targetWithAlias, isIncomplete, mj.isFake, 0, 0, sURLs.encKeyDB))
 	return sURLs.WithError(err)
 }
 


### PR DESCRIPTION
When a local file system is mirroring an S3 server, deleting a file on S3 caused a failure to delete the same file on the local file system.

Previously we were using `removeRecursive`. Fixing it to use `removeSingle`.

Fixes #2586