### PR TITLE
Replaces Minio refs with MinIO and links in mc docs

### DIFF
--- a/CONFLICT.md
+++ b/CONFLICT.md
@@ -1,8 +1,8 @@
-## mc (Minio Client) v/s Midnight Commander (mc)
+## mc (MinIO Client) v/s Midnight Commander (mc)
 
-There has been some amount of [requests](https://github.com/minio/mc/issues?q=is%3Aissue+midnight+commander+is%3Aclosed) on renaming this project to avoid the conflict with Midnight Commander for Unix distributions. We struggled with this, it is harder to find a name sweeter and shorter than `mc` for Minio Client.
+There has been some amount of [requests](https://github.com/minio/mc/issues?q=is%3Aissue+midnight+commander+is%3Aclosed) on renaming this project to avoid the conflict with Midnight Commander for Unix distributions. We struggled with this, it is harder to find a name sweeter and shorter than `mc` for MinIO Client.
 
-Besides `mc` is a single static binary and can reside inside your application and is fully self contained. Midnight Commander (mc) is a free software clone of Norton Commander (nc). Minio and Midnight shares no code or ideas. Only their abbreviation matches.
+Besides `mc` is a single static binary and can reside inside your application and is fully self contained. Midnight Commander (mc) is a free software clone of Norton Commander (nc). MinIO and Midnight shares no code or ideas. Only their abbreviation matches.
 
 Package managers are free to choose a different name if they like. One such solution [pointed out](https://github.com/minio/mc/issues/873#issuecomment-267583013) by one of our community members.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mc.exe --help
 ```
 
 ## Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/download/#minio-client.
 
 If you do not have a working Golang environment, please follow [How to install Golang](https://docs.min.io/docs/how-to-install-golang).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Minio Client Quickstart Guide
-[![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io) [![Go Report Card](https://goreportcard.com/badge/minio/mc)](https://goreportcard.com/report/minio/mc) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/mc.svg?maxAge=604800)](https://hub.docker.com/r/minio/mc/)
+# MinIO Client Quickstart Guide
+[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io) [![Go Report Card](https://goreportcard.com/badge/minio/mc)](https://goreportcard.com/report/minio/mc) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/mc.svg?maxAge=604800)](https://hub.docker.com/r/minio/mc/)
 
-Minio Client (mc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff, find etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
+MinIO Client (mc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff, find etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
 
 ```
 ls       list buckets and objects
@@ -41,7 +41,7 @@ docker pull minio/mc:edge
 docker run minio/mc:edge ls play
 ```
 
-**Note:** Above examples run `mc` against Minio [_play_ environment](#test-your-setup) by default. To run `mc` against other S3 compatible servers, start the container this way:
+**Note:** Above examples run `mc` against MinIO [_play_ environment](#test-your-setup) by default. To run `mc` against other S3 compatible servers, start the container this way:
 
 ```sh
 docker run -it --entrypoint=/bin/sh minio/mc
@@ -82,9 +82,9 @@ mc.exe --help
 ```
 
 ## Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://minio.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/downloads/#minio-client.
 
-If you do not have a working Golang environment, please follow [How to install Golang](https://docs.minio.io/docs/how-to-install-golang).
+If you do not have a working Golang environment, please follow [How to install Golang](https://docs.min.io/docs/how-to-install-golang).
 
 ```sh
 go get -d github.com/minio/mc
@@ -105,8 +105,8 @@ Alias is simply a short name to your cloud storage service. S3 end-point, access
 
 Lookup is an optional argument. It is used to indicate whether dns or path style url requests are supported by the server. It accepts "dns", "path" or "auto" as valid values. By default, it is set to "auto" and SDK automatically determines the type of url lookup to use.
 
-### Example - Minio Cloud Storage
-Minio server displays URL, access and secret keys.
+### Example - MinIO Cloud Storage
+MinIO server displays URL, access and secret keys.
 
 ```sh
 mc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
@@ -156,7 +156,7 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 NOTE: Google Cloud Storage only supports Legacy Signature Version 2, so you have to pick - S3v2
 
 ## Test Your Setup
-`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
@@ -217,12 +217,12 @@ cat      cp       event    head     mb       pipe     rm       share    stat    
 ```
 
 ## Explore Further
-- [Minio Client Complete Guide](https://docs.minio.io/docs/minio-client-complete-guide)
-- [Minio Quickstart Guide](https://docs.minio.io/docs/minio-quickstart-guide)
-- [The Minio documentation website](https://docs.minio.io)
+- [MinIO Client Complete Guide](https://docs.min.io/docs/minio-client-complete-guide)
+- [MinIO Quickstart Guide](https://docs.min.io/docs/minio-quickstart-guide)
+- [The MinIO documentation website](https://docs.min.io)
 
-## Contribute to Minio Project
-Please follow Minio [Contributor's Guide](https://github.com/minio/mc/blob/master/CONTRIBUTING.md)
+## Contribute to MinIO Project
+Please follow MinIO [Contributor's Guide](https://github.com/minio/mc/blob/master/CONTRIBUTING.md)
 
 
 ## License

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -1,7 +1,7 @@
-# Minio客户端快速入门指南
-[![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io) [![Go Report Card](https://goreportcard.com/badge/minio/mc)](https://goreportcard.com/report/minio/mc) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/mc.svg?maxAge=604800)](https://hub.docker.com/r/minio/mc/)
+# MinIO客户端快速入门指南
+[![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io) [![Go Report Card](https://goreportcard.com/badge/minio/mc)](https://goreportcard.com/report/minio/mc) [![Docker Pulls](https://img.shields.io/docker/pulls/minio/mc.svg?maxAge=604800)](https://hub.docker.com/r/minio/mc/)
 
-Minio Client (mc)为ls，cat，cp，mirror，diff，find等UNIX命令提供了一种替代方案。它支持文件系统和兼容Amazon S3的云存储服务（AWS Signature v2和v4）。
+MinIO Client (mc)为ls，cat，cp，mirror，diff，find等UNIX命令提供了一种替代方案。它支持文件系统和兼容Amazon S3的云存储服务（AWS Signature v2和v4）。
 
 
 ```
@@ -37,7 +37,7 @@ docker pull minio/mc:edge
 docker run minio/mc:edge ls play
 ```
 
-**注意:** 上述示例默认使用Minio[演示环境](#test-your-setup)做演示，如果想用`mc`操作其它S3兼容的服务，采用下面的方式来启动容器：
+**注意:** 上述示例默认使用MinIO[演示环境](#test-your-setup)做演示，如果想用`mc`操作其它S3兼容的服务，采用下面的方式来启动容器：
 
 ```sh
 docker run -it --entrypoint=/bin/sh minio/mc
@@ -76,9 +76,9 @@ mc.exe --help
 ```
 
 ## 通过源码安装
-通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从https://minio.io/downloads/#minio-client下载官方版本。
+通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从https://min.io/downloads/#minio-client下载官方版本。
 
-如果您没有Golang环境，请参照[如何安装Golang](https://docs.minio.io/docs/how-to-install-golang)。
+如果您没有Golang环境，请参照[如何安装Golang](https://docs.min.io/docs/how-to-install-golang)。
 
 ```sh
 go get -d github.com/minio/mc
@@ -97,8 +97,8 @@ mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY
 
 别名就是给你的云存储服务起了一个短点的外号。S3 endpoint,access key和secret key是你的云存储服务提供的。API签名是可选参数，默认情况下，它被设置为"S3v4"。
 
-### 示例-Minio云存储
-从Minio服务获得URL、access key和secret key。
+### 示例-MinIO云存储
+从MinIO服务获得URL、access key和secret key。
 
 ```sh
 mc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 S3v4
@@ -121,7 +121,7 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 注意：Google云存储只支持旧版签名版本V2，所以你需要选择S3v2。
 
 ## 验证
-`mc`预先配置了云存储服务URL：https://play.minio.io:9000，别名“play”。它是一个用于研发和测试的Minio服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
+`mc`预先配置了云存储服务URL：https://play.minio.io:9000，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
 
 *示例:*
 
@@ -165,9 +165,9 @@ cat      cp       events   mb       pipe     rm       share    version
 ```
 
 ## 了解更多
-- [Minio Client完全指南](https://docs.minio.io/docs/minio-client-complete-guide)
-- [Minio快速入门](https://docs.minio.io/docs/minio-quickstart-guide)
-- [Minio官方文档](https://docs.minio.io)
+- [MinIO Client完全指南](https://docs.min.io/docs/minio-client-complete-guide)
+- [MinIO快速入门](https://docs.min.io/docs/minio-quickstart-guide)
+- [MinIO官方文档](https://docs.min.io)
 
 ## 贡献
-请遵守Minio[贡献者指南](https://github.com/minio/mc/blob/master/docs/zh_CN/CONTRIBUTING.md)
+请遵守MinIO[贡献者指南](https://github.com/minio/mc/blob/master/docs/zh_CN/CONTRIBUTING.md)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -76,7 +76,7 @@ mc.exe --help
 ```
 
 ## 通过源码安装
-通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从https://min.io/downloads/#minio-client下载官方版本。
+通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从https://min.io/download/#minio-client下载官方版本。
 
 如果您没有Golang环境，请参照[如何安装Golang](https://docs.min.io/docs/how-to-install-golang)。
 

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -54,7 +54,7 @@ mc.exe --help
 ```
 
 ### Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/download/#minio-client.
 
 If you do not have a working Golang environment, please follow [How to install Golang](https://docs.min.io/docs/how-to-install-golang).
 

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -1,6 +1,6 @@
-# Minio Admin Complete Guide [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# MinIO Admin Complete Guide [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-Minio Client (mc) provides `admin` sub-command to perform administrative tasks on your Minio deployments.
+MinIO Client (mc) provides `admin` sub-command to perform administrative tasks on your MinIO deployments.
 
 ```sh
 service      stop, restart or get status of minio server
@@ -12,7 +12,7 @@ config       manage configuration file
 heal         heal disks, buckets and objects on minio server
 ```
 
-## 1.  Download Minio Client
+## 1.  Download MinIO Client
 ### Docker Stable
 ```
 docker pull minio/mc
@@ -54,9 +54,9 @@ mc.exe --help
 ```
 
 ### Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://minio.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/downloads/#minio-client.
 
-If you do not have a working Golang environment, please follow [How to install Golang](https://docs.minio.io/docs/how-to-install-golang).
+If you do not have a working Golang environment, please follow [How to install Golang](https://docs.min.io/docs/how-to-install-golang).
 
 ```sh
 go get -d github.com/minio/mc
@@ -64,7 +64,7 @@ cd ${GOPATH}/src/github.com/minio/mc
 make
 ```
 
-## 2. Run Minio Client
+## 2. Run MinIO Client
 
 ### GNU/Linux
 
@@ -86,8 +86,8 @@ chmod 755 mc
 mc.exe --help
 ```
 
-## 3. Add a Minio Storage Service
-Minio server displays URL, access and secret keys.
+## 3. Add a MinIO Storage Service
+MinIO server displays URL, access and secret keys.
 
 #### Usage
 
@@ -95,7 +95,7 @@ Minio server displays URL, access and secret keys.
 mc config host add <ALIAS> <YOUR-MINIO-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY>
 ```
 
-Alias is simply a short name to your Minio service. Minio end-point, access and secret keys are supplied by your Minio service. Admin API uses "S3v4" signature and cannot be changed.
+Alias is simply a short name to your MinIO service. MinIO end-point, access and secret keys are supplied by your MinIO service. Admin API uses "S3v4" signature and cannot be changed.
 
 ```sh
 mc config host add minio http://192.168.1.51:9000 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
@@ -105,7 +105,7 @@ mc config host add minio http://192.168.1.51:9000 BKIKJAA5BMMU2RHO6IBB V7f1CwQqA
 
 *Example:*
 
-Get Minio server information for the configured alias `minio`
+Get MinIO server information for the configured alias `minio`
 
 ```sh
 mc admin info minio
@@ -138,7 +138,7 @@ Debug option enables debug output to console.
 mc admin --debug info minio
 mc: <DEBUG> GET /minio/admin/v1/info HTTP/1.1
 Host: 192.168.1.51:9000
-User-Agent: Minio (linux; amd64) madmin-go/0.0.1 mc/2018-05-23T23:43:34Z
+User-Agent: MinIO (linux; amd64) madmin-go/0.0.1 mc/2018-05-23T23:43:34Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20180530/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 X-Amz-Content-Sha256: UNSIGNED-PAYLOAD
 X-Amz-Date: 20180530T001808Z
@@ -150,7 +150,7 @@ Accept-Ranges: bytes
 Content-Security-Policy: block-all-mixed-content
 Content-Type: application/json
 Date: Wed, 30 May 2018 00:18:08 GMT
-Server: Minio/DEVELOPMENT.2018-05-28T04-31-38Z (linux; amd64)
+Server: MinIO/DEVELOPMENT.2018-05-28T04-31-38Z (linux; amd64)
 Vary: Origin
 X-Amz-Request-Id: 1533440573A63034
 X-Xss-Protection: "1; mode=block"
@@ -169,7 +169,7 @@ mc: <DEBUG> Response Time:  140.70112ms
 ### Option [--json]
 JSON option enables parseable output in JSON format.
 
-*Example: Minio server information.*
+*Example: MinIO server information.*
 
 ```sh
 mc admin --json info minio
@@ -224,7 +224,7 @@ Skip SSL certificate verification.
 
 <a name="service"></a>
 ### Command `service` - stop, restart or get status of minio server
-`service` command provides a way to restart, stop one or get the status of Minio servers (distributed cluster)
+`service` command provides a way to restart, stop one or get the status of MinIO servers (distributed cluster)
 
 ```sh
 NAME:
@@ -239,7 +239,7 @@ COMMANDS:
   stop     stop minio server
 ```
 
-*Example: Display service uptime for Minio server.*
+*Example: Display service uptime for MinIO server.*
 
 ```sh
 mc admin service status play
@@ -248,7 +248,7 @@ Uptime: 1 days 19 hours 57 minutes 39 seconds.
 
 *Example: Restart remote minio service.*
 
-NOTE: `restart` and `stop` sub-commands are disruptive operations for your Minio service, any on-going API operations will be forcibly canceled. So, it should be used only under certain circumstances. Please use it with caution.
+NOTE: `restart` and `stop` sub-commands are disruptive operations for your MinIO service, any on-going API operations will be forcibly canceled. So, it should be used only under certain circumstances. Please use it with caution.
 
 ```sh
 mc admin service restart play
@@ -256,8 +256,8 @@ Restarted `play` successfully.
 ```
 
 <a name="info"></a>
-### Command `info` - Display Minio server information
-`info` command displays server information of one or many Minio servers (under distributed cluster)
+### Command `info` - Display MinIO server information
+`info` command displays server information of one or many MinIO servers (under distributed cluster)
 
 ```sh
 NAME:
@@ -267,7 +267,7 @@ FLAGS:
   --help, -h                       show help
 ```
 
-*Example: Display Minio server information.*
+*Example: Display MinIO server information.*
 
 ```sh
 mc admin info play
@@ -282,7 +282,7 @@ mc admin info play
 
 <a name="policy"></a>
 ### Command `policy` - Manage canned policies
-`policy` command to add, remove, list policies on Minio server.
+`policy` command to add, remove, list policies on MinIO server.
 
 ```sh
 NAME:
@@ -297,19 +297,19 @@ COMMANDS:
   list     List all policies
 ```
 
-*Example: Add a new policy 'newpolicy' on Minio, with policy from /tmp/newpolicy.json.*
+*Example: Add a new policy 'newpolicy' on MinIO, with policy from /tmp/newpolicy.json.*
 
 ```sh
 mc admin policy add myminio/ newpolicy /tmp/newpolicy.json
 ```
 
-*Example: Remove policy 'newpolicy' on Minio.*
+*Example: Remove policy 'newpolicy' on MinIO.*
 
 ```sh
 mc admin policy remove myminio/ newpolicy
 ```
 
-*Example: List all policies on Minio.*
+*Example: List all policies on MinIO.*
 
 ```sh
 mc admin policy list --json myminio/
@@ -336,37 +336,37 @@ COMMANDS:
   list     list all users
 ```
 
-*Example: Add a new user 'newuser' on Minio, with 'newpolicy' policy.*
+*Example: Add a new user 'newuser' on MinIO, with 'newpolicy' policy.*
 
 ```sh
 mc admin user add myminio/ newuser newuser123 newpolicy
 ```
 
-*Example: Change policy for a user 'newuser' on Minio to 'writeonly' policy.*
+*Example: Change policy for a user 'newuser' on MinIO to 'writeonly' policy.*
 
 ```sh
 mc admin user policy myminio/ newuser writeonly
 ```
 
-*Example: Disable a user 'newuser' on Minio.*
+*Example: Disable a user 'newuser' on MinIO.*
 
 ```sh
 mc admin user disable myminio/ newuser
 ```
 
-*Example: Enable a user 'newuser' on Minio.*
+*Example: Enable a user 'newuser' on MinIO.*
 
 ```sh
 mc admin user enable myminio/ newuser
 ```
 
-*Example: Remove user 'newuser' on Minio.*
+*Example: Remove user 'newuser' on MinIO.*
 
 ```sh
 mc admin user remove myminio/ newuser
 ```
 
-*Example: List all users on Minio.*
+*Example: List all users on MinIO.*
 
 ```sh
 mc admin user list --json myminio/
@@ -375,7 +375,7 @@ mc admin user list --json myminio/
 
 <a name="credential"></a>
 ### Command `credential` - Change server **admin** access and secret keys
-`credential` command to set new **admin** credential of a Minio server.
+`credential` command to set new **admin** credential of a MinIO server.
 
 ```sh
 NAME:
@@ -385,7 +385,7 @@ FLAGS:
   --help, -h                       Show help.
 ```
 
-*Example: Set new admin credential of a Minio server represented by its alias 'myminio'.*
+*Example: Set new admin credential of a MinIO server represented by its alias 'myminio'.*
 
 ```sh
 mc admin credential myminio/ minio minio123
@@ -393,7 +393,7 @@ mc admin credential myminio/ minio minio123
 
 <a name="config"></a>
 ### Command `config` - Manage server configuration
-`config` command to manage Minio server configuration.
+`config` command to manage MinIO server configuration.
 
 ```sh
 NAME:
@@ -403,32 +403,32 @@ USAGE:
   mc admin config COMMAND [COMMAND FLAGS | -h] [ARGUMENTS...]
 
 COMMANDS:
-  get  get config of a Minio server/cluster.
-  set  set new config file to a Minio server/cluster.
+  get  get config of a MinIO server/cluster.
+  set  set new config file to a MinIO server/cluster.
 
 FLAGS:
   --help, -h                       Show help.
 ```
 
-*Example: Get server configuration of a Minio server/cluster.*
+*Example: Get server configuration of a MinIO server/cluster.*
 
 ```sh
 mc admin config get myminio > /tmp/my-serverconfig
 ```
 
-*Example: Set server configuration of a Minio server/cluster.*
+*Example: Set server configuration of a MinIO server/cluster.*
 
 ```sh
 mc admin config set myminio < /tmp/my-serverconfig
 ```
 
 <a name="heal"></a>
-### Command `heal` - Heal disks, buckets and objects on Minio server
-`heal` command heals disks, missing buckets, objects on Minio server. NOTE: This command is only applicable for Minio erasure coded setup (standalone and distributed).
+### Command `heal` - Heal disks, buckets and objects on MinIO server
+`heal` command heals disks, missing buckets, objects on MinIO server. NOTE: This command is only applicable for MinIO erasure coded setup (standalone and distributed).
 
 ```sh
 NAME:
-  mc admin heal - heal disks, buckets and objects on Minio server
+  mc admin heal - heal disks, buckets and objects on MinIO server
 
 FLAGS:
   --recursive, -r                  heal recursively
@@ -437,19 +437,19 @@ FLAGS:
   --help, -h                       show help
 ```
 
-*Example: Heal Minio cluster after replacing a fresh disk, recursively heal all buckets and objects, where 'myminio' is the Minio server alias.*
+*Example: Heal MinIO cluster after replacing a fresh disk, recursively heal all buckets and objects, where 'myminio' is the MinIO server alias.*
 
 ```sh
 mc admin heal -r myminio
 ```
 
-*Example: Heal Minio cluster on a specific bucket recursively, where 'myminio' is the Minio server alias.*
+*Example: Heal MinIO cluster on a specific bucket recursively, where 'myminio' is the MinIO server alias.*
 
 ```sh
 mc admin heal -r myminio/mybucket
 ```
 
-*Example: Heal Minio cluster on a specific object prefix recursively, where 'myminio' is the Minio server alias.*
+*Example: Heal MinIO cluster on a specific object prefix recursively, where 'myminio' is the MinIO server alias.*
 
 ```sh
 mc admin heal -r myminio/mybucket/myobjectprefix

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -1,6 +1,6 @@
-# Minio Client Complete Guide [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# MinIO Client Complete Guide [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-Minio Client (mc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
+MinIO Client (mc) provides a modern alternative to UNIX commands like ls, cat, cp, mirror, diff etc. It supports filesystems and Amazon S3 compatible cloud storage service (AWS Signature v2 and v4).
 
 ```sh
 ls       list buckets and objects
@@ -27,7 +27,7 @@ update   check for a new software update
 version  print version info
 ```
 
-## 1.  Download Minio Client
+## 1.  Download MinIO Client
 ### Docker Stable
 ```
 docker pull minio/mc
@@ -40,7 +40,7 @@ docker pull minio/mc:edge
 docker run minio/mc:edge ls play
 ```
 
-**Note:** Above examples run `mc` against Minio [_play_ environment](#test-your-setup) by default. To run `mc` against other S3 compatible servers, start the container this way:
+**Note:** Above examples run `mc` against MinIO [_play_ environment](#test-your-setup) by default. To run `mc` against other S3 compatible servers, start the container this way:
 
 ```sh
 docker run -it --entrypoint=/bin/sh minio/mc
@@ -77,9 +77,9 @@ mc.exe --help
 ```
 
 ### Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://minio.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/downloads/#minio-client.
 
-If you do not have a working Golang environment, please follow [How to install Golang](https://docs.minio.io/docs/how-to-install-golang).
+If you do not have a working Golang environment, please follow [How to install Golang](https://docs.min.io/docs/how-to-install-golang).
 
 ```sh
 go get -d github.com/minio/mc
@@ -87,7 +87,7 @@ cd ${GOPATH}/src/github.com/minio/mc
 make
 ```
 
-## 2. Run Minio Client
+## 2. Run MinIO Client
 
 ### GNU/Linux
 
@@ -122,8 +122,8 @@ mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY
 
 Alias is simply a short name to your cloud storage service. S3 end-point, access and secret keys are supplied by your cloud storage provider. API signature is an optional argument. By default, it is set to "S3v4".
 
-### Example - Minio Cloud Storage
-Minio server displays URL, access and secret keys.
+### Example - MinIO Cloud Storage
+MinIO server displays URL, access and secret keys.
 
 
 ```sh
@@ -158,7 +158,7 @@ mc ls myalias
 ```
 
 ## 4. Test Your Setup
-`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted Minio server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
@@ -196,7 +196,7 @@ Debug option enables debug output to console.
 mc --debug ls play
 mc: <DEBUG> GET / HTTP/1.1
 Host: play.minio.io:9000
-User-Agent: Minio (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
+User-Agent: MinIO (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
 X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -208,7 +208,7 @@ Transfer-Encoding: chunked
 Accept-Ranges: bytes
 Content-Type: text/xml; charset=utf-8
 Date: Fri, 08 Apr 2016 14:54:55 GMT
-Server: Minio/DEVELOPMENT.2016-04-07T18-53-27Z (linux; amd64)
+Server: MinIO/DEVELOPMENT.2016-04-07T18-53-27Z (linux; amd64)
 Vary: Origin
 X-Amz-Request-Id: HP30I0W2U49BDBIO
 
@@ -225,7 +225,7 @@ mc: <DEBUG> Response Time:  1.220112837s
 ### Option [--json]
 JSON option enables parseable output in JSON format.
 
-*Example: List all buckets from Minio play service.*
+*Example: List all buckets from MinIO play service.*
 
 ```sh
 mc --json ls play
@@ -287,7 +287,7 @@ mc ls play
 
 <a name="mb"></a>
 ### Command `mb` - Make a Bucket
-`mb` command creates a new bucket on an object storage. On a filesystem, it behaves like `mkdir -p` command. Bucket is equivalent of a drive or mount point in filesystems and should not be treated as folders. Minio does not place any limits on the number of buckets created per user.
+`mb` command creates a new bucket on an object storage. On a filesystem, it behaves like `mkdir -p` command. Bucket is equivalent of a drive or mount point in filesystems and should not be treated as folders. MinIO does not place any limits on the number of buckets created per user.
 On Amazon S3, each account is limited to 100 buckets. Please refer to [Buckets Restrictions and Limitations on S3](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) for more information.
 
 ```sh
@@ -361,14 +361,14 @@ ENVIRONMENT VARIABLES:
 
 ```sh
 mc cat play/mybucket/myobject.txt
-Hello Minio!!
+Hello MinIO!!
 ```
 
 *Example: Display the contents of a server encrypted object `myencryptedobject.txt`*
 
 ```sh
 mc cat --encrypt-key "play/mybucket=32byteslongsecretkeymustbegiven1" play/mybucket/myencryptedobject.txt
-Hello Minio!!
+Hello MinIO!!
 ```
 
 <a name="sql"></a>
@@ -866,7 +866,7 @@ mc watch ~/Photos
 
 <a name="event"></a>
 ### Command `event` - Manage bucket event notification.
-``event`` provides a convenient way to configure various types of event notifications on a bucket. Minio event notification can be configured to use AMQP, Redis, ElasticSearch, NATS and PostgreSQL services. Minio configuration provides more details on how these services can be configured.
+``event`` provides a convenient way to configure various types of event notifications on a bucket. MinIO event notification can be configured to use AMQP, Redis, ElasticSearch, NATS and PostgreSQL services. MinIO configuration provides more details on how these services can be configured.
 
 ```sh
 USAGE:
@@ -966,8 +966,8 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'none'
 ```
 
 <a name="admin"></a>
-### Command `admin` - Manage Minio servers
-Please visit [here](https://docs.minio.io/docs/minio-admin-complete-guide) for a more comprehensive admin guide.
+### Command `admin` - Manage MinIO servers
+Please visit [here](https://docs.min.io/docs/minio-admin-complete-guide) for a more comprehensive admin guide.
 
 <a name="session"></a>
 ### Command `session` - Manage Sessions
@@ -1028,7 +1028,7 @@ FLAGS:
 
 *Example: Manage Config File*
 
-Add Minio server access and secret keys to config file host entry. Note that, the history feature of your shell may record these keys and pose a security risk. On `bash` shell, use `set -o` and `set +o` to disable and enable history feature momentarily.
+Add MinIO server access and secret keys to config file host entry. Note that, the history feature of your shell may record these keys and pose a security risk. On `bash` shell, use `set -o` and `set +o` to disable and enable history feature momentarily.
 
 ```sh
 set +o history

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -77,7 +77,7 @@ mc.exe --help
 ```
 
 ### Install from Source
-Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/downloads/#minio-client.
+Source installation is intended only for developers and advanced users. `mc update` command does not support update notifications for source based installations. Please download official releases from https://min.io/download/#minio-client.
 
 If you do not have a working Golang environment, please follow [How to install Golang](https://docs.min.io/docs/how-to-install-golang).
 

--- a/docs/minio-client-configuration-files.md
+++ b/docs/minio-client-configuration-files.md
@@ -1,9 +1,9 @@
-# Minio Client Configuration Files Guide [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# MinIO Client Configuration Files Guide [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-In this document we will walk you through the configuration files of Minio Client.
+In this document we will walk you through the configuration files of MinIO Client.
 
-## Minio Client configuration directory
-Minio Client configurations are stored in file name ``.mc``.  It is a hidden file which resides on user's home directory.
+## MinIO Client configuration directory
+MinIO Client configurations are stored in file name ``.mc``.  It is a hidden file which resides on user's home directory.
 
 **This how the structure of the directory looks like:**
 
@@ -21,7 +21,7 @@ tree ~/.mc
 ``session`` directory keeps metadata information of all incomplete upload or mirror. You can run ``mc session list`` to list the same. 
 
 #### ``config.json``
-config.json is the configuration file for Minio Client, it gets generated after you install and start Minio. All the credentials, endpoint information we add via ``mc config host`` are stored/modified here. 
+config.json is the configuration file for MinIO Client, it gets generated after you install and start MinIO. All the credentials, endpoint information we add via ``mc config host`` are stored/modified here. 
 
 ```sh
 cat config.json 
@@ -64,16 +64,16 @@ cat config.json
 
 ``version`` tells the version of the file.
 
-``hosts``  stores authentication credentials which will be used by Minio Client.
+``hosts``  stores authentication credentials which will be used by MinIO Client.
 
 #### ``config.json.old``
 This file keeps previous config file version details.
 
 #### ``share`` directory
-``share`` directory keeps metadata information of all upload and download URL for objects which is used by  Minio client ``mc share`` command. 
+``share`` directory keeps metadata information of all upload and download URL for objects which is used by  MinIO client ``mc share`` command. 
 
 ## Explore Further
-* [Minio Client Complete Guide](https://docs.minio.io/docs/minio-client-complete-guide)
+* [MinIO Client Complete Guide](https://docs.min.io/docs/minio-client-complete-guide)
 
 
 

--- a/docs/zh_CN/minio-client-complete-guide.md
+++ b/docs/zh_CN/minio-client-complete-guide.md
@@ -1,6 +1,6 @@
-# Minio Client完全指南 [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# MinIO Client完全指南 [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-Minio Client (mc)为ls，cat，cp，mirror，diff，find等UNIX命令提供了一种替代方案。它支持文件系统和兼容Amazon S3的云存储服务（AWS Signature v2和v4）。
+MinIO Client (mc)为ls，cat，cp，mirror，diff，find等UNIX命令提供了一种替代方案。它支持文件系统和兼容Amazon S3的云存储服务（AWS Signature v2和v4）。
 
 ```sh
 ls       列出文件和文件夹。
@@ -22,7 +22,7 @@ update   检查软件更新。
 version  输出版本信息。
 ```
 
-## 1.  下载Minio Client
+## 1.  下载MinIO Client
 ### Docker稳定版
 ```
 docker pull minio/mc
@@ -35,7 +35,7 @@ docker pull minio/mc:edge
 docker run minio/mc:edge ls play
 ```
 
-**注意:** 上述示例默认使用Minio[演示环境](#test-your-setup)做演示，如果想用`mc`操作其它S3兼容的服务，采用下面的方式来启动容器：
+**注意:** 上述示例默认使用MinIO[演示环境](#test-your-setup)做演示，如果想用`mc`操作其它S3兼容的服务，采用下面的方式来启动容器：
 
 ```sh
 docker run -it --entrypoint=/bin/sh minio/mc
@@ -71,9 +71,9 @@ mc.exe --help
 ```
 
 ### 通过源码安装
-通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从[minio-client](https://minio.io/downloads/#minio-client)下载官方版本。
+通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从[minio-client](https://min.io/downloads/#minio-client)下载官方版本。
 
-如果您没有Golang环境，请按照 [如何安装Golang](https://docs.minio.io/docs/how-to-install-golang)。
+如果您没有Golang环境，请按照 [如何安装Golang](https://docs.min.io/docs/how-to-install-golang)。
 
 ```sh
 go get -d github.com/minio/mc
@@ -81,7 +81,7 @@ cd ${GOPATH}/src/github.com/minio/mc
 make
 ```
 
-## 2. 运行Minio Client
+## 2. 运行MinIO Client
 
 ### GNU/Linux
 
@@ -116,8 +116,8 @@ mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY
 
 别名就是给你的云存储服务起了一个短点的外号。S3 endpoint,access key和secret key是你的云存储服务提供的。API签名是可选参数，默认情况下，它被设置为"S3v4"。
 
-### 示例-Minio云存储
-从Minio服务获得URL、access key和secret key。
+### 示例-MinIO云存储
+从MinIO服务获得URL、access key和secret key。
 
 
 ```sh
@@ -141,7 +141,7 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 注意：Google云存储只支持旧版签名版本V2，所以你需要选择S3v2。
 
 ## 4. 验证
-`mc`预先配置了云存储服务URL：[https://play.minio.io:9000](https://play.minio.io:9000)，别名“play”。它是一个用于研发和测试的Minio服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
+`mc`预先配置了云存储服务URL：[https://play.minio.io:9000](https://play.minio.io:9000)，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
 
 *示例:*
 
@@ -179,7 +179,7 @@ Debug参数开启控制台输出debug信息。
 mc --debug ls play
 mc: <DEBUG> GET / HTTP/1.1
 Host: play.minio.io:9000
-User-Agent: Minio (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
+User-Agent: MinIO (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
 X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -191,7 +191,7 @@ Transfer-Encoding: chunked
 Accept-Ranges: bytes
 Content-Type: text/xml; charset=utf-8
 Date: Fri, 08 Apr 2016 14:54:55 GMT
-Server: Minio/DEVELOPMENT.2016-04-07T18-53-27Z (linux; amd64)
+Server: MinIO/DEVELOPMENT.2016-04-07T18-53-27Z (linux; amd64)
 Vary: Origin
 X-Amz-Request-Id: HP30I0W2U49BDBIO
 
@@ -208,7 +208,7 @@ mc: <DEBUG> Response Time:  1.220112837s
 ### 参数 [--json]
 JSON参数启用JSON格式的输出。
 
-*示例：列出Minio play服务的所有存储桶。*
+*示例：列出MinIO play服务的所有存储桶。*
 
 ```sh
 mc --json ls play
@@ -267,7 +267,7 @@ mc ls play
 ```
 <a name="mb"></a>
 ### `mb`命令 - 创建存储桶
-`mb`命令在对象存储上创建一个新的存储桶。在文件系统，它就和`mkdir -p`命令是一样的。存储桶相当于文件系统中的磁盘或挂载点，不应视为文件夹。Minio对每个​​用户创建的存储桶数量没有限制。
+`mb`命令在对象存储上创建一个新的存储桶。在文件系统，它就和`mkdir -p`命令是一样的。存储桶相当于文件系统中的磁盘或挂载点，不应视为文件夹。MinIO对每个​​用户创建的存储桶数量没有限制。
 在Amazon S3上，每个帐户被限制为100个存储桶。有关更多信息，请参阅[S3上的存储桶限制和限制](http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) 。
 
 ```sh
@@ -305,7 +305,7 @@ FLAGS:
 
 ```sh
 mc cat play/mybucket/myobject.txt
-Hello Minio!!
+Hello MinIO!!
 ```
 <a name="pipe"></a>
 ### `pipe`命令 - Pipe到对象
@@ -578,7 +578,7 @@ mc watch ~/Photos
 
 <a name="events"></a>
 ### `events`命令 - 管理存储桶事件通知。
-``events``提供了一种方便的配置存储桶的各种类型事件通知的方式。Minio事件通知可以配置成使用 AMQP，Redis，ElasticSearch，NATS和PostgreSQL服务。Minio configuration提供了如何配置的更多细节。
+``events``提供了一种方便的配置存储桶的各种类型事件通知的方式。MinIO事件通知可以配置成使用 AMQP，Redis，ElasticSearch，NATS和PostgreSQL服务。MinIO configuration提供了如何配置的更多细节。
 
 ```sh
 用法：
@@ -723,7 +723,7 @@ FLAGS:
 
 *示例： 管理配置文件*
 
-添加Minio服务的access和secret key到配置文件，注意，shell的history特性可能会记录这些信息，从而带来安全隐患。在`bash` shell,使用`set -o`和`set +o`来关闭和开启history特性。
+添加MinIO服务的access和secret key到配置文件，注意，shell的history特性可能会记录这些信息，从而带来安全隐患。在`bash` shell,使用`set -o`和`set +o`来关闭和开启history特性。
 
 ```sh
 set +o history

--- a/docs/zh_CN/minio-client-complete-guide.md
+++ b/docs/zh_CN/minio-client-complete-guide.md
@@ -71,7 +71,7 @@ mc.exe --help
 ```
 
 ### 通过源码安装
-通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从[minio-client](https://min.io/downloads/#minio-client)下载官方版本。
+通过源码安装仅适用于开发人员和高级用户。`mc update`命令不支持基于源码安装的更新通知。请从[minio-client](https://min.io/download/#minio-client)下载官方版本。
 
 如果您没有Golang环境，请按照 [如何安装Golang](https://docs.min.io/docs/how-to-install-golang)。
 

--- a/docs/zh_CN/minio-client-configuration-files.md
+++ b/docs/zh_CN/minio-client-configuration-files.md
@@ -1,9 +1,9 @@
-# Minio Client配置文件指南 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# MinIO Client配置文件指南 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/minio/minio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-本文我们将详细介绍Minio Client的配置文件。
+本文我们将详细介绍MinIO Client的配置文件。
 
-## Minio Client配置目录
-Minio Client配置信息存储在``.mc``文件夹，它是用户home目录下的一个隐藏文件夹。
+## MinIO Client配置目录
+MinIO Client配置信息存储在``.mc``文件夹，它是用户home目录下的一个隐藏文件夹。
 
 **这就是配置文件夹的目录结构：**
 
@@ -21,7 +21,7 @@ tree ~/.mc
 ``session``目录保存所有不完整上传或镜像的元数据信息。你可以运行`mc session list``列出这些信息。
 
 #### ``config.json``
-config.json是Minio Client的配置文件，它在安装并启动Minio后生成。我们通过``mc config host``添加的所有凭证，endpoint信息都存储在这里。
+config.json是MinIO Client的配置文件，它在安装并启动MinIO后生成。我们通过``mc config host``添加的所有凭证，endpoint信息都存储在这里。
 
 ```sh
 cat config.json 
@@ -64,16 +64,16 @@ cat config.json
 
 ``version``代表的是这个文件的版本。
 
-``hosts``存储将被Minio Client使用的认证证书。
+``hosts``存储将被MinIO Client使用的认证证书。
 
 #### ``config.json.old``
 这个文件保存了以前的配置文件版本细节。
 
 #### ``share``目录
-``share``目录保存Minio Client ``mc share``命令使用的所有对象的上传和下载URL的元数据信息。
+``share``目录保存MinIO Client ``mc share``命令使用的所有对象的上传和下载URL的元数据信息。
 
 ## 了解更多
-* [Minio Client完全指南](https://docs.minio.io/docs/minio-client-complete-guide)
+* [MinIO Client完全指南](https://docs.min.io/docs/minio-client-complete-guide)
 
 
 


### PR DESCRIPTION
Official company name `Minio` became `MinIO`. 
This change required our documentation to be modified for all references to the old name, `Minio` as `MinIO` and the links `....://xxx.minio.io` as `....://xxx.min.io` in mc documents.

## Description of the change
Here are the changes done in all `../docs/*.md` files.

Used Visual Studio Code Editor regular expressions to find and replace those patterns that match the desired text. Here are the two regular expressions used to complete the job in 2 steps:

1. Set `files to include` to `*.md`, choose `Match Case` and `Use Regular Expression` and replace the links using the following regular expressions:

| Find | Replace |
| ------ | ----------- |
| (//(slack\|docs)\\.\|//)minio\\.io | $1min.io |

The above regular expression, as can be seen, only replaced the links that start with either `slack` or `docs` or nothing before `minio.io`. That excluded `dl.minio.io` and `blog.minio.io` since their `min.io` url versions have not been setup yet.

2. 
| Find | Replace |
| ------ | ----------- |
| \bMinio\b | MinIO |
