### PR TITLE
Issue 2725 Fish tab completion string error

### DIFF
--- a/vendor/github.com/posener/complete/cmd/install/fish.go
+++ b/vendor/github.com/posener/complete/cmd/install/fish.go
@@ -41,7 +41,7 @@ func (f fish) cmd(cmd, bin string) (string, error) {
 	params := struct{ Cmd, Bin string }{cmd, bin}
 	tmpl := template.Must(template.New("cmd").Parse(`
 function __complete_{{.Cmd}}
-    set -lx COMP_LINE (string join ' ' (commandline -o))
+    set -lx COMP_LINE (string join ' ' -- (commandline -o))
     test (commandline -ct) = ""
     and set COMP_LINE "$COMP_LINE "
     {{.Bin}}


### PR DESCRIPTION
Adds `--` before the commandline expansion so that additional options
are not treated as options to string.

Addresses issue https://github.com/minio/mc/issues/2725

# Testing
```
I leaf@sitka ~/w/mc (issue_2725=)> make install
Checking dependencies
Checking for project in GOPATH
Building minio binary to './mc'
Installing mc binary to '/home/leaf/working/go/bin/mc'
Installation successful. To learn more, try "mc --help".
```
```
leaf@sitka ~> mc cp -r --newer-than 2d <TAB>
                                                                                            mirror   synchronize object(s) to a remote site
  --config-dir value, -C value  path to configuration folder (default: "/home/leaf/.mc")    pipe     stream STDIN to an object
  --debug                       enable debug output                                         policy   manage anonymous access to buckets and objects
  --help, -h                    show help                                                   rb       remove a bucket
…and 18 more rows
```