### PR TITLE
Ignore broken symlink durring mirror

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -663,7 +663,8 @@ func (f *fsClient) listInRoutine(contentCh chan<- *clientContent) {
 		for _, file := range files {
 			fi := file
 			if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-				fi, e = os.Stat(filepath.Join(fpath, fi.Name()))
+				fp := filepath.Join(fpath, fi.Name())
+				fi, e = os.Stat(fp)
 				if os.IsPermission(e) {
 					contentCh <- &clientContent{
 						Err: probe.NewError(PathInsufficientPermission{Path: pathURL.Path}),
@@ -671,8 +672,12 @@ func (f *fsClient) listInRoutine(contentCh chan<- *clientContent) {
 					continue
 				}
 				if os.IsNotExist(e) {
+					// Lstat makes no attempt to follow the broken link.
+					_, e = os.Lstat(fp)
 					contentCh <- &clientContent{
-						Err: probe.NewError(BrokenSymlink{Path: file.Name()}),
+						URL:  pathURL,
+						Size: -1,
+						Err:  probe.NewError(e),
 					}
 					continue
 				}
@@ -849,10 +854,13 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan *clientContent) {
 					}
 					return nil
 				}
-				// Ignore in-accessible broken symlinks.
 				if os.IsNotExist(e) {
+					// Lstat makes no attempt to follow the broken link.
+					_, e = os.Lstat(fp)
 					contentCh <- &clientContent{
-						Err: probe.NewError(BrokenSymlink{Path: fp}),
+						URL:  *newClientURL(fp),
+						Size: -1,
+						Err:  probe.NewError(e),
 					}
 					return nil
 				}


### PR DESCRIPTION
The mirror action should fallback on errors and continue mirroring other non-infected objects rather failing on the first catch.

Fixes #2604 
