### PR TITLE
tests: Use rb instead of rm to clean test bucket

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -257,7 +257,7 @@ function setup()
 function teardown()
 {
     start_time=$(get_time)
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm --force --recursive "${SERVER_ALIAS}/${BUCKET_NAME}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force "${SERVER_ALIAS}/${BUCKET_NAME}"
 }
 
 function test_put_object()


### PR DESCRIPTION
rm command is not able to remove buckets anymore, so use the new rb
command instead.