### PR TITLE
Show background heal stats in mc admin heal

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -17,8 +17,10 @@
 package cmd
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
@@ -133,6 +135,30 @@ func (s stopHealMessage) JSON() string {
 	return string(stopHealJSONBytes)
 }
 
+// backgroundHealStatusMessage is container for stop heal success and failure messages.
+type backgroundHealStatusMessage struct {
+	Status   string `json:"status"`
+	HealInfo madmin.BgHealState
+}
+
+// String colorized to show background heal status message.
+func (s backgroundHealStatusMessage) String() string {
+	healPrettyMsg := console.Colorize("HealBackgroundTitle", "Background healing status:\n")
+	healPrettyMsg += fmt.Sprintf("  Total items scanned: %s\n",
+		console.Colorize("HealBackground", s.HealInfo.ScannedItemsCount))
+	healPrettyMsg += fmt.Sprintf("  Last background heal check: %s\n",
+		console.Colorize("HealBackground", timeDurationToHumanizedDuration(time.Since(s.HealInfo.LastHealActivity)).String()+" ago"))
+	return healPrettyMsg
+}
+
+// JSON jsonified stop heal message.
+func (s backgroundHealStatusMessage) JSON() string {
+	healJSONBytes, e := json.MarshalIndent(s, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(healJSONBytes)
+}
+
 func transformScanArg(scanArg string) madmin.HealScanMode {
 	switch scanArg {
 	case "deep":
@@ -152,6 +178,8 @@ func mainAdminHeal(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	console.SetColor("Heal", color.New(color.FgGreen, color.Bold))
+	console.SetColor("HealBackgroundTitle", color.New(color.FgGreen, color.Bold))
+	console.SetColor("HealBackground", color.New(color.Bold))
 	console.SetColor("HealUpdateUI", color.New(color.FgYellow, color.Bold))
 	console.SetColor("HealStopped", color.New(color.FgGreen, color.Bold))
 
@@ -167,6 +195,15 @@ func mainAdminHeal(ctx *cli.Context) error {
 	splits := splitStr(aliasedURL, "/", 3)
 	bucket, prefix := splits[1], splits[2]
 
+	// Return the background heal status when the user
+	// doesn't pass a bucket or --recursive flag.
+	if bucket == "" && !ctx.Bool("recursive") {
+		bgHealStatus, berr := client.BackgroundHealStatus()
+		fatalIf(probe.NewError(berr), "Failed to get the status of the background heal.")
+		printMsg(backgroundHealStatusMessage{Status: "success", HealInfo: bgHealStatus})
+		return nil
+	}
+
 	opts := madmin.HealOpts{
 		ScanMode:  transformScanArg(ctx.String("scan")),
 		Remove:    ctx.Bool("remove"),
@@ -178,13 +215,13 @@ func mainAdminHeal(ctx *cli.Context) error {
 	forceStop := ctx.Bool("force-stop")
 	if forceStop {
 		_, _, herr := client.Heal(bucket, prefix, opts, "", forceStart, forceStop)
-		errorIf(probe.NewError(herr), "Failed to stop heal sequence.")
+		fatalIf(probe.NewError(herr), "Failed to stop heal sequence.")
 		printMsg(stopHealMessage{Status: "success", Alias: aliasedURL})
 		return nil
 	}
 
 	healStart, _, herr := client.Heal(bucket, prefix, opts, "", forceStart, false)
-	errorIf(probe.NewError(herr), "Failed to start heal sequence.")
+	fatalIf(probe.NewError(herr), "Failed to start heal sequence.")
 
 	ui := uiData{
 		Bucket:                bucket,
@@ -203,9 +240,9 @@ func mainAdminHeal(ctx *cli.Context) error {
 		if res.FailureDetail != "" {
 			data, _ := json.MarshalIndent(res, "", " ")
 			traceStr := string(data)
-			errorIf(probe.NewError(e).Trace(aliasedURL, traceStr), "Unable to display heal status.")
+			fatalIf(probe.NewError(e).Trace(aliasedURL, traceStr), "Unable to display heal status.")
 		} else {
-			errorIf(probe.NewError(e).Trace(aliasedURL), "Unable to display heal status.")
+			fatalIf(probe.NewError(e).Trace(aliasedURL), "Unable to display heal status.")
 		}
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mattn/go-isatty v0.0.7
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/minio/cli v1.20.0
-	github.com/minio/minio v0.0.0-20190619212803-35c38e4bd893
+	github.com/minio/minio v0.0.0-20190626173654-be72609d1f8f
 	github.com/minio/minio-go v0.0.0-20190327203652-5325257a208f // indirect
 	github.com/minio/minio-go/v6 v6.0.29
 	github.com/minio/sha256-simd v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/minio/minio v0.0.0-20190325204105-0250f7de678b/go.mod h1:6ODmvb06uOpN
 github.com/minio/minio v0.0.0-20190510004154-ac3b59645e92/go.mod h1:yFbQSwuA61mB/SDurPvsaSydqDyJdfAlBYpMiEe1lz8=
 github.com/minio/minio v0.0.0-20190619212803-35c38e4bd893 h1:3vaOD8YTz5F6gp7BC66sDGN2Hj4x0lUxigG/rCSw0lo=
 github.com/minio/minio v0.0.0-20190619212803-35c38e4bd893/go.mod h1:E4YtMxTbDvy5kxqZYpHPJ427GowUH7GiQXIg68ctM8s=
+github.com/minio/minio v0.0.0-20190626173654-be72609d1f8f h1:MAaUl4XTytIdhQTaB4fI5FbclAUEKly+ELbVw1vN2tE=
+github.com/minio/minio v0.0.0-20190626173654-be72609d1f8f/go.mod h1:E4YtMxTbDvy5kxqZYpHPJ427GowUH7GiQXIg68ctM8s=
 github.com/minio/minio-go v0.0.0-20190227180923-59af836a7e6d/go.mod h1:/haSOWG8hQNx2+JOfLJ9GKp61EAmgPwRVw/Sac0NzaM=
 github.com/minio/minio-go v0.0.0-20190313212832-5d20267d970d/go.mod h1:/haSOWG8hQNx2+JOfLJ9GKp61EAmgPwRVw/Sac0NzaM=
 github.com/minio/minio-go v0.0.0-20190327203652-5325257a208f h1:u+iNxfkLrfyWp7KxSTV+ZhO4SMHT6qUFxSZ6yhYMQ0Q=


### PR DESCRIPTION
This commit adds printing some stats of the always running background heal status when the user types mc command the following way: `mc admin heal alias/`

```
$ mc admin heal myminio/
Background healing status:
  Total items scanned: 1100
  Last background heal check: 11 minutes 32 seconds ago
```