### PR TITLE
Close readers returned by Client.Get

### DIFF
--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -140,7 +140,7 @@ func checkCatSyntax(ctx *cli.Context) {
 
 // catURL displays contents of a URL to stdout.
 func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error {
-	var reader io.Reader
+	var reader io.ReadCloser
 	size := int64(-1)
 	switch sourceURL {
 	case "-":
@@ -159,6 +159,7 @@ func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error 
 		if reader, err = getSourceStreamFromURL(sourceURL, encKeyDB); err != nil {
 			return err.Trace(sourceURL)
 		}
+		defer reader.Close()
 	}
 	return catOut(reader, size).Trace(sourceURL)
 }

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -422,7 +422,7 @@ func (f *fsClient) Copy(source string, size int64, progress io.Reader, srcSSEKey
 }
 
 // get - get wrapper returning object reader.
-func (f *fsClient) get() (io.Reader, *probe.Error) {
+func (f *fsClient) get() (io.ReadCloser, *probe.Error) {
 	tmppath := f.PathURL.Path
 	// Golang strips trailing / if you clean(..) or
 	// EvalSymlinks(..). Adding '.' prevents it from doing so.
@@ -445,7 +445,7 @@ func (f *fsClient) get() (io.Reader, *probe.Error) {
 }
 
 // Get returns reader and any additional metadata.
-func (f *fsClient) Get(sseKey string) (io.Reader, *probe.Error) {
+func (f *fsClient) Get(sseKey string) (io.ReadCloser, *probe.Error) {
 	return f.get()
 }
 

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -572,7 +572,7 @@ func (c *s3Client) Watch(params watchParams) (*watchObject, *probe.Error) {
 }
 
 // Get - get object with metadata.
-func (c *s3Client) Get(sseKey string) (io.Reader, *probe.Error) {
+func (c *s3Client) Get(sseKey string) (io.ReadCloser, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	var opts minio.GetObjectOptions
 	if sseKey != "" {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -62,7 +62,7 @@ type Client interface {
 	Select(expression string, sseKey string) (io.ReadCloser, *probe.Error)
 
 	// I/O operations with metadata.
-	Get(sseKey string) (reader io.Reader, err *probe.Error)
+	Get(sseKey string) (reader io.ReadCloser, err *probe.Error)
 	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sseKey string) (n int64, err *probe.Error)
 
 	// I/O operations with expiration

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -83,7 +83,7 @@ func isAliasURLDir(aliasURL string, keys map[string][]prefixSSEPair) bool {
 }
 
 // getSourceStreamFromURL gets a reader from URL.
-func getSourceStreamFromURL(urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.Reader, err *probe.Error) {
+func getSourceStreamFromURL(urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.ReadCloser, err *probe.Error) {
 	alias, urlStrFull, _, err := expandAlias(urlStr)
 	if err != nil {
 		return nil, err.Trace(urlStr)
@@ -94,7 +94,7 @@ func getSourceStreamFromURL(urlStr string, encKeyDB map[string][]prefixSSEPair) 
 }
 
 // getSourceStream gets a reader from URL.
-func getSourceStream(alias string, urlStr string, fetchStat bool, sseKey string) (reader io.Reader, metadata map[string]string, err *probe.Error) {
+func getSourceStream(alias string, urlStr string, fetchStat bool, sseKey string) (reader io.ReadCloser, metadata map[string]string, err *probe.Error) {
 	sourceClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
@@ -180,6 +180,7 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader)
 		if err != nil {
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}
+		defer reader.Close()
 		// Get metadata from target content as well
 		if urls.TargetContent.Metadata != nil {
 			for k, v := range urls.TargetContent.Metadata {


### PR DESCRIPTION
When running `mc mirror --watch` over long periods of time I observed crashes with the message:
```
fatal error: runtime: out of memory
```

The stack trace revealed 324,798 goroutines similar to:
```
goroutine 1771 [select, 1008 minutes]:
github.com/minio/mc/vendor/github.com/minio/minio-go.Client.getObjectWithContext.func1(0xc4205bf380, 0xc4205bf3e0, 0xc4205bf440, 0xc4201b41f0, 0xc4205f1ec0, 0xc4204252c0, 0xca4420, 0xc4200240b8, 0xc4202f9e6a, 0x8, ...)
        /q/.q/sources/gopath/src/github.com/minio/mc/vendor/github.com/minio/minio-go/api-get-object.go:69 +0x172
created by github.com/minio/mc/vendor/github.com/minio/minio-go.Client.getObjectWithContext
        /q/.q/sources/gopath/src/github.com/minio/mc/vendor/github.com/minio/minio-go/api-get-object.go:60 +0x2c7
```

Upon review the `mc` code I found that the reader returned from `Client.Get` was not closed. Since the source of my mirror is a minio server, the `*Object` returned by `Client.GetObject` was not being closed causing the goroutine it starts to leak.

I imagine this could also be a problem for folks who are mirroring from a filesystem, but since `*os.File`s have a finalizer attached it's less likely to hit them. (Though finalizers are not guaranteed to run and opening many files between GCs could still cause a program to hit it's FD limit.)

I've modified `Client.Get` to return an `io.ReadCloser` instead of an `io.Reader` and deferred the closes at appropriate points. I've run these changes in my environment and the memory is stable rather than growing unbounded as I previously observed.

This sort of issue is a bit tricky to test for, but I could look into adding one of the leak test libraries if you'd like.