### PR TITLE
rb: Fix removing an empty bucket when passed as argument 

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -792,6 +792,13 @@ func (c *s3Client) Remove(isIncomplete, isRemoveBucket bool, contentCh <-chan *c
 		for content := range contentCh {
 			// Convert content.URL.Path to objectName for objectsCh.
 			bucket, objectName := c.splitPath(content.URL.Path)
+
+			// We don't treat path when bucket is
+			// empty, just skip it when it happens.
+			if bucket == "" {
+				continue
+			}
+
 			// Init objectsCh the first time.
 			if prevBucket == "" {
 				objectsCh = make(chan string)
@@ -858,7 +865,7 @@ func (c *s3Client) Remove(isIncomplete, isRemoveBucket bool, contentCh <-chan *c
 			}
 		}
 		// Remove last bucket if it qualifies.
-		if isRemoveBucket && !isIncomplete {
+		if isRemoveBucket && prevBucket != "" && !isIncomplete {
 			if err := c.api.RemoveBucket(prevBucket); err != nil {
 				errorCh <- probe.NewError(err)
 			}

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -257,7 +257,7 @@ function setup()
 function teardown()
 {
     start_time=$(get_time)
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm --force --recursive "${SERVER_ALIAS}/${BUCKET_NAME}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force "${SERVER_ALIAS}/${BUCKET_NAME}"
 }
 
 function test_put_object()


### PR DESCRIPTION
rb was relying on client.List() to find all elements that needs to be
removed. However it doesn't include 'alias/bucket' in the listing
when 'alias/bucket' itself is passed as an argument in rb command.

This PR will always attempt to delete the passed argument as this is
what the user wants in the first place.

This PR also fixes teardown() in functional-tests.sh to remove
the bucket using rb instead rm since rm does not remove buckets
anymore.

Fixes #2702 