### PR TITLE
With bracket characters in URL curl requires globbing turned off

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -381,7 +381,7 @@ function test_presigned_post_policy_error()
     endpoint=$(echo "$ENDPOINT" | sed 's|[][]|\\&|g')
 
     # Extract share field of json output, and append object name to the URL
-    upload=$(echo "$out" | jq -r .share | sed "s|<FILE>|$FILE_1_MB|g" | sed "s|curl|curl -sS|g" | sed "s|${endpoint}/${BUCKET_NAME}/|${endpoint}/${BUCKET_NAME}/${object_name}|g")
+    upload=$(echo "$out" | jq -r .share | sed "s|<FILE>|$FILE_1_MB|g" | sed "s|curl|curl -sSg|g" | sed "s|${endpoint}/${BUCKET_NAME}/|${endpoint}/${BUCKET_NAME}/${object_name}|g")
 
     # In case of virtual host style URL path, the previous replace would have failed.
     # One of the following two commands will append the object name in that scenario.
@@ -412,7 +412,7 @@ function test_presigned_put_object()
 
     out=$("${MC_CMD[@]}" --json share upload "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}")
     assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to get presigned put object url"
-    upload=$(echo "$out" | jq -r .share | sed "s|<FILE>|$FILE_1_MB|g" | sed "s|curl|curl -sS|g")
+    upload=$(echo "$out" | jq -r .share | sed "s|<FILE>|$FILE_1_MB|g" | sed "s|curl|curl -sSg|g")
     $upload >/dev/null 2>&1
     assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to upload $FILE_1_MB presigned put object url"
 
@@ -434,7 +434,7 @@ function test_presigned_get_object()
     out=$("${MC_CMD[@]}" --json share download "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}")
     assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to get presigned get object url"
     download_url=$(echo "$out" | jq -r .share)
-    curl --output "${object_name}.downloaded" -sS -X GET "$download_url"
+    curl -sSg --output "${object_name}.downloaded" -X GET "$download_url"
     assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to download $download_url"
 
     assert_success "$start_time" "${FUNCNAME[0]}" check_md5sum "$FILE_1_MB_MD5SUM" "${object_name}.downloaded"


### PR DESCRIPTION
This PR fixes an issue perhaps is present when curl commands
are used with IPv6 SERVER_ENDPOINTs