### PR TITLE
Accept metadata of form Cache-Control=max-age=xxxxxxx

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -65,7 +65,7 @@ var (
 )
 
 // ErrInvalidMetadata reflects invalid metadata format
-var ErrInvalidMetadata = errors.New("specified metadata should be of form key1=value1,key2=value2,... and so on")
+var ErrInvalidMetadata = errors.New("specified metadata should be of form key1=value1;key2=value2;... and so on")
 
 // Copy command.
 var cpCmd = cli.Command{
@@ -119,7 +119,7 @@ EXAMPLES:
       $ {{.HelpName}} --attr key1=value1,key2=value2 Music/*.mp4 play/mybucket/
 			
   11. Copy a folder recursively from MinIO cloud storage to Amazon S3 cloud storage with specified metadata.
-      $ {{.HelpName}} --attr key1=value1,key2=value2 --recursive play/mybucket/burningman2011/ s3/mybucket/
+      $ {{.HelpName}} --attr Cache-Control=max-age=90000,min-fresh=9000\;key1=value1\;key2=value2 --recursive play/mybucket/burningman2011/ s3/mybucket/
 
   12. Copy a text file to an object storage and assign REDUCED_REDUNDANCY storage-class to the uploaded object.
       $ {{.HelpName}} --storage-class REDUCED_REDUNDANCY myobject.txt play/mybucket
@@ -451,8 +451,8 @@ loop:
 // validate the passed metadataString and populate the map
 func getMetaDataEntry(metadataString string) (map[string]string, *probe.Error) {
 	metaDataMap := make(map[string]string)
-	for _, metaData := range strings.Split(metadataString, ",") {
-		metaDataEntry := strings.Split(metaData, "=")
+	for _, metaData := range strings.Split(metadataString, ";") {
+		metaDataEntry := strings.SplitN(metaData, "=", 2)
 		if len(metaDataEntry) == 2 {
 			metaDataMap[metaDataEntry[0]] = metaDataEntry[1]
 		} else {

--- a/cmd/cp-main_test.go
+++ b/cmd/cp-main_test.go
@@ -28,12 +28,14 @@ func TestParseMetaData(t *testing.T) {
 		err    error
 		status bool
 	}{
-		// success scenerio
-		{"key1=value1,key2=value2", map[string]string{"key1": "value1", "key2": "value2"}, nil, true},
-		// using different delimitter, other than ',' between multiple meta data
-		{"key1=value1;key2=value2", nil, ErrInvalidMetadata, false},
+		// success scenerio using ; as delimitter
+		{"key1=value1;key2=value2", map[string]string{"key1": "value1", "key2": "value2"}, nil, true},
+		// success scenerio using ; as delimitter
+		{"key1=m1=m2,m3=m4;key2=value2", map[string]string{"key1": "m1=m2,m3=m4", "key2": "value2"}, nil, true},
+		// success scenerio using = more than once
+		{"Cache-Control=max-age=90000,min-fresh=9000;key1=value1;key2=value2", map[string]string{"Cache-Control": "max-age=90000,min-fresh=9000", "key1": "value1", "key2": "value2"}, nil, true},
 		// using different delimitter, other than '=' between key value
-		{"key1:value1,key2:value2", nil, ErrInvalidMetadata, false},
+		{"key1:value1;key2:value2", nil, ErrInvalidMetadata, false},
 		// using no delimitter
 		{"key1:value1:key2:value2", nil, ErrInvalidMetadata, false},
 	}

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -557,10 +557,9 @@ FLAGS:
   --older-than value                 copy object(s) older than N days (default: 0)
   --newer-than value                 copy object(s) newer than N days (default: 0)
   --storage-class value, --sc value  set storage class for new object(s) on target
-  --attr                             add custom metadata for the object
+  --attr                             add custom metadata for the object (format: KeyName1=string;KeyName2=string)
   --encrypt value                    encrypt/decrypt objects (using server-side encryption with server managed keys)
   --encrypt-key value                encrypt/decrypt objects (using server-side encryption with customer provided keys)
-  --attr                             apply metadata to objects (format: KeyName1=string,KeyName2=string)
   --help, -h                         show help
 
 ENVIRONMENT VARIABLES:
@@ -578,8 +577,14 @@ myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓�
 *Example: Copy a text file to an object storage with specified metadata.*
 
 ```
-mc cp --attr key1=value1,key2=value2 myobject.txt play/mybucket
+mc cp --attr key1=value1;key2=value2 myobject.txt play/mybucket
 myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
+```
+
+*Example: Copy a folder recursively from MinIO cloud storage to Amazon S3 cloud storage with specified metadata.*
+```
+mc cp --attr Cache-Control=max-age=90000,min-fresh=9000\;key1=value1\;key2=value2 --recursive play/mybucket/burningman2011/ s3/mybucket/
+https://play.minio.io:9000/mybucket/myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
 ```
 
 *Example: Copy a text file to an object storage and assign storage-class `REDUCED_REDUNDANCY` to the uploaded object.*


### PR DESCRIPTION
Accepts the metadata if it contains more then one `=`.

How to test:
Run :
```
mc cp --attr Cache-Control="max-age=90000" /etc/issue play/mybucket
```
Closes #2839 
