### PR TITLE
ls: Remove space between size and unit

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -47,7 +47,7 @@ type contentMessage struct {
 // String colorized string message.
 func (c contentMessage) String() string {
 	message := console.Colorize("Time", fmt.Sprintf("[%s] ", c.Time.Format(printDate)))
-	message = message + console.Colorize("Size", fmt.Sprintf("%7s ", humanize.IBytes(uint64(c.Size))))
+	message = message + console.Colorize("Size", fmt.Sprintf("%7s ", strings.Join(strings.Fields(humanize.IBytes(uint64(c.Size))), "")))
 	message = func() string {
 		if c.Filetype == "folder" {
 			return message + console.Colorize("Dir", fmt.Sprintf("%s", c.Key))


### PR DESCRIPTION
With the move to go.mod, the latest humanize package is being used.
This introduces a space between size and the unit. Manually removing the space
to make it consistent with the older mc releases.

With the latest release, you will see output of `mc ls play/buckets/issue`
as 
`[2019-03-29 11:49:10 PDT]    20 B issue`

With older releases it will be
`[2019-03-29 11:49:10 PDT]    20B issue`

This Pr makes it consistent with the older output