### PR TITLE
Add config: Strip trailing separator in URL

### DIFF
--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -227,7 +227,7 @@ func mainConfigHostAdd(ctx *cli.Context) error {
 	console.SetColor("HostMessage", color.New(color.FgGreen))
 	var (
 		args      = ctx.Args()
-		url       = args.Get(1)
+		url       = trimTrailingSeparator(args.Get(1))
 		accessKey = args.Get(2)
 		secretKey = args.Get(3)
 		api       = ctx.String("api")

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -41,6 +41,12 @@ func isValidSecretKey(secretKey string) bool {
 	return len(secretKey) >= secretKeyMinLen
 }
 
+// trimTrailingSeparator - Remove trailing separator.
+func trimTrailingSeparator(hostURL string) string {
+	separator := string(newClientURL(hostURL).Separator)
+	return strings.TrimSuffix(hostURL, separator)
+}
+
 // isValidHostURL - validate input host url.
 func isValidHostURL(hostURL string) (ok bool) {
 	if strings.TrimSpace(hostURL) != "" {

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -209,7 +209,7 @@ func getAliasedPath(ctx *findContext, path string) string {
 	prefixPath := ctx.clnt.GetURL().String()
 	var aliasedPath string
 	if ctx.targetAlias != "" {
-		aliasedPath = ctx.targetAlias + strings.TrimPrefix(path, ctx.targetFullURL)
+		aliasedPath = ctx.targetAlias + strings.TrimPrefix(path, strings.TrimSuffix(ctx.targetFullURL, separator))
 	} else {
 		aliasedPath = path
 		// look for prefix path, if found filter at that, Watch calls


### PR DESCRIPTION
Trailing separator like `https://s3.amazonaws.com/` is causing issues like the one in #2645 .
This PR removes the trailing separator before storing the URL.

In the case of `find` command, for existing configs that has a trailing separator in
the URL, trim the separator from the URL.

Fixes #2645