### PR TITLE
Add normal/deep scan flag to admin heal cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/mattn/go-isatty v0.0.4
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/minio/cli v0.0.0-20170227073228-b8ae5507c0ce
-	github.com/minio/minio v0.0.0-20190206103305-fd4e15c11641
+	github.com/minio/minio v0.0.0-20190314200851-facbd653bad5
 	github.com/minio/minio-go v0.0.0-20190308013636-b32976861da0
 	github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16
 	github.com/minio/sio v0.0.0-20180327104954-6a41828a60f0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/minio/cli v0.0.0-20170227073228-b8ae5507c0ce h1:cMutC6C4ElU0TVblNfXx6
 github.com/minio/cli v0.0.0-20170227073228-b8ae5507c0ce/go.mod h1:hLsWNQy2wIf3FKFnMlH69f4RdEyn8nbRA2shaulTjGY=
 github.com/minio/minio v0.0.0-20190206103305-fd4e15c11641 h1:iW6Ns9yJPCzd1v+AjznM2xY9JwH2tIaHEdM6rsG8YKE=
 github.com/minio/minio v0.0.0-20190206103305-fd4e15c11641/go.mod h1:lXcp05uxYaW99ebgI6ZKIGYU7tqZkM5xSsG0xRt4VIU=
+github.com/minio/minio v0.0.0-20190314200851-facbd653bad5 h1:KgnwbhlfiLuT3Rq0rYOgV8E5iamKT7y6j4CDnYl0Mc4=
+github.com/minio/minio v0.0.0-20190314200851-facbd653bad5/go.mod h1:lXcp05uxYaW99ebgI6ZKIGYU7tqZkM5xSsG0xRt4VIU=
 github.com/minio/minio-go v0.0.0-20190308013636-b32976861da0 h1:yHdN+v8UkkeKXBF7evFjHE9hvdrW6WhyT/S0W07YM48=
 github.com/minio/minio-go v0.0.0-20190308013636-b32976861da0/go.mod h1:/haSOWG8hQNx2+JOfLJ9GKp61EAmgPwRVw/Sac0NzaM=
 github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16 h1:5W7KhL8HVF3XCFOweFD3BNESdnO8ewyYTFT2R+/b8FQ=

--- a/vendor/github.com/minio/minio/pkg/disk/disk.go
+++ b/vendor/github.com/minio/minio/pkg/disk/disk.go
@@ -29,12 +29,14 @@ import (
 )
 
 // file size for performance read and write checks
-const randBufSize = 1 * humanize.KiByte
-const randParts = 1024
-const fileSize = randParts * randBufSize
+const (
+	randBufSize = 1 * humanize.KiByte
+	randParts   = 1024
+	fileSize    = randParts * randBufSize
 
-// Total count of read / write iteration for performance measurement
-const iterations = 10
+	// Total count of read / write iteration for performance measurement
+	iterations = 10
+)
 
 // Info stat fs struct is container which holds following values
 // Total - total size of the volume / disk

--- a/vendor/github.com/minio/minio/pkg/disk/type_linux.go
+++ b/vendor/github.com/minio/minio/pkg/disk/type_linux.go
@@ -20,7 +20,7 @@ package disk
 
 import "strconv"
 
-// fsType2StringMap - list of filesystems supported by donut on linux
+// fsType2StringMap - list of filesystems supported on linux
 var fsType2StringMap = map[string]string{
 	"1021994":  "TMPFS",
 	"137d":     "EXT",
@@ -34,6 +34,9 @@ var fsType2StringMap = map[string]string{
 	"ef51":     "EXT2OLD",
 	"ef53":     "EXT4",
 	"f15f":     "ecryptfs",
+	"794c7630": "overlayfs",
+	"2fc12fc1": "zfs",
+	"ff534d42": "cifs",
 }
 
 // getFSType returns the filesystem type of the underlying mounted filesystem

--- a/vendor/github.com/minio/minio/pkg/madmin/api.go
+++ b/vendor/github.com/minio/minio/pkg/madmin/api.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -61,9 +60,6 @@ type AdminClient struct {
 	// Advanced functionality.
 	isTraceEnabled bool
 	traceOutput    io.Writer
-
-	// Random seed.
-	random *rand.Rand
 }
 
 // Global constants.
@@ -118,21 +114,17 @@ func privateNew(endpoint, accessKeyID, secretAccessKey string, secure bool) (*Ad
 }
 
 // SetAppInfo - add application details to user agent.
-func (c *AdminClient) SetAppInfo(appName string, appVersion string) {
+func (adm *AdminClient) SetAppInfo(appName string, appVersion string) {
 	// if app name and version is not set, we do not a new user
 	// agent.
 	if appName != "" && appVersion != "" {
-		c.appInfo = struct {
-			appName    string
-			appVersion string
-		}{}
-		c.appInfo.appName = appName
-		c.appInfo.appVersion = appVersion
+		adm.appInfo.appName = appName
+		adm.appInfo.appVersion = appVersion
 	}
 }
 
 // SetCustomTransport - set new custom transport.
-func (c *AdminClient) SetCustomTransport(customHTTPTransport http.RoundTripper) {
+func (adm *AdminClient) SetCustomTransport(customHTTPTransport http.RoundTripper) {
 	// Set this to override default transport
 	// ``http.DefaultTransport``.
 	//
@@ -147,28 +139,28 @@ func (c *AdminClient) SetCustomTransport(customHTTPTransport http.RoundTripper) 
 	//   }
 	//   api.SetTransport(tr)
 	//
-	if c.httpClient != nil {
-		c.httpClient.Transport = customHTTPTransport
+	if adm.httpClient != nil {
+		adm.httpClient.Transport = customHTTPTransport
 	}
 }
 
 // TraceOn - enable HTTP tracing.
-func (c *AdminClient) TraceOn(outputStream io.Writer) {
+func (adm *AdminClient) TraceOn(outputStream io.Writer) {
 	// if outputStream is nil then default to os.Stdout.
 	if outputStream == nil {
 		outputStream = os.Stdout
 	}
 	// Sets a new output stream.
-	c.traceOutput = outputStream
+	adm.traceOutput = outputStream
 
 	// Enable tracing.
-	c.isTraceEnabled = true
+	adm.isTraceEnabled = true
 }
 
 // TraceOff - disable HTTP tracing.
-func (c *AdminClient) TraceOff() {
+func (adm *AdminClient) TraceOff() {
 	// Disable tracing.
-	c.isTraceEnabled = false
+	adm.isTraceEnabled = false
 }
 
 // requestMetadata - is container for all the values to make a
@@ -181,7 +173,7 @@ type requestData struct {
 }
 
 // Filter out signature value from Authorization header.
-func (c AdminClient) filterSignature(req *http.Request) {
+func (adm AdminClient) filterSignature(req *http.Request) {
 	/// Signature V4 authorization header.
 
 	// Save the original auth.
@@ -197,19 +189,18 @@ func (c AdminClient) filterSignature(req *http.Request) {
 
 	// Set a temporary redacted auth
 	req.Header.Set("Authorization", newAuth)
-	return
 }
 
 // dumpHTTP - dump HTTP request and response.
-func (c AdminClient) dumpHTTP(req *http.Request, resp *http.Response) error {
+func (adm AdminClient) dumpHTTP(req *http.Request, resp *http.Response) error {
 	// Starts http dump.
-	_, err := fmt.Fprintln(c.traceOutput, "---------START-HTTP---------")
+	_, err := fmt.Fprintln(adm.traceOutput, "---------START-HTTP---------")
 	if err != nil {
 		return err
 	}
 
 	// Filter out Signature field from Authorization header.
-	c.filterSignature(req)
+	adm.filterSignature(req)
 
 	// Only display request header.
 	reqTrace, err := httputil.DumpRequestOut(req, false)
@@ -218,7 +209,7 @@ func (c AdminClient) dumpHTTP(req *http.Request, resp *http.Response) error {
 	}
 
 	// Write request to trace output.
-	_, err = fmt.Fprint(c.traceOutput, string(reqTrace))
+	_, err = fmt.Fprint(adm.traceOutput, string(reqTrace))
 	if err != nil {
 		return err
 	}
@@ -254,24 +245,24 @@ func (c AdminClient) dumpHTTP(req *http.Request, resp *http.Response) error {
 		}
 	}
 	// Write response to trace output.
-	_, err = fmt.Fprint(c.traceOutput, strings.TrimSuffix(string(respTrace), "\r\n"))
+	_, err = fmt.Fprint(adm.traceOutput, strings.TrimSuffix(string(respTrace), "\r\n"))
 	if err != nil {
 		return err
 	}
 
 	// Ends the http dump.
-	_, err = fmt.Fprintln(c.traceOutput, "---------END-HTTP---------")
+	_, err = fmt.Fprintln(adm.traceOutput, "---------END-HTTP---------")
 	return err
 }
 
 // do - execute http request.
-func (c AdminClient) do(req *http.Request) (*http.Response, error) {
+func (adm AdminClient) do(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 	// Do the request in a loop in case of 307 http is met since golang still doesn't
 	// handle properly this situation (https://github.com/golang/go/issues/7912)
 	for {
-		resp, err = c.httpClient.Do(req)
+		resp, err = adm.httpClient.Do(req)
 		if err != nil {
 			// Handle this specifically for now until future Golang
 			// versions fix this issue properly.
@@ -304,8 +295,8 @@ func (c AdminClient) do(req *http.Request) (*http.Response, error) {
 	}
 
 	// If trace is enabled, dump http request and response.
-	if c.isTraceEnabled {
-		err = c.dumpHTTP(req, resp)
+	if adm.isTraceEnabled {
+		err = adm.dumpHTTP(req, resp)
 		if err != nil {
 			return nil, err
 		}
@@ -323,7 +314,7 @@ var successStatus = []int{
 // executeMethod - instantiates a given method, and retries the
 // request upon any error up to maxRetries attempts in a binomially
 // delayed manner using a standard back off algorithm.
-func (c AdminClient) executeMethod(method string, reqData requestData) (res *http.Response, err error) {
+func (adm AdminClient) executeMethod(method string, reqData requestData) (res *http.Response, err error) {
 
 	// Create a done channel to control 'ListObjects' go routine.
 	doneCh := make(chan struct{}, 1)
@@ -333,13 +324,13 @@ func (c AdminClient) executeMethod(method string, reqData requestData) (res *htt
 
 	// Instantiate a new request.
 	var req *http.Request
-	req, err = c.newRequest(method, reqData)
+	req, err = adm.newRequest(method, reqData)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initiate the request.
-	res, err = c.do(req)
+	res, err = adm.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -368,15 +359,15 @@ func (c AdminClient) executeMethod(method string, reqData requestData) (res *htt
 }
 
 // set User agent.
-func (c AdminClient) setUserAgent(req *http.Request) {
+func (adm AdminClient) setUserAgent(req *http.Request) {
 	req.Header.Set("User-Agent", libraryUserAgent)
-	if c.appInfo.appName != "" && c.appInfo.appVersion != "" {
-		req.Header.Set("User-Agent", libraryUserAgent+" "+c.appInfo.appName+"/"+c.appInfo.appVersion)
+	if adm.appInfo.appName != "" && adm.appInfo.appVersion != "" {
+		req.Header.Set("User-Agent", libraryUserAgent+" "+adm.appInfo.appName+"/"+adm.appInfo.appVersion)
 	}
 }
 
 // newRequest - instantiate a new HTTP request for a given method.
-func (c AdminClient) newRequest(method string, reqData requestData) (req *http.Request, err error) {
+func (adm AdminClient) newRequest(method string, reqData requestData) (req *http.Request, err error) {
 	// If no method is supplied default to 'POST'.
 	if method == "" {
 		method = "POST"
@@ -386,7 +377,7 @@ func (c AdminClient) newRequest(method string, reqData requestData) (req *http.R
 	location := ""
 
 	// Construct a new target URL.
-	targetURL, err := c.makeTargetURL(reqData)
+	targetURL, err := adm.makeTargetURL(reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +388,7 @@ func (c AdminClient) newRequest(method string, reqData requestData) (req *http.R
 		return nil, err
 	}
 
-	c.setUserAgent(req)
+	adm.setUserAgent(req)
 	for k, v := range reqData.customHeaders {
 		req.Header.Set(k, v[0])
 	}
@@ -407,15 +398,15 @@ func (c AdminClient) newRequest(method string, reqData requestData) (req *http.R
 	req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(sum256(reqData.content)))
 	req.Body = ioutil.NopCloser(bytes.NewReader(reqData.content))
 
-	req = s3signer.SignV4(*req, c.accessKeyID, c.secretAccessKey, "", location)
+	req = s3signer.SignV4(*req, adm.accessKeyID, adm.secretAccessKey, "", location)
 	return req, nil
 }
 
 // makeTargetURL make a new target url.
-func (c AdminClient) makeTargetURL(r requestData) (*url.URL, error) {
+func (adm AdminClient) makeTargetURL(r requestData) (*url.URL, error) {
 
-	host := c.endpointURL.Host
-	scheme := c.endpointURL.Scheme
+	host := adm.endpointURL.Host
+	scheme := adm.endpointURL.Scheme
 
 	urlStr := scheme + "://" + host + libraryAdminURLPrefix + r.relPath
 

--- a/vendor/github.com/minio/minio/pkg/madmin/heal-commands.go
+++ b/vendor/github.com/minio/minio/pkg/madmin/heal-commands.go
@@ -26,11 +26,22 @@ import (
 	"time"
 )
 
+// HealScanMode represents the type of healing scan
+type HealScanMode int
+
+const (
+	// HealNormalScan checks if parts are present and not outdated
+	HealNormalScan HealScanMode = iota
+	// HealDeepScan checks for parts bitrot checksums
+	HealDeepScan
+)
+
 // HealOpts - collection of options for a heal sequence
 type HealOpts struct {
-	Recursive bool `json:"recursive"`
-	DryRun    bool `json:"dryRun"`
-	Remove    bool `json:"remove"`
+	Recursive bool         `json:"recursive"`
+	DryRun    bool         `json:"dryRun"`
+	Remove    bool         `json:"remove"`
+	ScanMode  HealScanMode `json:"scanMode"`
 }
 
 // HealStartSuccess - holds information about a successfully started

--- a/vendor/github.com/minio/minio/pkg/quick/errorutil.go
+++ b/vendor/github.com/minio/minio/pkg/quick/errorutil.go
@@ -62,17 +62,16 @@ func FormatJSONSyntaxError(data io.Reader, offset int64) (highlight string) {
 		if readBytes > offset {
 			break
 		}
-		switch b {
-		case '\n':
+		if b == '\n' {
 			readLine.Reset()
 			errLine++
-		case '\t':
+			continue
+		} else if b == '\t' {
 			readLine.WriteByte(' ')
-		case '\r':
+		} else if b == '\r' {
 			break
-		default:
-			readLine.WriteByte(b)
 		}
+		readLine.WriteByte(b)
 	}
 
 	lineLen := readLine.Len()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/mattn/go-colorable
 github.com/mattn/go-isatty
 # github.com/minio/cli v0.0.0-20170227073228-b8ae5507c0ce
 github.com/minio/cli
-# github.com/minio/minio v0.0.0-20190206103305-fd4e15c11641
+# github.com/minio/minio v0.0.0-20190314200851-facbd653bad5
 github.com/minio/minio/pkg/madmin
 github.com/minio/minio/pkg/mimedb
 github.com/minio/minio/pkg/quick


### PR DESCRIPTION
Add support of normal/deep scan flag to admin heal cmd:


```
SCAN MODES:
   normal (default): Heal objects which are missing on one or more disks.
   deep            : Heal objects which are missing on one or more disks. Also heal objects with silent data corruption.
```