### PR TITLE
Accept SECRET_KEY using prompt and standard input.

### DIFF
--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -97,6 +97,19 @@ MinIO server displays URL, access and secret keys.
 
 #### Usage
 
+```sh
+mc config host add <ALIAS> <YOUR-MINIO-ENDPOINT>
+```
+
+This asks for access key and secret key which are supplied by your MinIo service.
+
+```sh
+Enter Access Key : BKIKJAA5BMMU2RHO6IBB
+Enter Secret Key : V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
+```
+
+Host can also be added by passing access key, secret key using prompt
+
 ```
 mc config host add <ALIAS> <YOUR-MINIO-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY>
 ```
@@ -419,7 +432,19 @@ COMMANDS:
 *Example: Add a new user 'newuser' on MinIO.*
 
 ```
-mc admin user add myminio/ newuser newuser123
+
+*Example: Add a new user 'testuser' on MinIO, using standard input.*
+
+```sh
+$ {{.HelpName}} myminio
+   Enter Access Key : testuser
+   Enter Secret Key : testuser123
+```
+
+*Example: Change policy for a user 'newuser' on MinIO to 'writeonly' policy.*
+
+```sh
+mc admin user policy myminio/ newuser writeonly
 ```
 
 *Example: Disable a user 'newuser' on MinIO.*

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -117,8 +117,12 @@ To add one or more Amazon S3 compatible hosts, please follow the instructions be
 
 #### Usage
 
-```
-mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY> <API-SIGNATURE>
+```sh
+1. Add host by passing access key, secret key in command.
+ mc config host add <ALIAS> <YOUR-S3-ENDPOINT> <YOUR-ACCESS-KEY> <YOUR-SECRET-KEY> <API-SIGNATURE>
+
+2. Add host by accepting access key, secret key through standard input
+   mc config host add <ALIAS> <YOUR-S3-ENDPOINT>
 ```
 
 Alias is simply a short name to your cloud storage service. S3 end-point, access and secret keys are supplied by your cloud storage provider. API signature is an optional argument. By default, it is set to "S3v4".
@@ -129,6 +133,17 @@ MinIO server displays URL, access and secret keys.
 
 ```
 mc config host add minio http://192.168.1.51 BKIKJAA5BMMU2RHO6IBB V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 --api S3v4
+```
+
+```sh
+mc config host add minio http://192.168.1.51 --api S3v4
+```
+
+This prompts for details:
+
+```
+Enter Access Key : BKIKJAA5BMMU2RHO6IBB
+Enter Secret Key : V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
 ```
 
 ### Example - Amazon S3 Cloud Storage

--- a/go.mod
+++ b/go.mod
@@ -10,16 +10,17 @@ require (
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/mattn/go-colorable v0.1.1
 	github.com/mattn/go-isatty v0.0.7
-	github.com/minio/minio v0.0.0-20191001201215-ff5bf519522f
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio v0.0.0-20190927193314-1c5b05c130fa
-	github.com/minio/minio-go/v6 v6.0.39
+	github.com/minio/minio-go/v6 v6.0.38
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/profile v1.3.0
+	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	github.com/pkg/xattr v0.4.1
 	github.com/posener/complete v1.2.2-0.20190702141536-6ffe496ea953
 	github.com/rjeczalik/notify v0.9.2
+	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478
 	golang.org/x/text v0.3.2
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/minio/minio v0.0.0-20190325204105-0250f7de678b/go.mod h1:6ODmvb06uOpN
 github.com/minio/minio v0.0.0-20190510004154-ac3b59645e92/go.mod h1:yFbQSwuA61mB/SDurPvsaSydqDyJdfAlBYpMiEe1lz8=
 github.com/minio/minio v0.0.0-20190903181048-8a71b0ec5a72 h1:TMytDyYdKnVxNJhkISFRsw9SVoHIlSMIJFk3y/l9nik=
 github.com/minio/minio v0.0.0-20190903181048-8a71b0ec5a72/go.mod h1:H8OUaOxwJIALXHlfMpk2ESvk81dW+F7tSnrZi7rln/k=
+github.com/minio/minio v0.0.0-20190927193314-1c5b05c130fa h1:qESwVzJYhhVSeK2UasiiaIDlF6Zpj3jYH6isOZFWhkA=
+github.com/minio/minio v0.0.0-20190927193314-1c5b05c130fa/go.mod h1:47wx8w7yKTFAPw/hbmYPL4prsPivh6QuUqjTykftGgg=
 github.com/minio/minio v0.0.0-20191001201215-ff5bf519522f h1:jkAd6uD2DG8jt44xKJUXC9s4CCwPa+vKuA9468j8kT8=
 github.com/minio/minio v0.0.0-20191001201215-ff5bf519522f/go.mod h1:+vpJpzImdz4NCQto3r6/vF/24jWeEs5i3lsDfRmEcl4=
 github.com/minio/minio-go v0.0.0-20190227180923-59af836a7e6d h1:gptD0/Hnam7h4Iq9D/33fscRpHfzOOUqUbH2nPw9HcU=
@@ -532,6 +534,8 @@ github.com/pkg/profile v0.0.0-20160315012113-19396ecfda37/go.mod h1:hJw3o1OdXxsr
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/profile v1.3.0 h1:OQIvuDgm00gWVWGTf4m4mCt6W1/0YqU7Ntg0mySWgaI=
 github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 h1:A7GG7zcGjl3jqAqGPmcNjd/D9hzL95SuoOQAaFNdLU0=
+github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pkg/xattr v0.0.0-20170808190211-56ed87199eba/go.mod h1:wuo6utqb0b/WNJYm0fQyg57cKpORNfpX2lY6Ew6+Grg=
 github.com/pkg/xattr v0.4.1 h1:dhclzL6EqOXNaPDWqoeb9tIxATfBSmjqL0b4DpSjwRw=
 github.com/pkg/xattr v0.4.1/go.mod h1:W2cGD0TBEus7MkUgv0tNZ9JutLtVO3cXu+IBRuHqnFs=
@@ -580,7 +584,6 @@ github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/go-prompt v0.0.0-20161017233205-f0d19b6901ad/go.mod h1:B3ehdD1xPoWDKgrQgUaGk+m8H1xb1J5TyYDfKpKNeEE=
-github.com/segmentio/go-prompt v1.2.1-0.20161017233205-f0d19b6901ad h1:EqOdoSJGI7CsBQczPcIgmpm3hJE7X8Hj3jrgI002whs=
 github.com/segmentio/go-prompt v1.2.1-0.20161017233205-f0d19b6901ad/go.mod h1:B3ehdD1xPoWDKgrQgUaGk+m8H1xb1J5TyYDfKpKNeEE=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
The `ACCESS_KEY` , `SECRET_KEY` is taken as an input . This is done to avoid the credentials shown
in `ps aux` command.
Adding a new user asks for their credentials.

To test:
1. `mc config host add myminio http://192.168.86.149:9000 `
```
Enter Access Key : BKIKJAA5BMMU2RHO6IBB
Enter Secret Key : V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
Added `myminio` successfully.
```

2. `mc admin user add  myminio foobar readonly`
``` 
Enter Access Key : testuser 
Enter Secret Key : testuser123
```
Fixes #2651 