### PR TITLE
Fix: do not check if object listed equals object being removed

### DIFF
--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -155,7 +155,7 @@ func statURL(targetURL string, isIncomplete, isRecursive bool, encKeyDB map[stri
 		}
 		url := targetAlias + getKey(content)
 
-		if !isRecursive && url != targetURL {
+		if !isRecursive && !strings.HasPrefix(url, targetURL) {
 			return nil, errTargetNotFound(targetURL)
 		}
 


### PR DESCRIPTION
List within the statURL function considers object name as a prefix
and lists objects that have the same prefix.
currently, it errors out if the object is a subset of another object.

Fixes #2746