### PR TITLE
rm: Force removing an object when it is encrypted without key specified

### DIFF
--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -121,12 +121,18 @@ func mainStat(ctx *cli.Context) error {
 
 	var cErr error
 	for _, targetURL := range args {
-		var clnt Client
-		clnt, err := newClient(targetURL)
-		fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
-
-		targetAlias, _, _ := mustExpandAlias(targetURL)
-		return doStat(clnt, isRecursive, targetAlias, targetURL, encKeyDB)
+		stats, err := statURL(targetURL, false, isRecursive, encKeyDB)
+		if err != nil {
+			fatalIf(err, "Unable to stat `"+targetURL+"`.")
+		}
+		for _, stat := range stats {
+			st := parseStat(stat)
+			if !globalJSON {
+				printStat(st)
+			} else {
+				console.Println(st.JSON())
+			}
+		}
 	}
 	return cErr
 

--- a/cmd/stat_test.go
+++ b/cmd/stat_test.go
@@ -40,7 +40,7 @@ func (s *TestSuite) TestParseStat(c *C) {
 			"play"},
 	}
 	for _, testCase := range testCases {
-		statMsg := parseStat(testCase.targetAlias, &testCase.content)
+		statMsg := parseStat(&testCase.content)
 		c.Assert(testCase.content.Metadata, DeepEquals, statMsg.Metadata)
 		c.Assert(testCase.content.EncryptionHeaders, DeepEquals, statMsg.EncryptionHeaders)
 		c.Assert(testCase.content.Size, Equals, statMsg.Size)

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -96,6 +96,13 @@ var errInvalidTarget = func(URL string) *probe.Error {
 	return probe.NewError(invalidTargetErr(errors.New(msg))).Untrace()
 }
 
+type targetNotFoundErr error
+
+var errTargetNotFound = func(URL string) *probe.Error {
+	msg := "Target `" + URL + "` not found."
+	return probe.NewError(targetNotFoundErr(errors.New(msg))).Untrace()
+}
+
 type overwriteNotAllowedErr struct {
 	error
 }


### PR DESCRIPTION
Currently, a single remove HEAD an object, but this latter can return
400 Bad Request when the object is encrypted and the user doesn't specify
any encryption key.

So when HEAD fail, this PR will use GET listing to find the object and
remove it if existent.

We can avoid calling HEAD in the first place and use only listing, but this
has some penality on the server.