### PR TITLE
Edit the delete object message

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -129,7 +129,7 @@ type rmMessage struct {
 
 // Colorized message for console printing.
 func (r rmMessage) String() string {
-	return console.Colorize("Remove", fmt.Sprintf("Removing `%s`.", r.Key))
+	return console.Colorize("Remove", fmt.Sprintf("Attempting to remove `%s`.", r.Key))
 }
 
 // JSON'ified message for scripting.


### PR DESCRIPTION
Upon deletion of object the message was `Removing <<Object-Name>>` which has been changed to
`Attempting to remove <<Object-Name>>`
