### PR TITLE
Avoid ListBuckets to keep Stat() ops on bucket simpler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       env:
         - ARCH=x86_64
         - GO111MODULE=on
-      go: 1.11.4
+      go: 1.11.5
       script:
         - diff -au <(gofmt -d *.go) <(printf "")
         - diff -au <(gofmt -d cmd) <(printf "")
@@ -28,7 +28,7 @@ matrix:
       env:
         - ARCH=x86_64
         - GO111MODULE=on
-      go: 1.11.4
+      go: 1.11.5
       script:
         - go build --ldflags="$(go run buildscripts/gen-ldflags.go)" -o %GOPATH%\bin\mc.exe
         - for d in $(go list ./...); do go test -v -mod=vendor -race "$d"; done

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ checks:
 
 getdeps:
 	@GO111MODULE=on
-	@echo "Installing golint" && go get -u golang.org/x/lint/golint
+	@echo "Installing golint" && go get golang.org/x/lint/golint
 	@echo "Installing gocyclo" && go get -u github.com/fzipp/gocyclo
 	@echo "Installing misspell" && go get -u github.com/client9/misspell/cmd/misspell
 	@echo "Installing ineffassign" && go get -u github.com/gordonklaus/ineffassign

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.18.0 h1:IZl7mfBGfbhYx2p2rKRtYgDFw6SBz+kclmxYrCksPPA=
 google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
+google.golang.org/grpc v1.19.0 h1:cfg4PD8YEdSFnm7qLV4++93WcmhH2nIUhMjhdCvl3j8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Due to multi-user feature on Minio and `mc` adoption in
many different restrictive environments, most users disable
access to ListBuckets() calls. We can avoid such network
operations as they only add marginal value.