### PR TITLE
Fix policy set error

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"hash/fnv"
 	"io"
 	"net"
@@ -33,7 +34,6 @@ import (
 	"sync"
 	"time"
 
-	json "github.com/minio/mc/pkg/colorjson"
 	"github.com/minio/mc/pkg/httptracer"
 	"github.com/minio/mc/pkg/probe"
 	minio "github.com/minio/minio-go"
@@ -983,7 +983,7 @@ func (c *s3Client) SetAccess(bucketPolicy string, isJSON bool) *probe.Error {
 		}
 		return nil
 	}
-	policyB, e := json.MarshalIndent(p, "", " ")
+	policyB, e := json.Marshal(p)
 	if e != nil {
 		return probe.NewError(e)
 	}


### PR DESCRIPTION
When policy is being set,json does not need to be indented - it
is causing a policy has invalid resource error

Fixes commit c75abbb3f9ef200817214b2ffaf9b333d457ab60 

Repro:
➜  mc git:(master) mc policy public myminio/tbucket11
mc: <ERROR> Unable to set policy `public` for `myminio/tbucket11`. Policy has invalid resource.

