### PR TITLE
Adds missing codebase MinIO and min.io changes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,10 +6,10 @@
 #
 # For explanation on this file format: man git-shortlog
 
-Anand Babu (AB) Periasamy <ab@minio.io> Anand Babu (AB) Periasamy <abperiasamy@users.noreply.github.com>
-Anand Babu (AB) Periasamy <ab@minio.io> <ab@unlocksmith.org>
+Anand Babu (AB) Periasamy <ab@min.io> Anand Babu (AB) Periasamy <abperiasamy@users.noreply.github.com>
+Anand Babu (AB) Periasamy <ab@min.io> <ab@unlocksmith.org>
 Anis Elleuch <vadmeste@gmail.com>
-Frederick F. Kautz IV <fkautz@minio.io> <fkautz@alumni.cmu.edu>
-Harshavardhana <harsha@minio.io> <harsha@harshavardhana.net>
-Krishna Srinivas <krishna@minio.io> <krishna.srinivas@gmail.com>
+Frederick F. Kautz IV <fkautz@min.io> <fkautz@alumni.cmu.edu>
+Harshavardhana <harsha@min.io> <harsha@harshavardhana.net>
+Krishna Srinivas <krishna@min.io> <krishna.srinivas@gmail.com>
 Bosky <bosky@helpshift.com>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12-alpine
 
-LABEL maintainer="Minio Inc <dev@minio.io>"
+LABEL maintainer="MinIO Inc <dev@min.io>"
 
 ENV GOPATH /go
 ENV CGO_ENABLED 0

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,11 +1,11 @@
 FROM alpine:3.9
 
-MAINTAINER Minio Inc <dev@minio.io>
+MAINTAINER MinIO Inc <dev@min.io>
 
 RUN \
     apk add --no-cache ca-certificates && \
     apk add --no-cache --virtual .build-deps curl && \
-    curl https://dl.minio.io/client/mc/release/linux-amd64/mc > /usr/bin/mc && \
+    curl https://dl.min.io/client/mc/release/linux-amd64/mc > /usr/bin/mc && \
     chmod +x /usr/bin/mc && apk del .build-deps
 
 ENTRYPOINT ["mc"]

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ spelling:
 	@${GOPATH}/bin/misspell -error `find pkg/`
 	@${GOPATH}/bin/misspell -error `find docs/`
 
-# Builds minio, runs the verifiers then runs the tests.
+# Builds MinIO, runs the verifiers then runs the tests.
 check: test
 test: verifiers build
 	@echo "Running unit tests"
@@ -55,15 +55,15 @@ test: verifiers build
 	@(env bash $(PWD)/functional-tests.sh)
 
 coverage: build
-	@echo "Running all coverage for minio"
+	@echo "Running all coverage for MinIO"
 	@(env bash $(PWD)/buildscripts/go-coverage.sh)
 
-# Builds minio locally.
+# Builds MinIO locally.
 build: checks
-	@echo "Building minio binary to './mc'"
+	@echo "Building MinIO binary to './mc'"
 	@GO111MODULE=on GO_FLAGS="" CGO_ENABLED=0 go build -tags kqueue --ldflags $(BUILD_LDFLAGS) -o $(PWD)/mc
 
-# Builds minio and installs it to $GOPATH/bin.
+# Builds MinIO and installs it to $GOPATH/bin.
 install: build
 	@echo "Installing mc binary to '$(GOPATH)/bin/mc'"
 	@mkdir -p $(GOPATH)/bin && cp -uf $(PWD)/mc $(GOPATH)/bin/mc

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,9 @@
-Minio Client (C) 2014, 2015 Minio, Inc.
+MinIO Client (C) 2014, 2015 MinIO, Inc.
 
-This product includes software developed at Minio, Inc.
-(https://minio.io/).
+This product includes software developed at MinIO, Inc.
+(https://min.io/).
 
-The Minio project contains unmodified/modified subcomponents too with
+The MinIO project contains unmodified/modified subcomponents too with
 separate copyright notices and license terms. Your use of the source
 code for the these subcomponents is subject to the terms and conditions
 of the following licenses.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rm       remove objects
 event    manage object notifications
 watch    watch for object events
 policy   manage anonymous access to objects
-admin    manage minio servers
+admin    manage MinIO servers
 session  manage saved sessions for cp command
 config   manage mc configuration file
 update   check for a new software update

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ mc --help
 ### Binary Download
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc |
-||64-bit PPC|https://dl.minio.io/client/mc/release/linux-ppc64le/mc |
+|GNU/Linux|64-bit Intel|https://dl.min.io/client/mc/release/linux-amd64/mc |
+||64-bit PPC|https://dl.min.io/client/mc/release/linux-ppc64le/mc |
 
 ```sh
-wget https://dl.minio.io/client/mc/release/linux-amd64/mc
+wget https://dl.min.io/client/mc/release/linux-amd64/mc
 chmod +x mc
 ./mc --help
 ```
@@ -75,7 +75,7 @@ chmod +x mc
 ### Binary Download
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|Microsoft Windows|64-bit Intel|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe |
+|Microsoft Windows|64-bit Intel|https://dl.min.io/client/mc/release/windows-amd64/mc.exe |
 
 ```sh
 mc.exe --help
@@ -156,11 +156,11 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 NOTE: Google Cloud Storage only supports Legacy Signature Version 2, so you have to pick - S3v2
 
 ## Test Your Setup
-`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`mc` is pre-configured with https://play.min.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
-List all buckets from https://play.minio.io:9000
+List all buckets from https://play.min.io:9000
 
 ```sh
 mc ls play

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -58,7 +58,7 @@ mc --help
 ### 下载二进制文件
 | 平台 | CPU架构 | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc |
+|GNU/Linux|64-bit Intel|https://dl.min.io/client/mc/release/linux-amd64/mc |
 
 ```sh
 chmod +x mc
@@ -69,7 +69,7 @@ chmod +x mc
 ### 下载二进制文件
 | 平台 | CPU架构 | URL |
 | ---------- | -------- |------|
-|Microsoft Windows|64-bit Intel|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe |
+|Microsoft Windows|64-bit Intel|https://dl.min.io/client/mc/release/windows-amd64/mc.exe |
 
 ```sh
 mc.exe --help
@@ -121,11 +121,11 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 注意：Google云存储只支持旧版签名版本V2，所以你需要选择S3v2。
 
 ## 验证
-`mc`预先配置了云存储服务URL：https://play.minio.io:9000，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
+`mc`预先配置了云存储服务URL：https://play.min.io:9000，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
 
 *示例:*
 
-列出https://play.minio.io:9000上的所有存储桶。
+列出https://play.min.io:9000上的所有存储桶。
 
 ```sh
 mc ls play

--- a/buildscripts/checkdeps.sh
+++ b/buildscripts/checkdeps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Minio Client, (C) 2015, 2016, 2017, 2018, 2019 Minio, Inc.
+# MinIO Client, (C) 2015, 2016, 2017, 2018, 2019 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ assert_is_supported_os() {
 
 assert_check_golang_env() {
     if ! which go >/dev/null 2>&1; then
-        echo "Cannot find go binary in your PATH configuration, please refer to Go installation document at https://docs.minio.io/docs/how-to-install-golang"
+        echo "Cannot find go binary in your PATH configuration, please refer to Go installation document at https://docs.min.io/docs/how-to-install-golang"
         exit 1
     fi
 

--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -1,7 +1,7 @@
 // +build ignore
 
 /*
- * Minio Client (C) 2014, 2015, 2016, 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2014, 2015, 2016, 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/access-perms.go
+++ b/cmd/access-perms.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/accounting-reader.go
+++ b/cmd/accounting-reader.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Get server configuration of a Minio server/cluster.
+  1. Get server configuration of a MinIO server/cluster.
      $ {{.HelpName}} play/
 
 `,
@@ -82,7 +82,7 @@ func mainAdminConfigGet(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -24,7 +24,7 @@ import (
 
 var adminConfigGetCmd = cli.Command{
 	Name:   "get",
-	Usage:  "get config of a minio server/cluster",
+	Usage:  "get config of a MinIO server/cluster",
 	Before: setGlobalsFromContext,
 	Action: mainAdminConfigGet,
 	Flags:  globalFlags,

--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Set server configuration of a Minio server/cluster.
+  1. Set server configuration of a MinIO server/cluster.
      $ cat myconfig | {{.HelpName}} myminio/
 
 `,
@@ -59,12 +59,12 @@ func (u configSetMessage) String() (msg string) {
 	// Print the general set config status
 	if u.setConfigStatus {
 		msg += console.Colorize("SetConfigSuccess",
-			"Setting new Minio configuration file has been successful.\n")
+			"Setting new MinIO configuration file has been successful.\n")
 		msg += console.Colorize("SetConfigSuccess",
 			"Please restart your server with `mc admin service restart`.\n")
 	} else {
 		msg += console.Colorize("SetConfigFailure",
-			"Setting new Minio configuration file has failed.\n")
+			"Setting new MinIO configuration file has failed.\n")
 	}
 	return
 }
@@ -103,7 +103,7 @@ func mainAdminConfigSet(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -28,7 +28,7 @@ import (
 
 var adminConfigSetCmd = cli.Command{
 	Name:   "set",
-	Usage:  "set new config file to a minio server/cluster.",
+	Usage:  "set new config file to a MinIO server/cluster.",
 	Before: setGlobalsFromContext,
 	Action: mainAdminConfigSet,
 	Flags:  globalFlags,

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-credential.go
+++ b/cmd/admin-credential.go
@@ -43,7 +43,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
     1. Set new **admin** credential of a MinIO server represented by its alias 'alias'.
-       $ {{.HelpName}} alias/ minio minio123
+       $ {{.HelpName}} alias minio minio123
 
 `,
 }

--- a/cmd/admin-credential.go
+++ b/cmd/admin-credential.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016, 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2016, 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-    1. Set new **admin** credential of a Minio server represented by its alias 'alias'.
+    1. Set new **admin** credential of a MinIO server represented by its alias 'alias'.
        $ {{.HelpName}} alias/ minio minio123
 
 `,
@@ -65,15 +65,15 @@ func mainAdminCreds(ctx *cli.Context) error {
 	args := ctx.Args()
 	// TODO: if accessKey and secretKey are not supplied we should
 	// display the existing credential. This needs GetCredential
-	// support from Minio server.
+	// support from MinIO server.
 	aliasedURL := args.First()
 	accessKey, secretKey := args.Get(1), args.Get(2)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 
-	// Change the credential of the specified Minio server
+	// Change the credential of the specified MinIO server
 	e := client.SetAdminCredentials(accessKey, secretKey)
 	fatalIf(probe.NewError(e), "Unable to set new credential to '"+aliasedURL+"'.")
 

--- a/cmd/admin-heal-result-item.go
+++ b/cmd/admin-heal-result-item.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-heal-ui.go
+++ b/cmd/admin-heal-ui.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,10 @@ SCAN MODES:
    deep            : Heal objects which are missing on one or more disks. Also heal objects with silent data corruption.
 
 EXAMPLES:
-    1. To format newly replaced disks in a Minio server with alias 'play'
+    1. To format newly replaced disks in a MinIO server with alias 'play'
        $ {{.HelpName}} play
 
-    2. Heal 'testbucket' in a Minio server with alias 'play'
+    2. Heal 'testbucket' in a MinIO server with alias 'play'
        $ {{.HelpName}} play/testbucket/
 
     3. Heal all objects under 'dir' prefix
@@ -155,7 +155,7 @@ func mainAdminHeal(ctx *cli.Context) error {
 	console.SetColor("HealUpdateUI", color.New(color.FgYellow, color.Bold))
 	console.SetColor("HealStopped", color.New(color.FgGreen, color.Bold))
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	if err != nil {
 		fatalIf(err.Trace(aliasedURL), "Cannot initialize admin client.")

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -63,7 +63,7 @@ var adminHealFlags = []cli.Flag{
 
 var adminHealCmd = cli.Command{
 	Name:            "heal",
-	Usage:           "heal disks, buckets and objects on minio server",
+	Usage:           "heal disks, buckets and objects on MinIO server",
 	Action:          mainAdminHeal,
 	Before:          setGlobalsFromContext,
 	Flags:           append(adminHealFlags, globalFlags...),

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016, 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2016, 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Get server information of the 'play' Minio server.
+  1. Get server information of the 'play' MinIO server.
        $ {{.HelpName}} play/
 
 `,
@@ -219,7 +219,7 @@ func mainAdminInfo(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -38,7 +38,7 @@ var (
 
 var adminInfoCmd = cli.Command{
 	Name:   "info",
-	Usage:  "display minio server information",
+	Usage:  "display MinIO server information",
 	Action: mainAdminInfo,
 	Before: setGlobalsFromContext,
 	Flags:  append(adminInfoFlags, globalFlags...),

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -24,7 +24,7 @@ var (
 
 var adminCmd = cli.Command{
 	Name:            "admin",
-	Usage:           "manage minio servers",
+	Usage:           "manage MinIO servers",
 	Action:          mainAdmin,
 	HideHelpCommand: true,
 	Before:          setGlobalsFromContext,

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-monitor.go
+++ b/cmd/admin-monitor.go
@@ -134,7 +134,7 @@ func mainAdminMonitor(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new minio admin client
+	// Create a new MinIO admin client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-monitor.go
+++ b/cmd/admin-monitor.go
@@ -164,7 +164,7 @@ func mainAdminMonitor(ctx *cli.Context) error {
 		}
 		return nil
 	}
-	// Fetch info of all CPU loads (all minio server instances)
+	// Fetch info of all CPU loads (all MinIO server instances)
 	cpuLoads, e := client.ServerCPULoadInfo()
 	if err := processErr(e); err != nil {
 		// exit immediately if error encountered

--- a/cmd/admin-monitor.go
+++ b/cmd/admin-monitor.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-policy-add.go
+++ b/cmd/admin-policy-add.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ USAGE:
   {{.HelpName}} TARGET POLICYNAME POLICYFILE
 
 POLICYNAME:
-  Name of the canned policy on Minio server.
+  Name of the canned policy on MinIO server.
 
 POLICYFILE:
   Name of the policy file associated with the policy name.
@@ -108,7 +108,7 @@ func mainAdminPolicyAdd(ctx *cli.Context) error {
 	policy, e := ioutil.ReadFile(args.Get(2))
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to get policy")
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-policy-list.go
+++ b/cmd/admin-policy-list.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,16 +36,16 @@ USAGE:
   {{.HelpName}} TARGET POLICYNAME
 
 POLICYNAME:
-  Name of the canned policy on Minio server.
+  Name of the canned policy on MinIO server.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. List all policies on Minio server.
+  1. List all policies on MinIO server.
      $ {{.HelpName}} myminio
 
-  2. List only one policy on Minio server.
+  2. List only one policy on MinIO server.
      $ {{.HelpName}} myminio writeonly
 `,
 }
@@ -68,7 +68,7 @@ func mainAdminPolicyList(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-policy-remove.go
+++ b/cmd/admin-policy-remove.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,13 @@ USAGE:
   {{.HelpName}} TARGET POLICYNAME
 
 POLICYNAME:
-  Name of the canned policy on Minio server.
+  Name of the canned policy on MinIO server.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove 'writeonly' policy on Minio server.
+  1. Remove 'writeonly' policy on MinIO server.
      $ {{.HelpName}} myminio writeonly
 `,
 }
@@ -64,7 +64,7 @@ func mainAdminPolicyRemove(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-policy.go
+++ b/cmd/admin-policy.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-profile-start.go
+++ b/cmd/admin-profile-start.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ func mainAdminProfileStart(ctx *cli.Context) error {
 
 	profilerType := ctx.String("type")
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	if err != nil {
 		fatalIf(err.Trace(aliasedURL), "Cannot initialize admin client.")

--- a/cmd/admin-profile-stop.go
+++ b/cmd/admin-profile-stop.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ func mainAdminProfileStop(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	if err != nil {
 		fatalIf(err.Trace(aliasedURL), "Cannot initialize admin client.")

--- a/cmd/admin-profile.go
+++ b/cmd/admin-profile.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -29,7 +29,7 @@ import (
 
 var adminServiceRestartCmd = cli.Command{
 	Name:   "restart",
-	Usage:  "restart minio server",
+	Usage:  "restart MinIO server",
 	Action: mainAdminServiceRestart,
 	Before: setGlobalsFromContext,
 	Flags:  globalFlags,

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-    1. Restart Minio server represented by its alias 'play'.
+    1. Restart MinIO server represented by its alias 'play'.
        $ {{.HelpName}} play/
 
 `,
@@ -114,7 +114,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 
-	// Restart the specified Minio server
+	// Restart the specified MinIO server
 	fatalIf(probe.NewError(client.ServiceSendAction(
 		madmin.ServiceActionValueRestart)), "Cannot restart server.")
 
@@ -127,7 +127,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 	// Sleep for 6 seconds and then check if the server is online.
 	time.Sleep(6 * time.Second)
 
-	// Fetch the service status of the specified Minio server
+	// Fetch the service status of the specified MinIO server
 	_, e := client.ServiceStatus()
 
 	if e != nil {

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-    1. Check if the 'play' Minio server is online and show its uptime.
+    1. Check if the 'play' MinIO server is online and show its uptime.
        $ {{.HelpName}} play/
 `,
 }
@@ -107,11 +107,11 @@ func mainAdminServiceStatus(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 
-	// Fetch the service status of the specified Minio server
+	// Fetch the service status of the specified MinIO server
 	st, e := client.ServiceStatus()
 
 	// Check the availability of the server: online or offline. A server is considered

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -34,7 +34,7 @@ var (
 
 var adminServiceStatusCmd = cli.Command{
 	Name:   "status",
-	Usage:  "get the status of minio server",
+	Usage:  "get the status of MinIO server",
 	Action: mainAdminServiceStatus,
 	Before: setGlobalsFromContext,
 	Flags:  append(adminServiceStatusFlags, globalFlags...),

--- a/cmd/admin-service-stop.go
+++ b/cmd/admin-service-stop.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-    1. Stop Minio server represented by its alias 'play'.
+    1. Stop MinIO server represented by its alias 'play'.
        $ {{.HelpName}} play/
 
 `,
@@ -88,7 +88,7 @@ func mainAdminServiceStop(ctx *cli.Context) error {
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 
-	// Stop the specified Minio server
+	// Stop the specified MinIO server
 	pErr := client.ServiceSendAction(madmin.ServiceActionValueStop)
 	fatalIf(probe.NewError(pErr), "Cannot stop server.")
 

--- a/cmd/admin-service-stop.go
+++ b/cmd/admin-service-stop.go
@@ -27,7 +27,7 @@ import (
 
 var adminServiceStopCmd = cli.Command{
 	Name:   "stop",
-	Usage:  "stop minio server",
+	Usage:  "stop MinIO server",
 	Action: mainAdminServiceStop,
 	Before: setGlobalsFromContext,
 	Flags:  globalFlags,

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016, 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2016, 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -20,7 +20,7 @@ import "github.com/minio/cli"
 
 var adminServiceCmd = cli.Command{
 	Name:            "service",
-	Usage:           "stop, restart or get status of minio server",
+	Usage:           "stop, restart or get status of MinIO server",
 	Action:          mainAdminService,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,

--- a/cmd/admin-top-locks.go
+++ b/cmd/admin-top-locks.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ func mainAdminTopLocks(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-top.go
+++ b/cmd/admin-top.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/admin-user-add-policy.go
+++ b/cmd/admin-user-add-policy.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,13 @@ USAGE:
   {{.HelpName}} TARGET USERNAME POLICYNAME
 
 POLICYNAME:
-  Name of the canned policy created on Minio server.
+  Name of the canned policy created on MinIO server.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Set a policy 'writeonly' to 'foobar' on Minio server.
+  1. Set a policy 'writeonly' to 'foobar' on MinIO server.
      $ {{.HelpName}} myminio foobar writeonly
 `,
 }
@@ -64,7 +64,7 @@ func mainAdminUserPolicy(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-user-add.go
+++ b/cmd/admin-user-add.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,13 +37,13 @@ USAGE:
   {{.HelpName}} TARGET ACCESSKEY SECRETKEY POLICYNAME
 
 POLICYNAME:
-  Name of the policy available on Minio server.
+  Name of the policy available on MinIO server.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Add a new user 'foobar' to Minio server with policy 'writeonly'.
+  1. Add a new user 'foobar' to MinIO server with policy 'writeonly'.
      $ set -o history
      $ {{.HelpName}} myminio foobar foo12345 writeonly
      $ set +o history
@@ -112,7 +112,7 @@ func mainAdminUserAdd(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-user-disable.go
+++ b/cmd/admin-user-disable.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Disable a user 'foobar' on Minio server.
+  1. Disable a user 'foobar' on MinIO server.
      $ {{.HelpName}} myminio foobar
 `,
 }
@@ -62,7 +62,7 @@ func mainAdminUserDisable(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-user-enable.go
+++ b/cmd/admin-user-enable.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Enable a disabled user 'foobar' on Minio server.
+  1. Enable a disabled user 'foobar' on MinIO server.
      $ {{.HelpName}} myminio foobar
 `,
 }
@@ -62,7 +62,7 @@ func mainAdminUserEnable(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-user-list.go
+++ b/cmd/admin-user-list.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. List all users on Minio server.
+  1. List all users on MinIO server.
      $ {{.HelpName}} myminio
 `,
 }
@@ -65,7 +65,7 @@ func mainAdminUserList(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-user-remove.go
+++ b/cmd/admin-user-remove.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove a user 'foobar' on Minio server.
+  1. Remove a user 'foobar' on MinIO server.
      $ {{.HelpName}} myminio foobar
 `,
 }
@@ -61,7 +61,7 @@ func mainAdminUserRemove(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	// Create a new Minio Admin Client
+	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Cannot get a configured admin connection.")
 

--- a/cmd/admin-user.go
+++ b/cmd/admin-user.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/build-constants.go
+++ b/cmd/build-constants.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client, (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/cat_test.go
+++ b/cmd/cat_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -96,7 +96,7 @@ func createCAsDir() *probe.Error {
 	return nil
 }
 
-// mustGetCAFiles - get the list of the CA certificates stored in minio config dir
+// mustGetCAFiles - get the list of the CA certificates stored in MinIO config dir
 func mustGetCAFiles() (caCerts []string) {
 	CAsDir := mustGetCAsDir()
 	caFiles, _ := ioutil.ReadDir(CAsDir)
@@ -115,7 +115,7 @@ func mustGetSystemCertPool() *x509.CertPool {
 	return pool
 }
 
-// loadRootCAs fetches CA files provided in minio config and adds them to globalRootCAs
+// loadRootCAs fetches CA files provided in MinIO config and adds them to globalRootCAs
 // Currently under Windows, there is no way to load system + user CAs at the same time
 func loadRootCAs() {
 	caFiles := mustGetCAFiles()

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -44,7 +44,7 @@ func isCertsDirExists() bool {
 	return true
 }
 
-// createCertsDir - create minio client certs folder
+// createCertsDir - create MinIO Client certs folder
 func createCertsDir() *probe.Error {
 	p, err := getCertsDir()
 	if err != nil {
@@ -84,7 +84,7 @@ func isCAsDirExists() bool {
 	return true
 }
 
-// createCAsDir - create minio client CAs folder
+// createCAsDir - create MinIO Client CAs folder
 func createCAsDir() *probe.Error {
 	p, err := getCAsDir()
 	if err != nil {

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -63,7 +63,7 @@ func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 		var api *madmin.AdminClient
 		var found bool
 		if api, found = clientCache[confSum]; !found {
-			// Not found. Instantiate a new minio
+			// Not found. Instantiate a new MinIO
 			var e error
 			api, e = madmin.New(hostName, config.AccessKey, config.SecretKey, useTLS)
 			if e != nil {

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -99,7 +99,7 @@ func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 			// Set app info.
 			api.SetAppInfo(config.AppName, config.AppVersion)
 
-			// Cache the new minio client with hash of config as key.
+			// Cache the new MinIO Client with hash of config as key.
 			clientCache[confSum] = api
 		}
 

--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-fs_darwin.go
+++ b/cmd/client-fs_darwin.go
@@ -1,7 +1,7 @@
 // +build darwin
 
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-fs_freebsd.go
+++ b/cmd/client-fs_freebsd.go
@@ -1,7 +1,7 @@
 // +build freebsd
 
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-fs_linux.go
+++ b/cmd/client-fs_linux.go
@@ -1,7 +1,7 @@
 // +build linux
 
 /*
- * Minio Client (C) 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-fs_other.go
+++ b/cmd/client-fs_other.go
@@ -1,7 +1,7 @@
 // +build solaris openbsd
 
 /*
- * Minio Client (C) 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-fs_windows.go
+++ b/cmd/client-fs_windows.go
@@ -1,7 +1,7 @@
 // +build windows
 
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/client-s3-trace_v2.go
+++ b/cmd/client-s3-trace_v2.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client-s3-trace_v4.go
+++ b/cmd/client-s3-trace_v4.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015, 2016, 2017, 2018 Minio, Inc.
+ * MinIO Client (C) 2015, 2016, 2017, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -141,7 +141,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			if strings.ToUpper(config.Signature) == "S3V2" {
 				creds = credentials.NewStaticV2(config.AccessKey, config.SecretKey, "")
 			}
-			// Not found. Instantiate a new minio
+			// Not found. Instantiate a new MinIO
 			var e error
 
 			options := minio.Options{

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -217,7 +217,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			// Set app info.
 			api.SetAppInfo(config.AppName, config.AppVersion)
 
-			// Cache the new minio client with hash of config as key.
+			// Cache the new MinIO Client with hash of config as key.
 			clientCache[confSum] = api
 		}
 

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ type clientURLType int
 
 // enum types
 const (
-	objectStorage = iota // Minio and S3 compatible cloud storage
+	objectStorage = iota // MinIO and S3 compatible cloud storage
 	fileSystem           // POSIX compatible file systems
 )
 

--- a/cmd/client-url_test.go
+++ b/cmd/client-url_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/minio/mc/pkg/probe"
-	minio "github.com/minio/minio-go"
+	"github.com/minio/minio-go"
 	"github.com/minio/minio-go/pkg/encrypt"
 )
 

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-fix.go
+++ b/cmd/config-fix.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ func fixConfigV6ForHosts() {
 		// If host entry does not contain "http(s)", introduce a new entry and delete the old one.
 		if host == "s3.amazonaws.com" || host == "storage.googleapis.com" ||
 			host == "localhost:9000" || host == "127.0.0.1:9000" ||
-			host == "play.minio.io:9000" || host == "dl.minio.io:9000" {
+			host == "play.min.io:9000" || host == "dl.min.io:9000" {
 			console.Infoln("Found broken host entries, replacing " + host + " with https://" + host + ".")
 			url.Host = host
 			url.Scheme = "https"

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-host-list.go
+++ b/cmd/config-host-list.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-host-remove.go
+++ b/cmd/config-host-remove.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-host.go
+++ b/cmd/config-host.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -18,7 +18,7 @@ package cmd
 
 import "github.com/minio/cli"
 
-//   Configure minio client
+//   Configure MinIO Client
 //
 //   ----
 //   NOTE: that the configure command only writes values to the config file.
@@ -35,7 +35,7 @@ var (
 
 var configCmd = cli.Command{
 	Name:            "config",
-	Usage:           "configure minio client",
+	Usage:           "configure MinIO client",
 	Action:          mainConfig,
 	Before:          setGlobalsFromContext,
 	HideHelpCommand: true,

--- a/cmd/config-migrate.go
+++ b/cmd/config-migrate.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -401,7 +401,7 @@ func migrateConfigV6ToV7() {
 }
 
 // Migrate config version `7` to `8'. Remove hosts
-// 'play.minio.io:9002' and 'dl.minio.io:9000'.
+// 'play.min.io:9002' and 'dl.min.io:9000'.
 func migrateConfigV7ToV8() {
 	if !isMcConfigExists() {
 		return

--- a/cmd/config-old.go
+++ b/cmd/config-old.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,7 +184,7 @@ func newConfigV7() *configV7 {
 }
 
 func (c *configV7) loadDefaults() {
-	// Minio server running locally.
+	// MinIO server running locally.
 	c.setHost("local", hostConfigV7{
 		URL:       "http://localhost:9000",
 		AccessKey: "",
@@ -208,25 +208,25 @@ func (c *configV7) loadDefaults() {
 		API:       "S3v2",
 	})
 
-	// Minio anonymous server for demo.
+	// MinIO anonymous server for demo.
 	c.setHost("play", hostConfigV7{
-		URL:       "https://play.minio.io:9000",
+		URL:       "https://play.min.io:9000",
 		AccessKey: "",
 		SecretKey: "",
 		API:       "S3v4",
 	})
 
-	// Minio demo server with public secret and access keys.
+	// MinIO demo server with public secret and access keys.
 	c.setHost("player", hostConfigV7{
-		URL:       "https://play.minio.io:9002",
+		URL:       "https://play.min.io:9002",
 		AccessKey: "Q3AM3UQ867SPQQA43P2F",
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",
 	})
 
-	// Minio public download service.
+	// MinIO public download service.
 	c.setHost("dl", hostConfigV7{
-		URL:       "https://dl.minio.io:9000",
+		URL:       "https://dl.min.io:9000",
 		AccessKey: "",
 		SecretKey: "",
 		API:       "S3v4",
@@ -271,7 +271,7 @@ func (c *configV8) setHost(alias string, cfg hostConfigV8) {
 
 // load default values for missing entries.
 func (c *configV8) loadDefaults() {
-	// Minio server running locally.
+	// MinIO server running locally.
 	c.setHost("local", hostConfigV8{
 		URL:       "http://localhost:9000",
 		AccessKey: "",
@@ -295,9 +295,9 @@ func (c *configV8) loadDefaults() {
 		API:       "S3v2",
 	})
 
-	// Minio anonymous server for demo.
+	// MinIO anonymous server for demo.
 	c.setHost("play", hostConfigV8{
-		URL:       "https://play.minio.io:9000",
+		URL:       "https://play.min.io:9000",
 		AccessKey: "Q3AM3UQ867SPQQA43P2F",
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015, 2016 Minio, Inc.
+ * MinIO Client (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-utils_test.go
+++ b/cmd/config-utils_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config-v9.go
+++ b/cmd/config-v9.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ func (c *configV9) setHost(alias string, cfg hostConfigV9) {
 
 // load default values for missing entries.
 func (c *configV9) loadDefaults() {
-	// Minio server running locally.
+	// MinIO server running locally.
 	c.setHost("local", hostConfigV9{
 		URL:       "http://localhost:9000",
 		AccessKey: "",
@@ -94,9 +94,9 @@ func (c *configV9) loadDefaults() {
 		Lookup:    "dns",
 	})
 
-	// Minio anonymous server for demo.
+	// MinIO anonymous server for demo.
 	c.setHost("play", hostConfigV9{
-		URL:       "https://play.minio.io:9000",
+		URL:       "https://play.min.io:9000",
 		AccessKey: "Q3AM3UQ867SPQQA43P2F",
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",

--- a/cmd/config-validate.go
+++ b/cmd/config-validate.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ func validateConfigVersion(config *configV9) (bool, string) {
 	return true, ""
 }
 
-// Verifies the config file of the Minio Client
+// Verifies the config file of the MinIO Client
 func validateConfigFile(config *configV9) (bool, []string) {
 	ok, err := validateConfigVersion(config)
 	var validationSuccessful = true

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -32,12 +32,12 @@ import (
 // mcCustomConfigDir contains the whole path to config dir. Only access via get/set functions.
 var mcCustomConfigDir string
 
-// setMcConfigDir - set a custom minio client config folder.
+// setMcConfigDir - set a custom MinIO Client config folder.
 func setMcConfigDir(configDir string) {
 	mcCustomConfigDir = configDir
 }
 
-// getMcConfigDir - construct minio client config folder.
+// getMcConfigDir - construct MinIO Client config folder.
 func getMcConfigDir() (string, *probe.Error) {
 	if mcCustomConfigDir != "" {
 		return mcCustomConfigDir, nil
@@ -56,7 +56,7 @@ func getMcConfigDir() (string, *probe.Error) {
 	return configDir, nil
 }
 
-// mustGetMcConfigDir - construct minio client config folder or fail
+// mustGetMcConfigDir - construct MinIO Client config folder or fail
 func mustGetMcConfigDir() (configDir string) {
 	configDir, err := getMcConfigDir()
 	fatalIf(err.Trace(), "Unable to get mcConfigDir.")
@@ -64,7 +64,7 @@ func mustGetMcConfigDir() (configDir string) {
 	return configDir
 }
 
-// createMcConfigDir - create minio client config folder
+// createMcConfigDir - create MinIO Client config folder
 func createMcConfigDir() *probe.Error {
 	p, err := getMcConfigDir()
 	if err != nil {
@@ -76,7 +76,7 @@ func createMcConfigDir() *probe.Error {
 	return nil
 }
 
-// getMcConfigPath - construct minio client configuration path
+// getMcConfigPath - construct MinIO Client configuration path
 func getMcConfigPath() (string, *probe.Error) {
 	if mcCustomConfigDir != "" {
 		return filepath.Join(mcCustomConfigDir, globalMCConfigFile), nil

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,19 +92,19 @@ EXAMPLES:
    1. Copy a list of objects from local file system to Amazon S3 cloud storage.
       $ {{.HelpName}} Music/*.ogg s3/jukebox/
 
-   2. Copy a folder recursively from Minio cloud storage to Amazon S3 cloud storage.
+   2. Copy a folder recursively from MinIO cloud storage to Amazon S3 cloud storage.
       $ {{.HelpName}} --recursive play/mybucket/burningman2011/ s3/mybucket/
 
-   3. Copy multiple local folders recursively to Minio cloud storage.
+   3. Copy multiple local folders recursively to MinIO cloud storage.
       $ {{.HelpName}} --recursive backup/2014/ backup/2015/ play/archive/
 
    4. Copy a bucket recursively from aliased Amazon S3 cloud storage to local filesystem on Windows.
       $ {{.HelpName}} --recursive s3\documents\2014\ C:\Backups\2014
 
-   5. Copy files older than 7 days and 10 hours from Minio cloud storage to Amazon S3 cloud storage.
+   5. Copy files older than 7 days and 10 hours from MinIO cloud storage to Amazon S3 cloud storage.
       $ {{.HelpName}} --older-than 7d10h play/mybucket/burningman2011/ s3/mybucket/
 
-   6. Copy files newer than 7 days and 10 hours from Minio cloud storage to a local path.
+   6. Copy files newer than 7 days and 10 hours from MinIO cloud storage to a local path.
       $ {{.HelpName}} --newer-than 7d10h play/mybucket/burningman2011/ ~/latest/
 
    7. Copy an object with name containing unicode characters to Amazon S3 cloud storage.
@@ -113,13 +113,13 @@ EXAMPLES:
    8. Copy a local folder with space separated characters to Amazon S3 cloud storage.
       $ {{.HelpName}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
 
-   9. Copy a folder with encrypted objects recursively from Amazon S3 to Minio cloud storage.
+   9. Copy a folder with encrypted objects recursively from Amazon S3 to MinIO cloud storage.
       $ {{.HelpName}} --recursive --encrypt-key "s3/documents/=32byteslongsecretkeymustbegiven1,myminio/documents/=32byteslongsecretkeymustbegiven2" s3/documents/ myminio/documents/
 
-  10. Copy a list of objects from local file system to Minio cloud storage with specified metadata.
+  10. Copy a list of objects from local file system to MinIO cloud storage with specified metadata.
 			$ {{.HelpName}} --attr key1=value1,key2=value2 Music/*.mp4 play/mybucket/
 			
-	11. Copy a folder recursively from Minio cloud storage to Amazon S3 cloud storage with specified metadata.
+	11. Copy a folder recursively from MinIO cloud storage to Amazon S3 cloud storage with specified metadata.
 			$ {{.HelpName}} --attr key1=value1,key2=value2 --recursive play/mybucket/burningman2011/ s3/mybucket/
 
  `,

--- a/cmd/cp-main_test.go
+++ b/cmd/cp-main_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/difference_test.go
+++ b/cmd/difference_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/event-add.go
+++ b/cmd/event-add.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/event-list.go
+++ b/cmd/event-list.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/event-main.go
+++ b/cmd/event-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/event-remove.go
+++ b/cmd/event-remove.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/fs-pathutils_nix.go
+++ b/cmd/fs-pathutils_nix.go
@@ -1,7 +1,7 @@
 // +build !windows
 
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/fs-pathutils_windows.go
+++ b/cmd/fs-pathutils_windows.go
@@ -1,7 +1,7 @@
 // +build windows
 
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/head-main.go
+++ b/cmd/head-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2018 Minio, Inc.
+ * MinIO Client, (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/humanized-duration.go
+++ b/cmd/humanized-duration.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014-2019 Minio, Inc.
+ * MinIO Client (C) 2014-2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2014, 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -329,14 +329,14 @@ func registerApp() *cli.App {
 	app := cli.NewApp()
 	app.Action = func(ctx *cli.Context) {
 		if strings.HasPrefix(ReleaseTag, "RELEASE.") {
-			// Check for new updates from dl.minio.io.
+			// Check for new updates from dl.min.io.
 			checkUpdate(ctx)
 		}
 		cli.ShowAppHelp(ctx)
 	}
 
 	app.HideHelpCommand = true
-	app.Usage = "Minio Client for cloud storage and filesystems."
+	app.Usage = "MinIO Client for cloud storage and filesystems."
 	app.Commands = commands
 	app.Author = "Minio.io"
 	app.Version = ReleaseTag

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -338,7 +338,7 @@ func registerApp() *cli.App {
 	app.HideHelpCommand = true
 	app.Usage = "MinIO Client for cloud storage and filesystems."
 	app.Commands = commands
-	app.Author = "Minio.io"
+	app.Author = "MinIO, Inc."
 	app.Version = ReleaseTag
 	app.Flags = append(mcFlags, globalFlags...)
 	app.CustomAppHelpTemplate = mcHelpTemplate

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/mc_test.go
+++ b/cmd/mc_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015, 2016 Minio, Inc.
+ * MinIO Client, (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 
 EXAMPLES:
-   1. Mirror a bucket recursively from Minio cloud storage to a bucket on Amazon S3 cloud storage.
+   1. Mirror a bucket recursively from MinIO cloud storage to a bucket on Amazon S3 cloud storage.
       $ {{.HelpName}} play/photos/2014 s3/backup-photos
 
    2. Mirror a local folder recursively to Amazon S3 cloud storage.
@@ -126,11 +126,11 @@ EXAMPLES:
    5. Mirror a bucket from aliased Amazon S3 cloud storage to a local folder use '--overwrite' to overwrite destination.
       $ {{.HelpName}} --overwrite s3/miniocloud miniocloud-backup
 
-   6. Mirror a bucket from Minio cloud storage to a bucket on Amazon S3 cloud storage and remove any extraneous
+   6. Mirror a bucket from MinIO cloud storage to a bucket on Amazon S3 cloud storage and remove any extraneous
       files on Amazon S3 cloud storage.
       $ {{.HelpName}} --remove play/photos/2014 s3/backup-photos/2014
 
-   7. Continuously mirror a local folder recursively to Minio cloud storage. '--watch' continuously watches for
+   7. Continuously mirror a local folder recursively to MinIO cloud storage. '--watch' continuously watches for
       new objects, uploads and removes extraneous files on Amazon S3 cloud storage.
       $ {{.HelpName}} --remove --watch /var/lib/backups play/backups
 
@@ -144,7 +144,7 @@ EXAMPLES:
   10. Mirror objects older than 30 days from Amazon S3 bucket test to a local folder.
       $ {{.HelpName}} --older-than 30d s3/test ~/test
 
-  11. Mirror server encrypted objects from Minio cloud storage to a bucket on Amazon S3 cloud storage
+  11. Mirror server encrypted objects from MinIO cloud storage to a bucket on Amazon S3 cloud storage
       $ {{.HelpName}} --encrypt-key "minio/photos=32byteslongsecretkeymustbegiven1,s3/archive=32byteslongsecretkeymustbegiven2" minio/photos/ s3/archive/
 `,
 }

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015, 2016 Minio, Inc.
+ * MinIO Client (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client, (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/pipechan.go
+++ b/cmd/pipechan.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/pipechan_test.go
+++ b/cmd/pipechan_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015, 2016 Minio, Inc.
+ * MinIO Client, (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/pretty-record.go
+++ b/cmd/pretty-record.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/pretty-table.go
+++ b/cmd/pretty-table.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/pretty-table_test.go
+++ b/cmd/pretty-table_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/progress-bar.go
+++ b/cmd/progress-bar.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/runtime-checks.go
+++ b/cmd/runtime-checks.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015, 2016 Minio, Inc.
+ * MinIO Client (C) 2014, 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,6 @@ func checkGoVersion() {
 
 	// Check for minimum version.
 	if !constraints.Check(curVersion) {
-		console.Fatalln(fmt.Sprintf("Please recompile Minio with Golang version %s.", minGoVersion))
+		console.Fatalln(fmt.Sprintf("Please recompile MinIO with Golang version %s.", minGoVersion))
 	}
 }

--- a/cmd/scan-bar.go
+++ b/cmd/scan-bar.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014-2016 Minio, Inc.
+ * MinIO Client (C) 2014-2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-clear.go
+++ b/cmd/session-clear.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-list.go
+++ b/cmd/session-list.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-main.go
+++ b/cmd/session-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015 Minio, Inc.
+ * MinIO Client, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-migrate.go
+++ b/cmd/session-migrate.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-old.go
+++ b/cmd/session-old.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-resume.go
+++ b/cmd/session-resume.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session-v8.go
+++ b/cmd/session-v8.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015, 2016 Minio, Inc.
+ * MinIO Client, (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015 Minio, Inc.
+ * MinIO Client, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/share-db-v1.go
+++ b/cmd/share-db-v1.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/share-list-main.go
+++ b/cmd/share-list-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2015 Minio, Inc.
+ * MinIO Client, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2018 Minio, Inc.
+ * MinIO Client, (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 
 SERIALIZATION OPTIONS:
-   For query serialization options, refer to https://docs.minio.io/docs/minio-client-complete-guide#sql
+   For query serialization options, refer to https://docs.min.io/docs/minio-client-complete-guide#sql
 
 EXAMPLES:
    1. Run a query on a set of objects recursively on AWS S3.
@@ -104,12 +104,12 @@ EXAMPLES:
       $ {{.HelpName}} --encrypt-key "myminio/iot-devices=32byteslongsecretkeymustbegiven1" \
 		      --query "select count(s.power) from S3Object s" myminio/iot-devices/power-ratio-encrypted.csv
 
-   4. Run a query on an object on Minio in gzip format using ; as field delimiter,
+   4. Run a query on an object on MinIO in gzip format using ; as field delimiter,
       newline as record delimiter and file header to be used
       $ {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
 		      --query "select count(s.power) from S3Object" myminio/iot-devices/power-ratio.csv.gz
 
-   5. Run a query on an object on Minio in gzip format using ; as field delimiter,
+   5. Run a query on an object on MinIO in gzip format using ; as field delimiter,
       newline as record delimiter and file header to be used
       $ {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
 							 --json-output "rd=\n\n" --query "select * from S3Object" myminio/iot-devices/data.csv

--- a/cmd/sql-main_test.go
+++ b/cmd/sql-main_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2019 Minio, Inc.
+ * MinIO Client (C) 2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/stat_test.go
+++ b/cmd/stat_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,13 +30,13 @@ func (s *TestSuite) TestParseStat(c *C) {
 		content     clientContent
 		targetAlias string
 	}{
-		{clientContent{URL: *newClientURL("https://play.minio.io:9000/abc"), Size: 0, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Now()},
+		{clientContent{URL: *newClientURL("https://play.min.io:9000/abc"), Size: 0, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Now()},
 			"play"},
-		{clientContent{URL: *newClientURL("https://play.minio.io:9000/testbucket"), Size: 500, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Unix(0, 0).UTC()},
+		{clientContent{URL: *newClientURL("https://play.min.io:9000/testbucket"), Size: 500, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Unix(0, 0).UTC()},
 			"play"},
 		{clientContent{URL: *newClientURL("https://s3.amazonaws.com/yrdy"), Size: 0, Time: localTime, Type: 0644, ETag: "abcdefasaas", Metadata: map[string]string{}, EncryptionHeaders: map[string]string{}},
 			"s3"},
-		{clientContent{URL: *newClientURL("https://play.minio.io:9000/yrdy"), Size: 10000, Time: localTime, Type: 0644, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{"X-Amz-Iv": "test", "X-Amz-Matdesc": "abcd"}},
+		{clientContent{URL: *newClientURL("https://play.min.io:9000/yrdy"), Size: 10000, Time: localTime, Type: 0644, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{"X-Amz-Iv": "test", "X-Amz-Matdesc": "abcd"}},
 			"play"},
 	}
 	for _, testCase := range testCases {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2016 Minio, Inc.
+ * MinIO Client, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/table-ui.go
+++ b/cmd/table-ui.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2018 Minio, Inc.
+ * MinIO Client (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015, 2018 Minio, Inc.
+ * MinIO Client (C) 2014, 2015, 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -62,7 +62,7 @@ var errInvalidAlias = func(alias string) *probe.Error {
 type invalidURLErr error
 
 var errInvalidURL = func(URL string) *probe.Error {
-	msg := "URL `" + URL + "` for minio client should be of the form scheme://host[:port]/ without resource component."
+	msg := "URL `" + URL + "` for MinIO Client should be of the form scheme://host[:port]/ without resource component."
 	return probe.NewError(invalidURLErr(errors.New(msg)))
 }
 

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015, 2016, 2017 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ EXAMPLES:
 const (
 	mcReleaseTagTimeLayout = "2006-01-02T15-04-05Z"
 	mcOSARCH               = runtime.GOOS + "-" + runtime.GOARCH
-	mcReleaseURL           = "https://dl.minio.io/client/mc/release/" + mcOSARCH + "/"
+	mcReleaseURL           = "https://dl.min.io/client/mc/release/" + mcOSARCH + "/"
 )
 
 var (

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -184,7 +184,7 @@ func IsDCOS() bool {
 	return os.Getenv("MESOS_CONTAINER_NAME") != ""
 }
 
-// IsKubernetes returns true if minio is running in kubernetes.
+// IsKubernetes returns true if MinIO is running in kubernetes.
 func IsKubernetes() bool {
 	// Kubernetes env used to validate if we are
 	// indeed running inside a kubernetes pod

--- a/cmd/update-notifier.go
+++ b/cmd/update-notifier.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client, (C) 2018 Minio, Inc.
+ * MinIO Client, (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2017 Minio, Inc.
+ * MinIO Client (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,19 +32,19 @@ func TestParseURLEnv(t *testing.T) {
 		success        bool
 	}{
 		{
-			envURL:         "https://username:password@play.minio.io:9000/",
-			expectedURL:    "https://play.minio.io:9000/",
+			envURL:         "https://username:password@play.min.io:9000/",
+			expectedURL:    "https://play.min.io:9000/",
 			expectedAccess: "username",
 			expectedSecret: "password",
 			success:        true,
 		},
 		{
-			envURL:      "https://play.minio.io:9000/",
-			expectedURL: "https://play.minio.io:9000/",
+			envURL:      "https://play.min.io:9000/",
+			expectedURL: "https://play.min.io:9000/",
 			success:     true,
 		},
 		{
-			envURL:  "ftp://play.minio.io:9000/",
+			envURL:  "ftp://play.min.io:9000/",
 			success: false,
 		},
 		{
@@ -52,11 +52,11 @@ func TestParseURLEnv(t *testing.T) {
 			success: false,
 		},
 		{
-			envURL:  "https://play.minio.io:9000/path",
+			envURL:  "https://play.min.io:9000/path",
 			success: false,
 		},
 		{
-			envURL:  "https://play.minio.io:9000/?path=value",
+			envURL:  "https://play.min.io:9000/?path=value",
 			success: false,
 		},
 	}

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015, 2016, 2017 Minio, Inc.
+ * MinIO Client (C) 2014, 2015, 2016, 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -52,7 +52,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 EXAMPLES:
-   1. Prints the minio client version:
+   1. Prints the MinIO Client version:
        $ {{.HelpName}}
 `,
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -69,16 +69,16 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}{{end}}
 EXAMPLES:
-   1. Watch new S3 operations on a minio server
+   1. Watch new S3 operations on a MinIO server
       $ {{.HelpName}} play/testbucket
 
-   2. Watch new events for a specific prefix "output/"  on minio server.
+   2. Watch new events for a specific prefix "output/"  on MinIO server.
       $ {{.HelpName}} --prefix "output/" play/testbucket
 
-   3. Watch new events for a specific suffix ".jpg" on minio server.
+   3. Watch new events for a specific suffix ".jpg" on MinIO server.
       $ {{.HelpName}} --suffix ".jpg" play/testbucket
 
-   4. Watch new events on a specific prefix and suffix on minio server.
+   4. Watch new events on a specific prefix and suffix on MinIO server.
       $ {{.HelpName}} --suffix ".jpg" --prefix "photos/" play/testbucket
 
    5. Watch for events on local directory.

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015 Minio, Inc.
+ * MinIO Client (C) 2014, 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -37,8 +37,8 @@ mc --help
 ### Binary Download (GNU/Linux)
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc |
-||64-bit PPC|https://dl.minio.io/client/mc/release/linux-ppc64le/mc |
+|GNU/Linux|64-bit Intel|https://dl.min.io/client/mc/release/linux-amd64/mc |
+||64-bit PPC|https://dl.min.io/client/mc/release/linux-ppc64le/mc |
 
 ```sh
 chmod +x mc
@@ -48,7 +48,7 @@ chmod +x mc
 ### Binary Download (Microsoft Windows)
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|Microsoft Windows|64-bit Intel|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe |
+|Microsoft Windows|64-bit Intel|https://dl.min.io/client/mc/release/windows-amd64/mc.exe |
 
 ```sh
 mc.exe --help
@@ -273,7 +273,7 @@ FLAGS:
 
 ```sh
 mc admin info play
-●  play.minio.io:9000
+●  play.min.io:9000
    Uptime : online since 1 day ago
   Version : 2018-05-28T04:31:38Z
    Region :

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -3,13 +3,13 @@
 MinIO Client (mc) provides `admin` sub-command to perform administrative tasks on your MinIO deployments.
 
 ```
-service      stop, restart or get status of minio server
-info         display minio server information
+service      stop, restart or get status of MinIO server
+info         display MinIO server information
 user         manage users
 policy       manage canned policies
 credential   change admin server access and secret keys
 config       manage configuration file
-heal         heal disks, buckets and objects on minio server
+heal         heal disks, buckets and objects on MinIO server
 top          provide top like statistics for MinIO
 ```
 
@@ -215,30 +215,30 @@ Skip SSL certificate verification.
 
 |   |
 |:---|
-|[**service** - start, stop or get the status of minio server](#service) |
-|[**info** - display minio server information](#info) |
+|[**service** - start, stop or get the status of MinIO server](#service) |
+|[**info** - display MinIO server information](#info) |
 |[**user** - manage users](#user) |
 |[**policy** - manage canned policies](#policy) |
 |[**credential** - change **admin** server access and secret keys](#credential) |
 |[**config** - manage server configuration file](#config)|
-|[**heal** - heal disks, buckets and objects on minio server](#heal) |
+|[**heal** - heal disks, buckets and objects on MinIO server](#heal) |
 |[**top** - provide top like statistics for MinIO](#top) |
 
 <a name="service"></a>
-### Command `service` - stop, restart or get status of minio server
+### Command `service` - stop, restart or get status of MinIO server
 `service` command provides a way to restart, stop one or get the status of MinIO servers (distributed cluster)
 
 ```sh
 NAME:
-  mc admin service - stop, restart or get status of minio server
+  mc admin service - stop, restart or get status of MinIO server
 
 FLAGS:
   --help, -h                       show help
 
 COMMANDS:
-  status   get the status of minio server
-  restart  restart minio server
-  stop     stop minio server
+  status   get the status of MinIO server
+  restart  restart MinIO server
+  stop     stop MinIO server
 ```
 
 *Example: Display service uptime for MinIO server.*
@@ -248,7 +248,7 @@ mc admin service status play
 Uptime: 1 days 19 hours 57 minutes 39 seconds.
 ```
 
-*Example: Restart remote minio service.*
+*Example: Restart remote MinIO service.*
 
 NOTE: `restart` and `stop` sub-commands are disruptive operations for your MinIO service, any on-going API operations will be forcibly canceled. So, it should be used only under certain circumstances. Please use it with caution.
 
@@ -263,7 +263,7 @@ Restarted `play` successfully.
 
 ```sh
 NAME:
-  mc admin info - get minio server information
+  mc admin info - get MinIO server information
 
 FLAGS:
   --help, -h                       show help
@@ -320,7 +320,7 @@ mc admin policy list --json myminio/
 
 <a name="user"></a>
 ### Command `user` - Manage users
-`user` command to add, remove, enable, disable, list users on minio server.
+`user` command to add, remove, enable, disable, list users on MinIO server.
 
 ```sh
 NAME:

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -20,7 +20,7 @@ rm       remove objects
 event    manage object notifications
 watch    watch for object events
 policy   manage anonymous access to objects
-admin    manage minio servers
+admin    manage MinIO servers
 session  manage saved sessions for cp command
 config   manage mc configuration file
 update   check for a new software update

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -59,8 +59,8 @@ mc --help
 ### Binary Download (GNU/Linux)
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc |
-||64-bit PPC|https://dl.minio.io/client/mc/release/linux-ppc64le/mc |
+|GNU/Linux|64-bit Intel|https://dl.min.io/client/mc/release/linux-amd64/mc |
+||64-bit PPC|https://dl.min.io/client/mc/release/linux-ppc64le/mc |
 
 ```sh
 chmod +x mc
@@ -70,7 +70,7 @@ chmod +x mc
 ### Binary Download (Microsoft Windows)
 | Platform | Architecture | URL |
 | ---------- | -------- |------|
-|Microsoft Windows|64-bit Intel|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe |
+|Microsoft Windows|64-bit Intel|https://dl.min.io/client/mc/release/windows-amd64/mc.exe |
 
 ```sh
 mc.exe --help
@@ -153,16 +153,16 @@ export MC_HOST_<alias>=https://<Access Key>:<Secret Key>@<YOUR-S3-ENDPOINT>
 
 Example:
 ```sh
-export MC_HOST_myalias=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG@play.minio.io:9000
+export MC_HOST_myalias=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG@play.min.io:9000
 mc ls myalias
 ```
 
 ## 4. Test Your Setup
-`mc` is pre-configured with https://play.minio.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`mc` is pre-configured with https://play.min.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
-List all buckets from https://play.minio.io:9000
+List all buckets from https://play.min.io:9000
 
 ```sh
 mc ls play
@@ -195,7 +195,7 @@ Debug option enables debug output to console.
 ```sh
 mc --debug ls play
 mc: <DEBUG> GET / HTTP/1.1
-Host: play.minio.io:9000
+Host: play.min.io:9000
 User-Agent: MinIO (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
@@ -274,7 +274,7 @@ FLAGS:
   --help, -h                    show help
 ```
 
-*Example: List all buckets on https://play.minio.io:9000.*
+*Example: List all buckets on https://play.min.io:9000.*
 
 ```sh
 mc ls play
@@ -301,7 +301,7 @@ FLAGS:
 
 ```
 
-*Example: Create a new bucket named "mybucket" on https://play.minio.io:9000.*
+*Example: Create a new bucket named "mybucket" on https://play.min.io:9000.*
 
 
 ```sh
@@ -333,7 +333,7 @@ FLAGS:
 
 ```
 
-*Example: Remove a bucket named "mybucket" on https://play.minio.io:9000.*
+*Example: Remove a bucket named "mybucket" on https://play.min.io:9000.*
 
 
 ```sh
@@ -659,9 +659,9 @@ FLAGS:
 ```sh
 
 mc share download --expire 4h play/mybucket/myobject.txt
-URL: https://play.minio.io:9000/mybucket/myobject.txt
+URL: https://play.min.io:9000/mybucket/myobject.txt
 Expire: 0 days 4 hours 0 minutes 0 seconds
-Share: https://play.minio.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
+Share: https://play.min.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
 
 ```
 
@@ -683,9 +683,9 @@ FLAGS:
 
 ```sh
 mc share upload play/mybucket/myotherobject.txt
-URL: https://play.minio.io:9000/mybucket/myotherobject.txt
+URL: https://play.min.io:9000/mybucket/myotherobject.txt
 Expire: 7 days 0 hours 0 minutes 0 seconds
-Share: curl https://play.minio.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
+Share: curl https://play.min.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
 ```
 
 #### Sub-command `share list` - Share List
@@ -728,14 +728,14 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 ```
 
-*Example: Mirror a local directory to 'mybucket' on https://play.minio.io:9000.*
+*Example: Mirror a local directory to 'mybucket' on https://play.min.io:9000.*
 
 ```sh
 mc mirror localdir/ play/mybucket
 localdir/b.txt:  40 B / 40 B  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃  100.00 % 73 B/s 0
 ```
 
-*Example: Continuously watch for changes on a local directory and mirror the changes to 'mybucket' on https://play.minio.io:9000.*
+*Example: Continuously watch for changes on a local directory and mirror the changes to 'mybucket' on https://play.min.io:9000.*
 
 ```sh
 mc mirror -w localdir play/mybucket
@@ -802,7 +802,7 @@ LEGEND:
 
 ```sh
  mc diff localdir play/mybucket
-‘localdir/notes.txt’ and ‘https://play.minio.io:9000/mybucket/notes.txt’ - only in first.
+‘localdir/notes.txt’ and ‘https://play.min.io:9000/mybucket/notes.txt’ - only in first.
 ```
 
 ### Option [--json]
@@ -849,9 +849,9 @@ FLAGS:
 
 ```sh
 mc watch play/testbucket
-[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.minio.io:9000/testbucket/CONTRIBUTING.md
-[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.minio.io:9000/testbucket/MAINTAINERS.md
-[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.minio.io:9000/testbucket/README.md
+[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.min.io:9000/testbucket/CONTRIBUTING.md
+[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.min.io:9000/testbucket/MAINTAINERS.md
+[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.min.io:9000/testbucket/README.md
 ```
 
 *Example: Watch for all events on local directory*
@@ -940,7 +940,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is ‘none’
 
 *Example : Set anonymous bucket policy to download only*
 
-Set anonymous bucket policy  for ``mybucket/myphotos/2020/`` sub-directory and its objects to ``download`` only. Now, objects under the sub-directory are publicly accessible. e.g ``mybucket/myphotos/2020/yourobjectname``is available at [https://play.minio.io:9000/mybucket/myphotos/2020/yourobjectname](https://play.minio.io:9000/mybucket/myphotos/2020/yourobjectname)
+Set anonymous bucket policy  for ``mybucket/myphotos/2020/`` sub-directory and its objects to ``download`` only. Now, objects under the sub-directory are publicly accessible. e.g ``mybucket/myphotos/2020/yourobjectname``is available at [https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname](https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname)
 
 ```sh
 mc policy download play/mybucket/myphotos/2020/
@@ -1038,7 +1038,7 @@ set -o history
 
 <a name="update"></a>
 ### Command `update` - Software Updates
-Check for new software updates from [https://dl.minio.io](https://dl.minio.io). Experimental flag checks for unstable experimental releases primarily meant for testing purposes.
+Check for new software updates from [https://dl.min.io](https://dl.min.io). Experimental flag checks for unstable experimental releases primarily meant for testing purposes.
 
 ```sh
 USAGE:
@@ -1096,7 +1096,7 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 ```
 
-*Example: Display information on a bucket named "mybucket" on https://play.minio.io:9000.*
+*Example: Display information on a bucket named "mybucket" on https://play.min.io:9000.*
 
 
 ```sh
@@ -1107,7 +1107,7 @@ Size      : 0B
 Type      : folder
 ```
 
-*Example: Display information on an encrypted object "myobject" in "mybucket" on https://play.minio.io:9000.*
+*Example: Display information on an encrypted object "myobject" in "mybucket" on https://play.min.io:9000.*
 
 
 ```sh
@@ -1123,7 +1123,7 @@ Metadata  :
   X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
 ```
 
-*Example: Display information on objects contained in the bucket named "mybucket" on https://play.minio.io:9000.*
+*Example: Display information on objects contained in the bucket named "mybucket" on https://play.min.io:9000.*
 
 ```sh
 mc stat -r play/mybucket

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -441,7 +441,7 @@ COMPRESSION TYPE
 mc sql --recursive --query "select * from S3Object" s3/personalbucket/my-large-csvs/
 ```
 
-*Example: Run an aggregation query on an object on minio*
+*Example: Run an aggregation query on an object on MinIO*
 
 ```sh
 mc sql --query "select count(s.power) from S3Object" myminio/iot-devices/power-ratio.csv
@@ -768,7 +768,7 @@ FLAGS:
   --help, -h                    show help
 ```
 
-*Example: Find all jpeg images from s3 bucket and copy to minio "play/bucket" bucket continuously.*
+*Example: Find all jpeg images from s3 bucket and copy to MinIO "play/bucket" bucket continuously.*
 ```sh
 mc find s3/bucket --name "*.jpg" --watch --exec "mc cp {} play/bucket"
 ```

--- a/docs/minio-client-configuration-files.md
+++ b/docs/minio-client-configuration-files.md
@@ -47,7 +47,7 @@ cat config.json
 			"api": "S3v2"
 		},
 		"play": {
-			"url": "https://play.minio.io:9000",
+			"url": "https://play.min.io:9000",
 			"accessKey": "Q3AM3UQ867SPQQA43P2F",
 			"secretKey": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 			"api": "S3v4"

--- a/docs/zh_CN/minio-client-complete-guide.md
+++ b/docs/zh_CN/minio-client-complete-guide.md
@@ -54,7 +54,7 @@ mc --help
 ### 下载二进制文件(GNU/Linux)
 | 平台 | CPU架构 | URL |
 | ---------- | -------- |------|
-|GNU/Linux|64-bit Intel|https://dl.minio.io/client/mc/release/linux-amd64/mc |
+|GNU/Linux|64-bit Intel|https://dl.min.io/client/mc/release/linux-amd64/mc |
 
 ```sh
 chmod +x mc
@@ -64,7 +64,7 @@ chmod +x mc
 ### 下载二进制文件(Microsoft Windows)
 | 平台 | CPU架构 | URL |
 | ---------- | -------- |------|
-|Microsoft Windows|64-bit Intel|https://dl.minio.io/client/mc/release/windows-amd64/mc.exe |
+|Microsoft Windows|64-bit Intel|https://dl.min.io/client/mc/release/windows-amd64/mc.exe |
 
 ```sh
 mc.exe --help
@@ -141,11 +141,11 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 注意：Google云存储只支持旧版签名版本V2，所以你需要选择S3v2。
 
 ## 4. 验证
-`mc`预先配置了云存储服务URL：[https://play.minio.io:9000](https://play.minio.io:9000)，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
+`mc`预先配置了云存储服务URL：[https://play.min.io:9000](https://play.min.io:9000)，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
 
 *示例:*
 
-列出[https://play.minio.io:9000](https://play.minio.io:9000)上的所有存储桶。
+列出[https://play.min.io:9000](https://play.min.io:9000)上的所有存储桶。
 
 ```sh
 mc ls play
@@ -178,7 +178,7 @@ Debug参数开启控制台输出debug信息。
 ```sh
 mc --debug ls play
 mc: <DEBUG> GET / HTTP/1.1
-Host: play.minio.io:9000
+Host: play.min.io:9000
 User-Agent: MinIO (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
@@ -255,7 +255,7 @@ FLAGS:
   --incomplete, -I		   列出未完整上传的对象。
 ```
 
-*示例： 列出所有https://play.minio.io:9000上的存储桶。*
+*示例： 列出所有https://play.min.io:9000上的存储桶。*
 
 ```sh
 mc ls play
@@ -280,7 +280,7 @@ FLAGS:
 
 ```
 
-*示例：在https://play.minio.io:9000上创建一个名叫"mybucket"的存储桶。*
+*示例：在https://play.min.io:9000上创建一个名叫"mybucket"的存储桶。*
 
 
 ```sh
@@ -428,9 +428,9 @@ FLAGS:
 ```sh
 
 mc share download --expire 4h play/mybucket/myobject.txt
-URL: https://play.minio.io:9000/mybucket/myobject.txt
+URL: https://play.min.io:9000/mybucket/myobject.txt
 Expire: 0 days 4 hours 0 minutes 0 seconds
-Share: https://play.minio.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
+Share: https://play.min.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
 
 ```
 
@@ -452,9 +452,9 @@ FLAGS:
 
 ```sh
 mc share upload play/mybucket/myotherobject.txt
-URL: https://play.minio.io:9000/mybucket/myotherobject.txt
+URL: https://play.min.io:9000/mybucket/myotherobject.txt
 Expire: 7 days 0 hours 0 minutes 0 seconds
-Share: curl https://play.minio.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
+Share: curl https://play.min.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
 ```
 
 #### 子命令`share list` - 列出之前的共享
@@ -485,14 +485,14 @@ FLAGS:
   --remove			   删除目标上的外部的文件。
 ```
 
-*示例： 将一个本地文件夹镜像到https://play.minio.io:9000上的'mybucket'存储桶。*
+*示例： 将一个本地文件夹镜像到https://play.min.io:9000上的'mybucket'存储桶。*
 
 ```sh
 mc mirror localdir/ play/mybucket
 localdir/b.txt:  40 B / 40 B  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃  100.00 % 73 B/s 0
 ```
 
-*示例： 持续监听本地文件夹修改并镜像到https://play.minio.io:9000上的'mybucket'存储桶。*
+*示例： 持续监听本地文件夹修改并镜像到https://play.min.io:9000上的'mybucket'存储桶。*
 
 ```sh
 mc mirror -w localdir play/mybucket
@@ -538,7 +538,7 @@ FLAGS:
 
 ```sh
  mc diff localdir play/mybucket
-‘localdir/notes.txt’ and ‘https://play.minio.io:9000/mybucket/notes.txt’ - only in first.
+‘localdir/notes.txt’ and ‘https://play.min.io:9000/mybucket/notes.txt’ - only in first.
 ```
 
 <a name="watch"></a>
@@ -561,9 +561,9 @@ FLAGS:
 
 ```sh
 mc watch play/testbucket
-[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.minio.io:9000/testbucket/CONTRIBUTING.md
-[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.minio.io:9000/testbucket/MAINTAINERS.md
-[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.minio.io:9000/testbucket/README.md
+[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.min.io:9000/testbucket/CONTRIBUTING.md
+[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.min.io:9000/testbucket/MAINTAINERS.md
+[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.min.io:9000/testbucket/README.md
 ```
 
 *示例： 监听本地文件夹的所有事件*
@@ -648,7 +648,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is ‘none’
 
 *示例：设置可下载的匿名存储桶策略。*
 
-设置``mybucket/myphotos/2020/``子文件夹可匿名下载的策略。现在，这个文件夹下的对象可被公开访问。比如：``mybucket/myphotos/2020/yourobjectname``可通过这个URL [https://play.minio.io:9000/mybucket/myphotos/2020/yourobjectname](https://play.minio.io:9000/mybucket/myphotos/2020/yourobjectname)访问。
+设置``mybucket/myphotos/2020/``子文件夹可匿名下载的策略。现在，这个文件夹下的对象可被公开访问。比如：``mybucket/myphotos/2020/yourobjectname``可通过这个URL [https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname](https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname)访问。
 
 ```sh
 mc policy download play/mybucket/myphotos/2020/
@@ -733,7 +733,7 @@ set -o history
 
 <a name="update"></a>
 ### `update`命令 - 软件更新
-从[https://dl.minio.io](https://dl.minio.io)检查软件更新。Experimental标志会检查unstable实验性的版本，通常用作测试用途。
+从[https://dl.min.io](https://dl.min.io)检查软件更新。Experimental标志会检查unstable实验性的版本，通常用作测试用途。
 
 ```sh
 用法：

--- a/docs/zh_CN/minio-client-configuration-files.md
+++ b/docs/zh_CN/minio-client-configuration-files.md
@@ -47,7 +47,7 @@ cat config.json
 			"api": "S3v2"
 		},
 		"play": {
-			"url": "https://play.minio.io:9000",
+			"url": "https://play.min.io:9000",
 			"accessKey": "Q3AM3UQ867SPQQA43P2F",
 			"secretKey": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 			"api": "S3v4"

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -17,7 +17,7 @@
 
 ################################################################################
 #
-# This script is usable by mc functional tests, mint tests and minio verification
+# This script is usable by mc functional tests, mint tests and MinIO verification
 # tests.
 #
 # * As mc functional tests, just run this script.  It uses mc executable binary
@@ -26,7 +26,7 @@
 #
 # * For other, call this script with environment variables MINT_MODE,
 #   MINT_DATA_DIR, SERVER_ENDPOINT, ACCESS_KEY, SECRET_KEY and ENABLE_HTTPS. It
-#   uses mc executable binary in current working directory and uses given minio
+#   uses mc executable binary in current working directory and uses given MinIO
 #   server to run tests. MINT_MODE is set by mint to specify what category of
 #   tests to run.
 #

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -22,7 +22,7 @@
 #
 # * As mc functional tests, just run this script.  It uses mc executable binary
 #   in current working directory or in the path.  The tests uses play.min.io
-#   as minio server.
+#   as MinIO server.
 #
 # * For other, call this script with environment variables MINT_MODE,
 #   MINT_DATA_DIR, SERVER_ENDPOINT, ACCESS_KEY, SECRET_KEY and ENABLE_HTTPS. It

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Minio Client (C) 2017 Minio, Inc.
+# MinIO Client (C) 2017 MinIO, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 # tests.
 #
 # * As mc functional tests, just run this script.  It uses mc executable binary
-#   in current working directory or in the path.  The tests uses play.minio.io
+#   in current working directory or in the path.  The tests uses play.min.io
 #   as minio server.
 #
 # * For other, call this script with environment variables MINT_MODE,
@@ -55,7 +55,7 @@ if [ -n "$MINT_MODE" ]; then
 fi
 
 if [ -z "${SERVER_ENDPOINT+x}" ]; then
-    SERVER_ENDPOINT="play.minio.io:9000"
+    SERVER_ENDPOINT="play.min.io:9000"
     ACCESS_KEY="Q3AM3UQ867SPQQA43P2F"
     SECRET_KEY="zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
     ENABLE_HTTPS=1

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2014, 2015, 2016 Minio, Inc.
+ * MinIO Client (C) 2014, 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/console/console_test.go
+++ b/pkg/console/console_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/console/themes.go
+++ b/pkg/console/themes.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/hookreader/hookreader.go
+++ b/pkg/hookreader/hookreader.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/hookreader/hookreader_test.go
+++ b/pkg/hookreader/hookreader_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2016 Minio, Inc.
+ * MinIO Client (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/httptracer/httptracer.go
+++ b/pkg/httptracer/httptracer.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/httptracer/httptracer_test.go
+++ b/pkg/httptracer/httptracer_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Client (C) 2015 Minio, Inc.
+ * MinIO Client (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/ioutils/filepath.go
+++ b/pkg/ioutils/filepath.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/ioutils/format.go
+++ b/pkg/ioutils/format.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2018 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2018 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/ioutils/ioutils_test.go
+++ b/pkg/ioutils/ioutils_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -1,5 +1,5 @@
 /*
- * Minimalist Object Storage, (C) 2015 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -1,5 +1,5 @@
 /*
- * Minio Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/probe/wrapper.go
+++ b/pkg/probe/wrapper.go
@@ -1,5 +1,5 @@
 /*
- * Minimalist Object Storage, (C) 2015 Minio, Inc.
+ * MinIO Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #2744 

Official company name `Minio` became `MinIO`. 
This change required our documentation to be modified for all references to the old name, `Minio`, as `MinIO` and the links `....://xxx.minio.io` as `....://xxx.min.io` in mc documents.

## Description of the change
The changes are in `../docs/*` and `../cmd/*` files.

Used Visual Studio Code Editor regular expressions to find and replace those patterns that match the desired text. Here are the two regular expressions used to complete the job in 2 steps:

1. Choose `Match Case` and `Use Regular Expression` and replace the links using the following regular expressions:

| Find | Replace |
| ------ | ----------- |
|minio.io | min.io |

2. 
| Find | Replace |
| ------ | ----------- |
| \bMinio\b(?!\.) | MinIO |
