### PR TITLE
mirror: fix 0 byte files not getting mirrored

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -353,7 +353,9 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, cancelMirror context.Cance
 			}
 
 			sourceURL := newClientURL(eventPath)
-			aliasedPath := strings.Replace(eventPath, sourceURLFull, mj.sourceURL, -1)
+			// trim trailing slash from source url
+			sourceURLStr := strings.TrimSuffix(sourceURLFull, string(sourceURL.Separator))
+			aliasedPath := strings.Replace(eventPath, sourceURLStr, mj.sourceURL, -1)
 
 			// build target path, it is the relative of the eventPath with the sourceUrl
 			// joined to the targetURL.


### PR DESCRIPTION
Fixes: #2737

See issue for replicating the error.  Issue was due to source url constructed incorrectly without slash delimiter for 0 byte files - dminiobucket/obj instead of dminio/bucket/obj