### PR TITLE
mirror: Fix double printing of remove object msg

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -319,7 +319,8 @@ func (mj *mirrorJob) startStatus() {
 			} else if sURLs.TargetContent != nil {
 				// Construct user facing message and path.
 				targetPath := filepath.ToSlash(filepath.Join(sURLs.TargetAlias, sURLs.TargetContent.URL.Path))
-				mj.status.PrintMsg(rmMessage{Key: targetPath})
+				size := sURLs.TargetContent.Size
+				mj.status.PrintMsg(rmMessage{Key: targetPath, Size: size})
 			}
 		}
 	}()


### PR DESCRIPTION
Mirror code depends on rm code which naturally prints delete messages,
this PR will make mirror uses its own delete code since it is simple
enough to do.

Fixes #2083 