### PR TITLE
make mc ls output consistent while listing

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	json "github.com/minio/mc/pkg/colorjson"
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/mc/pkg/probe"
@@ -140,6 +140,8 @@ func doList(clnt Client, isRecursive, isIncomplete bool) error {
 		contentURL := filepath.ToSlash(content.URL.Path)
 		prefixPath = filepath.ToSlash(prefixPath)
 
+		// Trim prefix of current working dir
+		prefixPath = strings.TrimPrefix(prefixPath, "."+separator)
 		// Trim prefix path from the content path.
 		contentURL = strings.TrimPrefix(contentURL, prefixPath)
 		content.URL.Path = contentURL


### PR DESCRIPTION
directories on file system.
```
➜  mc git:(master) mc ls ./vendor/
[2019-03-21 12:14:57 PDT] 4.0KiB vendor/github.com/
[2019-03-21 12:14:57 PDT] 4.0KiB vendor/go.uber.org/
[2019-03-11 11:26:59 PDT] 4.0KiB vendor/golang.org/
[2019-03-21 12:14:58 PDT] 4.0KiB vendor/google.golang.org/
[2019-03-21 12:14:58 PDT] 4.0KiB vendor/gopkg.in/
[2019-03-21 12:59:55 PDT] 6.8KiB vendor/modules.txt
```
```
➜  mc git:(master) mc ls vendor/  
[2019-03-21 12:14:57 PDT] 4.0KiB github.com/
[2019-03-21 12:14:57 PDT] 4.0KiB go.uber.org/
[2019-03-11 11:26:59 PDT] 4.0KiB golang.org/
[2019-03-21 12:14:58 PDT] 4.0KiB google.golang.org/
[2019-03-21 12:14:58 PDT] 4.0KiB gopkg.in/
[2019-03-21 12:59:55 PDT] 6.8KiB modules.txt
```
Both commands should give identical listing , just like unix ls command