### PR TITLE
Add metadata in mc copy

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -367,7 +367,7 @@ func readFile(fpath string) (io.ReadCloser, error) {
 }
 
 // Copy - copy data from source to destination
-func (f *fsClient) Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide) *probe.Error {
+func (f *fsClient) Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string) *probe.Error {
 	destination := f.PathURL.Path
 	rc, e := readFile(source)
 	if e != nil {

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -360,6 +360,6 @@ func (s *TestSuite) TestCopy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	err = fsClientTarget.Copy(sourcePath, int64(len(data)), nil, nil, nil)
+	err = fsClientTarget.Copy(sourcePath, int64(len(data)), nil, nil, nil, nil)
 	c.Assert(err, IsNil)
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -626,7 +626,7 @@ func (c *s3Client) Get(sse encrypt.ServerSide) (io.ReadCloser, *probe.Error) {
 // Copy - copy object, uses server side copy API. Also uses an abstracted API
 // such that large file sizes will be copied in multipart manner on server
 // side.
-func (c *s3Client) Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide) *probe.Error {
+func (c *s3Client) Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string) *probe.Error {
 	dstBucket, dstObject := c.url2BucketAndObject()
 	if dstBucket == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -638,7 +638,7 @@ func (c *s3Client) Copy(source string, size int64, progress io.Reader, srcSSE, t
 	src := minio.NewSourceInfo(tokens[1], tokens[2], srcSSE)
 
 	// Destination object
-	dst, e := minio.NewDestinationInfo(dstBucket, dstObject, tgtSSE, nil)
+	dst, e := minio.NewDestinationInfo(dstBucket, dstObject, tgtSSE, metadata)
 	if e != nil {
 		return probe.NewError(e)
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -57,7 +57,7 @@ type Client interface {
 	SetAccess(access string, isJSON bool) *probe.Error
 
 	// I/O operations
-	Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide) *probe.Error
+	Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string) *probe.Error
 
 	// Runs select expression on object storage on specific files.
 	Select(expression string, sse encrypt.ServerSide) (io.ReadCloser, *probe.Error)
@@ -87,6 +87,7 @@ type clientContent struct {
 	Size              int64
 	Type              os.FileMode
 	Metadata          map[string]string
+	UserMetadata      map[string]string
 	ETag              string
 	Expires           time.Time
 	EncryptionHeaders map[string]string

--- a/cmd/cp-main_test.go
+++ b/cmd/cp-main_test.go
@@ -1,0 +1,61 @@
+/*
+ * Minio Client (C) 2019 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMetaData(t *testing.T) {
+	metaDataCases := []struct {
+		input  string
+		output map[string]string
+		err    error
+		status bool
+	}{
+		// success scenerio
+		{"key1=value1,key2=value2", map[string]string{"key1": "value1", "key2": "value2"}, nil, true},
+		// using different delimitter, other than ',' between multiple meta data
+		{"key1=value1;key2=value2", nil, ErrInvalidMetadata, false},
+		// using different delimitter, other than '=' between key value
+		{"key1:value1,key2:value2", nil, ErrInvalidMetadata, false},
+		// using no delimitter
+		{"key1:value1:key2:value2", nil, ErrInvalidMetadata, false},
+	}
+
+	for idx, testCase := range metaDataCases {
+		metaDatamap, errMeta := getMetaDataEntry(testCase.input)
+		if testCase.status == true {
+			if errMeta != nil {
+				t.Fatalf("Test %d: generated error not matching, expected = `%s`, found = `%s`", idx+1, testCase.err, errMeta)
+			}
+			if !reflect.DeepEqual(metaDatamap, testCase.output) {
+				t.Fatalf("Test %d: generated Map not matching, expected = `%s`, found = `%s`", idx+1, testCase.input, metaDatamap)
+			}
+		}
+
+		if testCase.status == false {
+			if !reflect.DeepEqual(metaDatamap, testCase.output) {
+				t.Fatalf("Test %d: generated Map not matching, expected = `%s`, found = `%s`", idx+1, testCase.input, metaDatamap)
+			}
+			if errMeta.Cause.Error() != testCase.err.Error() {
+				t.Fatalf("Test %d: generated error not matching, expected = `%s`, found = `%s`", idx+1, testCase.err, errMeta)
+			}
+		}
+	}
+}

--- a/cmd/session-v8.go
+++ b/cmd/session-v8.go
@@ -50,6 +50,7 @@ type sessionV8Header struct {
 	LastRemoved        string            `json:"lastRemoved"`
 	TotalBytes         int64             `json:"totalBytes"`
 	TotalObjects       int64             `json:"totalObjects"`
+	UserMetaData       map[string]string `json:"metaData"`
 }
 
 // sessionMessage container for session messages
@@ -174,6 +175,7 @@ func newSessionV8() *sessionV8 {
 	s.Header.CommandBoolFlags = make(map[string]bool)
 	s.Header.CommandIntFlags = make(map[string]int)
 	s.Header.CommandStringFlags = make(map[string]string)
+	s.Header.UserMetaData = make(map[string]string)
 	s.Header.When = UTCNow()
 	s.mutex = new(sync.Mutex)
 	s.SessionID = newRandomID(8)

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -334,6 +334,21 @@ function test_put_object_with_storage_class_error()
     log_success "$start_time" "${FUNCNAME[0]}"
 }
 
+## Test mc cp command with valid metadata string
+function test_put_object_with_metadata()
+{
+    show "${FUNCNAME[0]}"
+
+    start_time=$(get_time)
+    object_name="mc-test-object-$RANDOM"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp --attr key1=val1,key2=val2 "${FILE_1_MB}" "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"
+    diff -bB <(echo "val1")  <("${MC_CMD[@]}"   --json stat "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"  |  jq -r '.metadata."X-Amz-Meta-Key1"')  >/dev/null 2>&1
+    assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to put object with metadata"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"
+    log_success "$start_time" "${FUNCNAME[0]}"
+
+}
+
 function test_get_object()
 {
     show "${FUNCNAME[0]}"
@@ -805,12 +820,12 @@ function run_test()
     test_make_bucket_error
 
     setup
-
     test_put_object
     test_put_object_error
     test_put_object_0byte
     test_put_object_with_storage_class
     test_put_object_with_storage_class_error
+    test_put_object_with_metadata
     test_put_object_multipart
     test_get_object
     test_get_object_multipart


### PR DESCRIPTION
mc copy provisioned to pass metadata as string.

Example : mc cp --metadata key1=value1,key=value2 play/mybucket/burningman2011/ ~/latest/

Fixes: [2639](https://github.com/minio/mc/issues/2636)