### PR TITLE
mirror: Proper exit when preparing diff returns an error

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -516,8 +516,9 @@ func (mj *mirrorJob) startMirror(ctx context.Context, cancelMirror context.Cance
 				return
 			}
 			if sURLs.Error != nil {
+				stopParallel()
 				errCh <- sURLs.Error
-				continue
+				return
 			}
 
 			if sURLs.SourceContent != nil {


### PR DESCRIPTION
A bad synchornization between startMirror() and its caller mirror() happens when preparing the difference of objects between source & target returns an error: mirror() quits when it receives an error from startMirror() without give a chance for that latter to properly stop the parallel mirror manager.

This PR will:
1. Quit mirroring when listing returns an error: this means calculating diff needs to stop and no further action needs to be taken since it can be dangerous especially when --remove flag is passed.
2. Properly stop parallel mirroring manager before quitting.

Fixes #2682 