### PR TITLE
Remove port 9000 for play.min.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,11 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 NOTE: Google Cloud Storage only supports Legacy Signature Version 2, so you have to pick - S3v2
 
 ## Test Your Setup
-`mc` is pre-configured with https://play.min.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`mc` is pre-configured with https://play.min.io, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
-List all buckets from https://play.min.io:9000
+List all buckets from https://play.min.io
 
 ```
 mc ls play

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -121,11 +121,11 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 注意：Google云存储只支持旧版签名版本V2，所以你需要选择S3v2。
 
 ## 验证
-`mc`预先配置了云存储服务URL：https://play.min.io:9000，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
+`mc`预先配置了云存储服务URL：https://play.min.io，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
 
 *示例:*
 
-列出https://play.min.io:9000上的所有存储桶。
+列出https://play.min.io上的所有存储桶。
 
 ```
 mc ls play

--- a/cmd/config-old.go
+++ b/cmd/config-old.go
@@ -210,7 +210,7 @@ func (c *configV7) loadDefaults() {
 
 	// MinIO anonymous server for demo.
 	c.setHost("play", hostConfigV7{
-		URL:       "https://play.min.io:9000",
+		URL:       "https://play.min.io",
 		AccessKey: "",
 		SecretKey: "",
 		API:       "S3v4",
@@ -297,7 +297,7 @@ func (c *configV8) loadDefaults() {
 
 	// MinIO anonymous server for demo.
 	c.setHost("play", hostConfigV8{
-		URL:       "https://play.min.io:9000",
+		URL:       "https://play.min.io",
 		AccessKey: "Q3AM3UQ867SPQQA43P2F",
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",

--- a/cmd/config-v9.go
+++ b/cmd/config-v9.go
@@ -96,7 +96,7 @@ func (c *configV9) loadDefaults() {
 
 	// MinIO anonymous server for demo.
 	c.setHost("play", hostConfigV9{
-		URL:       "https://play.min.io:9000",
+		URL:       "https://play.min.io",
 		AccessKey: "Q3AM3UQ867SPQQA43P2F",
 		SecretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 		API:       "S3v4",

--- a/cmd/sql-main_test.go
+++ b/cmd/sql-main_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -122,7 +121,6 @@ func TestParseSerializationOpts(t *testing.T) {
 	for i, test := range testParseSerializationCases {
 		optsMap, err := parseSerializationOpts(test.inp, test.validKeys, test.validAbbrKeys)
 		gerr := err.ToGoError()
-		fmt.Println(i+1, optsMap, gerr)
 		if gerr != nil && gerr.Error() != test.errMsg {
 			// match partial error message
 			if !strings.Contains(gerr.Error(), test.errMsg) {

--- a/cmd/stat_test.go
+++ b/cmd/stat_test.go
@@ -30,13 +30,13 @@ func (s *TestSuite) TestParseStat(c *C) {
 		content     clientContent
 		targetAlias string
 	}{
-		{clientContent{URL: *newClientURL("https://play.min.io:9000/abc"), Size: 0, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Now()},
+		{clientContent{URL: *newClientURL("https://play.min.io/abc"), Size: 0, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Now()},
 			"play"},
-		{clientContent{URL: *newClientURL("https://play.min.io:9000/testbucket"), Size: 500, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Unix(0, 0).UTC()},
+		{clientContent{URL: *newClientURL("https://play.min.io/testbucket"), Size: 500, Time: localTime, Type: os.ModeDir, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{}, Expires: time.Unix(0, 0).UTC()},
 			"play"},
 		{clientContent{URL: *newClientURL("https://s3.amazonaws.com/yrdy"), Size: 0, Time: localTime, Type: 0644, ETag: "abcdefasaas", Metadata: map[string]string{}, EncryptionHeaders: map[string]string{}},
 			"s3"},
-		{clientContent{URL: *newClientURL("https://play.min.io:9000/yrdy"), Size: 10000, Time: localTime, Type: 0644, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{"X-Amz-Iv": "test", "X-Amz-Matdesc": "abcd"}},
+		{clientContent{URL: *newClientURL("https://play.min.io/yrdy"), Size: 10000, Time: localTime, Type: 0644, ETag: "blahblah", Metadata: map[string]string{"cusom-key": "custom-value"}, EncryptionHeaders: map[string]string{"X-Amz-Iv": "test", "X-Amz-Matdesc": "abcd"}},
 			"play"},
 	}
 	for _, testCase := range testCases {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -32,19 +32,19 @@ func TestParseURLEnv(t *testing.T) {
 		success        bool
 	}{
 		{
-			envURL:         "https://username:password@play.min.io:9000/",
-			expectedURL:    "https://play.min.io:9000/",
+			envURL:         "https://username:password@play.min.io/",
+			expectedURL:    "https://play.min.io/",
 			expectedAccess: "username",
 			expectedSecret: "password",
 			success:        true,
 		},
 		{
-			envURL:      "https://play.min.io:9000/",
-			expectedURL: "https://play.min.io:9000/",
+			envURL:      "https://play.min.io/",
+			expectedURL: "https://play.min.io/",
 			success:     true,
 		},
 		{
-			envURL:  "ftp://play.min.io:9000/",
+			envURL:  "ftp://play.min.io/",
 			success: false,
 		},
 		{
@@ -52,11 +52,11 @@ func TestParseURLEnv(t *testing.T) {
 			success: false,
 		},
 		{
-			envURL:  "https://play.min.io:9000/path",
+			envURL:  "https://play.min.io/path",
 			success: false,
 		},
 		{
-			envURL:  "https://play.min.io:9000/?path=value",
+			envURL:  "https://play.min.io/?path=value",
 			success: false,
 		},
 	}

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -271,7 +271,7 @@ FLAGS:
 
 ```
 mc admin info play
-●  play.min.io:9000
+●  play.min.io
    Uptime : online since 1 day ago
   Version : 2018-05-28T04:31:38Z
    Region :

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -153,16 +153,16 @@ export MC_HOST_<alias>=https://<Access Key>:<Secret Key>@<YOUR-S3-ENDPOINT>
 
 Example:
 ```
-export MC_HOST_myalias=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG@play.min.io:9000
+export MC_HOST_myalias=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG@play.min.io
 mc ls myalias
 ```
 
 ## 4. Test Your Setup
-`mc` is pre-configured with https://play.min.io:9000, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
+`mc` is pre-configured with https://play.min.io, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 
 *Example:*
 
-List all buckets from https://play.min.io:9000
+List all buckets from https://play.min.io
 
 ```
 mc ls play
@@ -195,7 +195,7 @@ Debug option enables debug output to console.
 ```
 mc --debug ls play
 mc: <DEBUG> GET / HTTP/1.1
-Host: play.min.io:9000
+Host: play.min.io
 User-Agent: MinIO (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
@@ -274,7 +274,7 @@ FLAGS:
   --help, -h                    show help
 ```
 
-*Example: List all buckets on https://play.min.io:9000.*
+*Example: List all buckets on https://play.min.io.*
 
 ```
 mc ls play
@@ -301,7 +301,7 @@ FLAGS:
 
 ```
 
-*Example: Create a new bucket named "mybucket" on https://play.min.io:9000.*
+*Example: Create a new bucket named "mybucket" on https://play.min.io.*
 
 
 ```
@@ -335,7 +335,7 @@ FLAGS:
 
 ```
 
-*Example: Remove a bucket named "mybucket" on https://play.min.io:9000.*
+*Example: Remove a bucket named "mybucket" on https://play.min.io.*
 
 
 ```
@@ -678,9 +678,9 @@ FLAGS:
 ```
 
 mc share download --expire 4h play/mybucket/myobject.txt
-URL: https://play.min.io:9000/mybucket/myobject.txt
+URL: https://play.min.io/mybucket/myobject.txt
 Expire: 0 days 4 hours 0 minutes 0 seconds
-Share: https://play.min.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
+Share: https://play.min.io/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
 
 ```
 
@@ -702,9 +702,9 @@ FLAGS:
 
 ```
 mc share upload play/mybucket/myotherobject.txt
-URL: https://play.min.io:9000/mybucket/myotherobject.txt
+URL: https://play.min.io/mybucket/myotherobject.txt
 Expire: 7 days 0 hours 0 minutes 0 seconds
-Share: curl https://play.min.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
+Share: curl https://play.min.io/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
 ```
 
 #### Sub-command `share list` - Share List
@@ -747,14 +747,14 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 ```
 
-*Example: Mirror a local directory to 'mybucket' on https://play.min.io:9000.*
+*Example: Mirror a local directory to 'mybucket' on https://play.min.io.*
 
 ```
 mc mirror localdir/ play/mybucket
 localdir/b.txt:  40 B / 40 B  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃  100.00 % 73 B/s 0
 ```
 
-*Example: Continuously watch for changes on a local directory and mirror the changes to 'mybucket' on https://play.min.io:9000.*
+*Example: Continuously watch for changes on a local directory and mirror the changes to 'mybucket' on https://play.min.io.*
 
 ```
 mc mirror -w localdir play/mybucket
@@ -821,7 +821,7 @@ LEGEND:
 
 ```
  mc diff localdir play/mybucket
-‘localdir/notes.txt’ and ‘https://play.min.io:9000/mybucket/notes.txt’ - only in first.
+‘localdir/notes.txt’ and ‘https://play.min.io/mybucket/notes.txt’ - only in first.
 ```
 
 ### Option [--json]
@@ -868,9 +868,9 @@ FLAGS:
 
 ```
 mc watch play/testbucket
-[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.min.io:9000/testbucket/CONTRIBUTING.md
-[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.min.io:9000/testbucket/MAINTAINERS.md
-[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.min.io:9000/testbucket/README.md
+[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.min.io/testbucket/CONTRIBUTING.md
+[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.min.io/testbucket/MAINTAINERS.md
+[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.min.io/testbucket/README.md
 ```
 
 *Example: Watch for all events on local directory*
@@ -959,7 +959,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is ‘none’
 
 *Example : Set anonymous bucket policy to download only*
 
-Set anonymous bucket policy  for ``mybucket/myphotos/2020/`` sub-directory and its objects to ``download`` only. Now, objects under the sub-directory are publicly accessible. e.g ``mybucket/myphotos/2020/yourobjectname``is available at [https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname](https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname)
+Set anonymous bucket policy  for ``mybucket/myphotos/2020/`` sub-directory and its objects to ``download`` only. Now, objects under the sub-directory are publicly accessible. e.g ``mybucket/myphotos/2020/yourobjectname``is available at [https://play.min.io/mybucket/myphotos/2020/yourobjectname](https://play.min.io/mybucket/myphotos/2020/yourobjectname)
 
 ```
 mc policy download play/mybucket/myphotos/2020/
@@ -1127,7 +1127,7 @@ ENVIRONMENT VARIABLES:
    MC_ENCRYPT_KEY:  list of comma delimited prefix=secret values
 ```
 
-*Example: Display information on a bucket named "mybucket" on https://play.min.io:9000.*
+*Example: Display information on a bucket named "mybucket" on https://play.min.io.*
 
 
 ```
@@ -1138,7 +1138,7 @@ Size      : 0B
 Type      : folder
 ```
 
-*Example: Display information on an encrypted object "myobject" in "mybucket" on https://play.min.io:9000.*
+*Example: Display information on an encrypted object "myobject" in "mybucket" on https://play.min.io.*
 
 
 ```
@@ -1154,7 +1154,7 @@ Metadata  :
   X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
 ```
 
-*Example: Display information on objects contained in the bucket named "mybucket" on https://play.min.io:9000.*
+*Example: Display information on objects contained in the bucket named "mybucket" on https://play.min.io.*
 
 ```
 mc stat -r play/mybucket

--- a/docs/minio-client-configuration-files.md
+++ b/docs/minio-client-configuration-files.md
@@ -47,7 +47,7 @@ cat config.json
 			"api": "S3v2"
 		},
 		"play": {
-			"url": "https://play.min.io:9000",
+			"url": "https://play.min.io",
 			"accessKey": "Q3AM3UQ867SPQQA43P2F",
 			"secretKey": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 			"api": "S3v4"

--- a/docs/zh_CN/minio-client-complete-guide.md
+++ b/docs/zh_CN/minio-client-complete-guide.md
@@ -141,11 +141,11 @@ mc config host add gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1
 注意：Google云存储只支持旧版签名版本V2，所以你需要选择S3v2。
 
 ## 4. 验证
-`mc`预先配置了云存储服务URL：[https://play.min.io:9000](https://play.min.io:9000)，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
+`mc`预先配置了云存储服务URL：[https://play.min.io](https://play.min.io)，别名“play”。它是一个用于研发和测试的MinIO服务。如果想测试Amazon S3,你可以将“play”替换为“s3”。
 
 *示例:*
 
-列出[https://play.min.io:9000](https://play.min.io:9000)上的所有存储桶。
+列出[https://play.min.io](https://play.min.io)上的所有存储桶。
 
 ```
 mc ls play
@@ -178,7 +178,7 @@ Debug参数开启控制台输出debug信息。
 ```
 mc --debug ls play
 mc: <DEBUG> GET / HTTP/1.1
-Host: play.min.io:9000
+Host: play.min.io
 User-Agent: MinIO (darwin; amd64) minio-go/1.0.1 mc/2016-04-01T00:22:11Z
 Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20160408/us-east-1/s3/aws4_request, SignedHeaders=expect;host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
 Expect: 100-continue
@@ -255,7 +255,7 @@ FLAGS:
   --incomplete, -I		   列出未完整上传的对象。
 ```
 
-*示例： 列出所有https://play.min.io:9000上的存储桶。*
+*示例： 列出所有https://play.min.io上的存储桶。*
 
 ```
 mc ls play
@@ -280,7 +280,7 @@ FLAGS:
 
 ```
 
-*示例：在https://play.min.io:9000上创建一个名叫"mybucket"的存储桶。*
+*示例：在https://play.min.io上创建一个名叫"mybucket"的存储桶。*
 
 
 ```
@@ -428,9 +428,9 @@ FLAGS:
 ```
 
 mc share download --expire 4h play/mybucket/myobject.txt
-URL: https://play.min.io:9000/mybucket/myobject.txt
+URL: https://play.min.io/mybucket/myobject.txt
 Expire: 0 days 4 hours 0 minutes 0 seconds
-Share: https://play.min.io:9000/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
+Share: https://play.min.io/mybucket/myobject.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20160408%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160408T182008Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1527fc8f21a3a7e39ce3c456907a10b389125047adc552bcd86630b9d459b634
 
 ```
 
@@ -452,9 +452,9 @@ FLAGS:
 
 ```
 mc share upload play/mybucket/myotherobject.txt
-URL: https://play.min.io:9000/mybucket/myotherobject.txt
+URL: https://play.min.io/mybucket/myotherobject.txt
 Expire: 7 days 0 hours 0 minutes 0 seconds
-Share: curl https://play.min.io:9000/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
+Share: curl https://play.min.io/mybucket -F x-amz-date=20160408T182356Z -F x-amz-signature=de343934bd0ba38bda0903813b5738f23dde67b4065ea2ec2e4e52f6389e51e1 -F bucket=mybucket -F policy=eyJleHBpcmF0aW9uIjoiMjAxNi0wNC0xNVQxODoyMzo1NS4wMDdaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwibXlidWNrZXQiXSxbImVxIiwiJGtleSIsIm15b3RoZXJvYmplY3QudHh0Il0sWyJlcSIsIiR4LWFtei1kYXRlIiwiMjAxNjA0MDhUMTgyMzU2WiJdLFsiZXEiLCIkeC1hbXotYWxnb3JpdGhtIiwiQVdTNC1ITUFDLVNIQTI1NiJdLFsiZXEiLCIkeC1hbXotY3JlZGVudGlhbCIsIlEzQU0zVVE4NjdTUFFRQTQzUDJGLzIwMTYwNDA4L3VzLWVhc3QtMS9zMy9hd3M0X3JlcXVlc3QiXV19 -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=Q3AM3UQ867SPQQA43P2F/20160408/us-east-1/s3/aws4_request -F key=myotherobject.txt -F file=@<FILE>
 ```
 
 #### 子命令`share list` - 列出之前的共享
@@ -485,14 +485,14 @@ FLAGS:
   --remove			   删除目标上的外部的文件。
 ```
 
-*示例： 将一个本地文件夹镜像到https://play.min.io:9000上的'mybucket'存储桶。*
+*示例： 将一个本地文件夹镜像到https://play.min.io上的'mybucket'存储桶。*
 
 ```
 mc mirror localdir/ play/mybucket
 localdir/b.txt:  40 B / 40 B  ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃  100.00 % 73 B/s 0
 ```
 
-*示例： 持续监听本地文件夹修改并镜像到https://play.min.io:9000上的'mybucket'存储桶。*
+*示例： 持续监听本地文件夹修改并镜像到https://play.min.io上的'mybucket'存储桶。*
 
 ```
 mc mirror -w localdir play/mybucket
@@ -538,7 +538,7 @@ FLAGS:
 
 ```
  mc diff localdir play/mybucket
-‘localdir/notes.txt’ and ‘https://play.min.io:9000/mybucket/notes.txt’ - only in first.
+‘localdir/notes.txt’ and ‘https://play.min.io/mybucket/notes.txt’ - only in first.
 ```
 
 <a name="watch"></a>
@@ -561,9 +561,9 @@ FLAGS:
 
 ```
 mc watch play/testbucket
-[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.min.io:9000/testbucket/CONTRIBUTING.md
-[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.min.io:9000/testbucket/MAINTAINERS.md
-[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.min.io:9000/testbucket/README.md
+[2016-08-18T00:51:29.735Z] 2.7KiB ObjectCreated https://play.min.io/testbucket/CONTRIBUTING.md
+[2016-08-18T00:51:29.780Z]  1009B ObjectCreated https://play.min.io/testbucket/MAINTAINERS.md
+[2016-08-18T00:51:29.839Z] 6.9KiB ObjectCreated https://play.min.io/testbucket/README.md
 ```
 
 *示例： 监听本地文件夹的所有事件*
@@ -648,7 +648,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is ‘none’
 
 *示例：设置可下载的匿名存储桶策略。*
 
-设置``mybucket/myphotos/2020/``子文件夹可匿名下载的策略。现在，这个文件夹下的对象可被公开访问。比如：``mybucket/myphotos/2020/yourobjectname``可通过这个URL [https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname](https://play.min.io:9000/mybucket/myphotos/2020/yourobjectname)访问。
+设置``mybucket/myphotos/2020/``子文件夹可匿名下载的策略。现在，这个文件夹下的对象可被公开访问。比如：``mybucket/myphotos/2020/yourobjectname``可通过这个URL [https://play.min.io/mybucket/myphotos/2020/yourobjectname](https://play.min.io/mybucket/myphotos/2020/yourobjectname)访问。
 
 ```
 mc policy download play/mybucket/myphotos/2020/

--- a/docs/zh_CN/minio-client-configuration-files.md
+++ b/docs/zh_CN/minio-client-configuration-files.md
@@ -47,7 +47,7 @@ cat config.json
 			"api": "S3v2"
 		},
 		"play": {
-			"url": "https://play.min.io:9000",
+			"url": "https://play.min.io",
 			"accessKey": "Q3AM3UQ867SPQQA43P2F",
 			"secretKey": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
 			"api": "S3v4"

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -55,7 +55,7 @@ if [ -n "$MINT_MODE" ]; then
 fi
 
 if [ -z "${SERVER_ENDPOINT+x}" ]; then
-    SERVER_ENDPOINT="play.min.io:9000"
+    SERVER_ENDPOINT="play.min.io"
     ACCESS_KEY="Q3AM3UQ867SPQQA43P2F"
     SECRET_KEY="zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
     ENABLE_HTTPS=1


### PR DESCRIPTION
Most corporate environments block port 9000,
since we already allow access from port 80 and
port 443 just default to https port instead.