### PR TITLE
For non-canned policies, show policy status as custom

### DIFF
--- a/cmd/access-perms.go
+++ b/cmd/access-perms.go
@@ -40,4 +40,5 @@ const (
 	accessDownload = accessPerms("download")
 	accessUpload   = accessPerms("upload")
 	accessPublic   = accessPerms("public")
+	accessCustom   = accessPerms("custom")
 )

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -893,28 +893,28 @@ func (f *fsClient) GetAccessRules() (map[string]string, *probe.Error) {
 }
 
 // GetAccess - get access policy permissions.
-func (f *fsClient) GetAccess() (access string, err *probe.Error) {
+func (f *fsClient) GetAccess() (access string, policyJSON string, err *probe.Error) {
 	// For windows this feature is not implemented.
 	if runtime.GOOS == "windows" {
-		return "", probe.NewError(APINotImplemented{API: "GetAccess", APIType: "filesystem"})
+		return "", "", probe.NewError(APINotImplemented{API: "GetAccess", APIType: "filesystem"})
 	}
 	st, err := f.fsStat(false)
 	if err != nil {
-		return "", err.Trace(f.PathURL.String())
+		return "", "", err.Trace(f.PathURL.String())
 	}
 	if !st.Mode().IsDir() {
-		return "", probe.NewError(APINotImplemented{API: "GetAccess", APIType: "filesystem"})
+		return "", "", probe.NewError(APINotImplemented{API: "GetAccess", APIType: "filesystem"})
 	}
 	// Mask with os.ModePerm to get only inode permissions
 	switch st.Mode() & os.ModePerm {
 	case os.FileMode(0777):
-		return "readwrite", nil
+		return "readwrite", "", nil
 	case os.FileMode(0555):
-		return "readonly", nil
+		return "readonly", "", nil
 	case os.FileMode(0333):
-		return "writeonly", nil
+		return "writeonly", "", nil
 	}
-	return "none", nil
+	return "none", "", nil
 }
 
 // SetAccess - set access policy permissions.

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -231,7 +231,7 @@ func (s *TestSuite) TestBucketACLFails(c *C) {
 		err = fsClient.SetAccess("readonly", false)
 		c.Assert(err, IsNil)
 
-		_, err = fsClient.GetAccess()
+		_, _, err = fsClient.GetAccess()
 		c.Assert(err, IsNil)
 	}
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -52,7 +52,7 @@ type Client interface {
 	MakeBucket(region string, ignoreExisting bool) *probe.Error
 
 	// Access policy operations.
-	GetAccess() (access string, error *probe.Error)
+	GetAccess() (access string, policyJSON string, error *probe.Error)
 	GetAccessRules() (policyRules map[string]string, error *probe.Error)
 	SetAccess(access string, isJSON bool) *probe.Error
 

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -655,7 +655,7 @@ func copyBucketPolicies(srcClt, dstClt Client, isOverwrite bool) *probe.Error {
 	}
 	// Set found rules to target bucket if permitted
 	for _, r := range rules {
-		originalRule, err := dstClt.GetAccess()
+		originalRule, _, err := dstClt.GetAccess()
 		if err != nil {
 			return err
 		}

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -91,7 +91,7 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 
 SERIALIZATION OPTIONS:
-  For query serialization options, refer to https://docs.minio.io/docs/minio-client-complete-guide#sql
+   For query serialization options, refer to https://docs.minio.io/docs/minio-client-complete-guide#sql
 
 EXAMPLES:
    1. Run a query on a set of objects recursively on AWS S3.


### PR DESCRIPTION
When user has a custom policy that doesn't fall under the canned policies, ```mc policy alias/bucket``` displays `none` which is incorrect. This was reported by a user on slack.

This PR changes this behavior to return `custom` when a noncanned policy is set and also display the policy in --json mode.
