### PR TITLE
Add env variable for no autocomplete installation

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -57,6 +57,7 @@ var globalFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:  "no-autocompletion",
 		Usage: "disable automatic install of mc auto-completion",
+		EnvVar: "MINIO_NO_AUTOCOMPLETE",
 	},
 }
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -57,7 +57,7 @@ var globalFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:   "no-autocompletion",
 		Usage:  "disable automatic install of mc auto-completion",
-		EnvVar: "MINIO_NO_AUTOCOMPLETE",
+		EnvVar: "MC_NO_AUTOCOMPLETE",
 	},
 }
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -55,8 +55,8 @@ var globalFlags = []cli.Flag{
 		Usage: "disable SSL certificate verification",
 	},
 	cli.BoolFlag{
-		Name:  "no-autocompletion",
-		Usage: "disable automatic install of mc auto-completion",
+		Name:   "no-autocompletion",
+		Usage:  "disable automatic install of mc auto-completion",
 		EnvVar: "MINIO_NO_AUTOCOMPLETE",
 	},
 }


### PR DESCRIPTION
This makes it a bit easier for users to avoid being prompted all the time if they don't include the --no-autocomplete flag.