### PR TITLE
Update hint message of `user add`'s usage

### DIFF
--- a/cmd/admin-users-add.go
+++ b/cmd/admin-users-add.go
@@ -35,7 +35,7 @@ var adminUsersAddCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET USERNAME PASSWORD POLICYNAME
+  {{.HelpName}} TARGET ACCESSKEY SECRETKEY POLICYNAME
 
 POLICYNAME:
   Name of the canned policy created on Minio server.


### PR DESCRIPTION
Since `ACCESSKEY/SECRETKEY` is a common knowledge for S3 user,
so we should make to clear to avoid confusing people.