### PR TITLE
Add --ignore-existing/-p flag up addition of event

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -230,7 +230,7 @@ func (c *s3Client) GetURL() clientURL {
 }
 
 // Add bucket notification
-func (c *s3Client) AddNotificationConfig(arn string, events []string, prefix, suffix string) *probe.Error {
+func (c *s3Client) AddNotificationConfig(arn string, events []string, prefix, suffix string, ignoreExisting bool) *probe.Error {
 	bucket, _ := c.url2BucketAndObject()
 	// Validate total fields in ARN.
 	fields := strings.Split(arn, ":")
@@ -286,6 +286,9 @@ func (c *s3Client) AddNotificationConfig(arn string, events []string, prefix, su
 
 	// Set the new bucket configuration
 	if err := c.api.SetBucketNotification(bucket, mb); err != nil {
+		if ignoreExisting && strings.Contains(err.Error(), "An object key name filtering rule defined with overlapping prefixes, overlapping suffixes, or overlapping combinations of prefixes and suffixes for the same event types") {
+			return nil
+		}
 		return probe.NewError(err)
 	}
 	return nil

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -897,6 +897,7 @@ COMMANDS:
   list    list bucket notifications
 
 FLAGS:
+  --ignore-existing, -p            ignore if event already exists
   --help, -h                       show help
 ```
 


### PR DESCRIPTION
If the event is already present the server throws an error. With the --ignore-existing/ -p flag these error messages are discarded.

Fixes https://github.com/minio/mc/issues/2771