### PR TITLE
fix crash when parsing empty/invalid MC_HOST_* environment variable

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -231,7 +231,7 @@ func parseEnvURLStr(envURL string) (*url.URL, string, string, *probe.Error) {
 		res := re.FindAllStringSubmatch(envURL, -1)
 		// regex will return full match, scheme, accessKey, secretKey and endpoint:port as
 		// captured groups.
-		if len(res[0]) != 5 {
+		if res == nil || len(res[0]) != 5 {
 			return nil, "", "", err
 		}
 		for k, v := range res[0] {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -69,3 +69,11 @@ func TestParseEnvURLStr(t *testing.T) {
 		}
 	}
 }
+
+func TestParseEnvURLStrInvalid(t *testing.T) {
+	_, _, _, err := parseEnvURLStr("")
+	if err == nil {
+		t.Fatalf("Expected failure")
+	}
+}
+

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -76,4 +76,3 @@ func TestParseEnvURLStrInvalid(t *testing.T) {
 		t.Fatalf("Expected failure")
 	}
 }
-


### PR DESCRIPTION
mc crashes when MC_HOST_* is empty or invalid. To reproduce run 
```
export MC_HOST_SCRIPT=""
mc ls SCRIPT
```
using the current release of mc. This pull request prevents the crash.
