### PR TITLE
 OlderThan & NewerThan configured for Days, Hours and Minutes

### DIFF
--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -57,13 +57,13 @@ func TestMatchFind(t *testing.T) {
 			clnt: &s3Client{
 				targetURL: &clientURL{},
 			},
-			olderThan: time.Unix(12000, 0).UTC(),
+			olderThan: "1d",
 		},
 		&findContext{
 			clnt: &s3Client{
 				targetURL: &clientURL{},
 			},
-			newerThan: time.Unix(12000, 0).UTC(),
+			newerThan: "32000d",
 		},
 		&findContext{
 			clnt: &s3Client{
@@ -333,57 +333,6 @@ func TestFindMatch(t *testing.T) {
 				t.Fatalf("Unexpected result %t, with pattern %s, flag %s and filepath %s \n",
 					!test.match, test.pattern, test.flagName, test.filePath)
 			}
-		}
-	}
-}
-
-// Tests for parsing time layout.
-func TestParseTime(t *testing.T) {
-	testCases := []struct {
-		value   string
-		success bool
-	}{
-		// Parses 1 day successfully.
-		{
-			value:   "1d",
-			success: true,
-		},
-		// Parses 1 week successfully.
-		{
-			value:   "1w",
-			success: true,
-		},
-		// Parses 1 year successfully.
-		{
-			value:   "1y",
-			success: true,
-		},
-		// Parses 2 months successfully.
-		{
-			value:   "2m",
-			success: true,
-		},
-		// Failure to parse "xd".
-		{
-			value:   "xd",
-			success: false,
-		},
-		// Failure to parse empty string.
-		{
-			value:   "",
-			success: false,
-		},
-	}
-	for i, testCase := range testCases {
-		pt, err := parseTime(testCase.value)
-		if err != nil && testCase.success {
-			t.Errorf("Test: %d, Expected to be successful, but found error %s, for time value %s", i+1, err, testCase.value)
-		}
-		if pt.IsZero() && testCase.success {
-			t.Errorf("Test: %d, Expected time to be non zero, but found zero time for time value %s", i+1, testCase.value)
-		}
-		if err == nil && !testCase.success {
-			t.Errorf("Test: %d, Expected error but found to be successful for time value %s", i+1, testCase.value)
 		}
 	}
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/minio-go/pkg/encrypt"
 
 	"github.com/minio/mc/pkg/console"
+	"github.com/minio/mc/pkg/ioutils"
 	"github.com/minio/mc/pkg/probe"
 )
 
@@ -162,15 +163,27 @@ func lineTrunc(content string, maxLen int) string {
 }
 
 // isOlder returns true if the passed object is older than olderRef
-func isOlder(c *clientContent, olderRef int) bool {
-	objectAge := UTCNow().Sub(c.Time)
-	return objectAge < (time.Duration(olderRef) * Day)
+func isOlder(ti time.Time, olderRef string) bool {
+	objectAge := UTCNow().Sub(ti)
+	var e error
+	var olderThan time.Duration
+	if olderRef != "" {
+		olderThan, e = ioutils.ParseDurationTime(olderRef)
+		fatalIf(probe.NewError(e), "Unable to parse olderThan=`"+olderRef+"`.")
+	}
+	return objectAge < olderThan
 }
 
 // isNewer returns true if the passed object is newer than newerRef
-func isNewer(c *clientContent, newerRef int) bool {
-	objectAge := UTCNow().Sub(c.Time)
-	return objectAge > (time.Duration(newerRef) * Day)
+func isNewer(ti time.Time, newerRef string) bool {
+	objectAge := UTCNow().Sub(ti)
+	var e error
+	var newerThan time.Duration
+	if newerRef != "" {
+		newerThan, e = ioutils.ParseDurationTime(newerRef)
+		fatalIf(probe.NewError(e), "Unable to parse newerThan=`"+newerRef+"`.")
+	}
+	return objectAge >= newerThan
 }
 
 // getLookupType returns the minio.BucketLookupType for lookup

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -531,8 +531,8 @@ FLAGS:
   --incomplete, -I              remove incomplete uploads
   --fake                        perform a fake remove operation
   --stdin                       read object names from STDIN
-  --older-than value            remove objects older than N days (default: 0)
-  --newer-than value            remove objects newer than N days (default: 0)
+  --older-than value            remove objects older than L days, M hours and N minutes LNM[d|h|m]. (default: 0)
+  --newer-than value            remove objects newer than L days, M hours and N minutes LNM[d|h|m]. (default: 0)
   --encrypt-key value           encrypt/decrypt objects (using server-side encryption with customer provided keys)
   --help, -h                    show help
 
@@ -567,10 +567,10 @@ Removing `play/mybucket/otherobject.txt`.
 mc rm --incomplete play/mybucket/myobject.1gig
 Removing `play/mybucket/myobject.1gig`.
 ```
-*Example: Remove object and output a message only if the object is created older than one day. Otherwise, the command stays quiet and nothing is printed out.*
+*Example: Remove object and output a message only if the object is created older than 1 day, 2 hours and 30 minutes. Otherwise, the command stays quiet and nothing is printed out.*
 
 ```sh
-mc rm -r --force --older-than=1 myminio/mybucket
+mc rm -r --force --older-than 1d2h30m myminio/mybucket
 Removing `myminio/mybucket/dayOld1.txt`.
 Removing `myminio/mybucket/dayOld2.txt`.
 Removing `myminio/mybucket/dayOld3.txt`.
@@ -708,8 +708,8 @@ FLAGS:
   --exec value                  spawn an external process for each matching object (see FORMAT)
   --ignore value                exclude objects matching the wildcard pattern
   --name value                  find object names matching wildcard pattern
-  --newer value                 match all objects newer than specified time in units (see UNITS)
-  --older value                 match all objects older than specified time in units (see UNITS)
+  --newer value                 match all objects newer than specified time L days, M hours and N minutes
+  --older value                 match all objects older than specified time L days, M hours and N minutes
   --path value                  match directory names matching wildcard pattern
   --print value                 print in custom format to STDOUT (see FORMAT)
   --regex value                 match directory and object name with PCRE regex pattern

--- a/pkg/ioutils/format.go
+++ b/pkg/ioutils/format.go
@@ -1,0 +1,219 @@
+/*
+ * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ioutils
+
+import (
+	"errors"
+	"time"
+)
+
+// A Duration represents the elapsed time between two instants
+// as an int64 nanosecond count. The representation limits the
+// largest representable duration to approximately 290 years.
+type Duration int64
+
+// never printed
+var errLeadingInt = errors.New("time: bad [0-9]*")
+
+// Common durations. There is no definition for units of Day or larger
+// to avoid confusion across daylight savings time zone transitions.
+//
+// To count the number of units in a Duration, divide:
+//	second := time.Second
+//	fmt.Print(int64(second/time.Millisecond)) // prints 1000
+//
+// To convert an integer number of units to a Duration, multiply:
+//	seconds := 10
+//	fmt.Print(time.Duration(seconds)*time.Second) // prints 10s
+//
+const (
+	Nanosecond  Duration = 1
+	Microsecond          = 1000 * Nanosecond
+	Millisecond          = 1000 * Microsecond
+	Second               = 1000 * Millisecond
+	Minute               = 60 * Second
+	Hour                 = 60 * Minute
+	Day                  = 24 * Hour
+)
+
+var unitMap = map[string]int64{
+	"ns": int64(Nanosecond),
+	"us": int64(Microsecond),
+	"ms": int64(Millisecond),
+	"s":  int64(Second),
+	"m":  int64(Minute),
+	"h":  int64(Hour),
+	"d":  int64(Day),
+}
+
+// ParseDurationTime parses a duration string in
+// the form "10d4h3m".
+// A duration string is a possibly signed sequence of
+// decimal numbers, each with optional fraction and a unit suffix,
+// such as "300ms", "-1.5h" or "2h45m".
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h", "d".
+// It add the days functionality to time.ParseDuration().
+func ParseDurationTime(s string) (time.Duration, error) {
+	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
+	orig := s
+	var d int64
+	neg := false
+
+	// Consume [-+]?
+	if s != "" {
+		c := s[0]
+		if c == '-' || c == '+' {
+			neg = c == '-'
+			s = s[1:]
+		}
+	}
+	// Special case: if all that is left is "0", this is zero.
+	if s == "0" {
+		return 0, nil
+	}
+	if s == "" {
+		return 0, errors.New("time: invalid duration " + orig)
+	}
+	for s != "" {
+		var (
+			v, f  int64       // integers before, after decimal point
+			scale float64 = 1 // value = v + f/scale
+		)
+
+		var err error
+
+		// The next character must be [0-9.]
+		if !(s[0] == '.' || '0' <= s[0] && s[0] <= '9') {
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+		// Consume [0-9]*
+		pl := len(s)
+		v, s, err = leadingInt(s)
+		if err != nil {
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+		pre := pl != len(s) // whether we consumed anything before a period
+
+		// Consume (\.[0-9]*)?
+		post := false
+		if s != "" && s[0] == '.' {
+			s = s[1:]
+			pl := len(s)
+			f, scale, s = leadingFraction(s)
+			post = pl != len(s)
+		}
+		if !pre && !post {
+			// no digits (e.g. ".s" or "-.s")
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+
+		// Consume unit.
+		i := 0
+		for ; i < len(s); i++ {
+			c := s[i]
+			if c == '.' || '0' <= c && c <= '9' {
+				break
+			}
+		}
+		if i == 0 {
+			return 0, errors.New("time: missing unit in duration " + orig + ". Should be of days, hours and minutes format like 7d4h20m ")
+		}
+		u := s[:i]
+		s = s[i:]
+		unit, ok := unitMap[u]
+		if !ok {
+			return 0, errors.New("time: unknown unit " + u + " in duration " + orig)
+		}
+		if v > (1<<63-1)/unit {
+			// overflow
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+		v *= unit
+		if f > 0 {
+			// float64 is needed to be nanosecond accurate for fractions of hours.
+			// v >= 0 && (f*unit/scale) <= 3.6e+12 (ns/h, h is the largest unit)
+			v += int64(float64(f) * (float64(unit) / scale))
+			if v < 0 {
+				// overflow
+				return 0, errors.New("time: invalid duration " + orig)
+			}
+		}
+		d += v
+		if d < 0 {
+			// overflow
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+	}
+
+	if neg {
+		d = -d
+	}
+
+	return time.Duration(d), nil
+}
+
+// leadingInt consumes the leading [0-9]* from s.
+func leadingInt(s string) (x int64, rem string, err error) {
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if x > (1<<63-1)/10 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+		x = x*10 + int64(c) - '0'
+		if x < 0 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+	}
+	return x, s[i:], nil
+}
+
+// leadingFraction consumes the leading [0-9]* from s.
+// It is used only for fractions, so does not return an error on overflow,
+// it just stops accumulating precision.
+func leadingFraction(s string) (x int64, scale float64, rem string) {
+	i := 0
+	scale = 1
+	overflow := false
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if overflow {
+			continue
+		}
+		if x > (1<<63-1)/10 {
+			// It's possible for overflow to give a positive number, so take care.
+			overflow = true
+			continue
+		}
+		y := x*10 + int64(c) - '0'
+		if y < 0 {
+			overflow = true
+			continue
+		}
+		x = y
+		scale *= 10
+	}
+	return x, scale, s[i:]
+}

--- a/pkg/ioutils/ioutils_test.go
+++ b/pkg/ioutils/ioutils_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/minio/mc/pkg/ioutils"
 
@@ -40,4 +41,42 @@ func (s *MySuite) TestIoutils(c *C) {
 	status, err := ioutils.IsDirEmpty(path)
 	c.Assert(err, IsNil)
 	c.Assert(status, Equals, true)
+}
+
+// Test for ParseDurationTime. Validates the returned value
+// for given time value in days, hours and minute format.
+func TestParseDurationTime(t *testing.T) {
+
+	testCases := []struct {
+		timeValue string
+		expected  time.Duration
+		err       string
+	}{
+		// Test 1: empty string as input
+		{"", 0, "time: invalid duration "},
+		// Test 2: Input string contains 4 day, 10 hour and 3 minutes
+		{"4d10h3m", 381780000000000, ""},
+		// Test 3: Input string contains 10 day and  3 hours
+		{"10d3h", 874800000000000, ""},
+		// Test 4: Input string contains minutes and days
+		{"3m7d", 604980000000000, ""},
+		// Test 5: Input string contains unknown unit
+		{"4a3d", 0, "time: unknown unit a in duration 4a3d"},
+		// Test 6: Input string contains fractional day
+		{"1.5d", 129600000000000, ""},
+		// Test 6: Input string contains fractional day and hour
+		{"2.5d1.5h", 221400000000000, ""},
+		// Test 7: Input string contains fractional day , hour and minute
+		{"2.5d1.5h3.5m", 221610000000000, ""},
+	}
+
+	for _, testCase := range testCases {
+		myVal, err := ioutils.ParseDurationTime(testCase.timeValue)
+		if err != nil && err.Error() != testCase.err {
+			t.Error()
+		}
+		if myVal != testCase.expected {
+			t.Error()
+		}
+	}
 }


### PR DESCRIPTION
Previously `OlderThan` and `NewerThan` was configured for day
which has been changed to Days, Hours and Minutes. The filed is used in `copy`, `remove` and `mirror` .

This resolves the [bug](https://github.com/minio/mc/issues/2539)