### PR TITLE
Fix for container startup issues on Openshift

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -7,5 +7,9 @@ RUN \
     apk add --no-cache --virtual .build-deps curl && \
     curl https://dl.minio.io/client/mc/release/linux-amd64/mc > /usr/bin/mc && \
     chmod +x /usr/bin/mc && apk del .build-deps
+    
+RUN mkdir /.mc && chgrp -R 0 /.mc && chmod -R g=u /.mc
 
 ENTRYPOINT ["mc"]
+
+USER 1001

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 
 MAINTAINER Minio Inc <dev@minio.io>
 


### PR DESCRIPTION
On Openshift, containers will be running under a random uid by default, e.g. `uid=1012330000 gid=0(root) groups=0(root),1012330000`. Dockerfiles should ideally switch the user context e.g. by using `USER 1001`. `1001` will be substituted with a generated uid by Openshift out of a range of uids that is specific to the namespace the deployment is running in. All directories within the container are owned by the `root` user as per Docker default. When writes to certain directories are necessary, containers should use `RUN chgrp -R 0 /some/directory && chmod -R g=u /some/directory` to make the directories accessible from the `root` group (note: not user).

Detailed information for the used fix: https://docs.openshift.com/container-platform/3.10/creating_images/guidelines.html