### PR TITLE
Error out in list policy if policy doesn't exist

### DIFF
--- a/cmd/admin-policy-list.go
+++ b/cmd/admin-policy-list.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/console"
@@ -76,11 +77,15 @@ func mainAdminPolicyList(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Cannot list policy")
 
 	if policyName := args.Get(1); policyName != "" {
-		printMsg(userPolicyMessage{
-			op:         "list",
-			Policy:     policyName,
-			PolicyJSON: policies[policyName],
-		})
+		if len(policies[policyName]) != 0 {
+			printMsg(userPolicyMessage{
+				op:         "list",
+				Policy:     policyName,
+				PolicyJSON: policies[policyName],
+			})
+		} else {
+			fatalIf(probe.NewError(fmt.Errorf("%s is not found", policyName)), "Cannot list the policy")
+		}
 	} else {
 		for k := range policies {
 			printMsg(userPolicyMessage{


### PR DESCRIPTION
Error out in case of list policy `mc admin policy list minio fdasfdas` if the policy ` fdasfdas` is not present.

Closes #2758 