### PR TITLE
mc admin info changes

### DIFF
--- a/pkg/console/themes.go
+++ b/pkg/console/themes.go
@@ -26,6 +26,7 @@ var (
 		"Error":  color.New(color.FgYellow, color.Italic),
 		"Info":   color.New(color.FgGreen, color.Bold),
 		"Print":  color.New(),
+		"PrintB": color.New(color.FgBlue, color.Bold),
 		"PrintC": color.New(color.FgGreen, color.Bold),
 	}
 )


### PR DESCRIPTION
- sorts the list of outputs in `mc admin info`
- move status to its own field
- show uptime in a separate field
- shows drives per accurately
- writes version as `<development>` if it is `DEVELOPMENT.GOGET`
- writes error message as `unreachable` if a node is unreachable. It used to show up as `rpc: retry error`
- skips `SQS ARN` if it is empty
- skips `Region` if it is empty

