### PR TITLE
Fix error message in mc tree

### DIFF
--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -119,9 +119,8 @@ func checkTreeSyntax(ctx *cli.Context) {
 	}
 
 	for _, url := range args {
-		if !isURLPrefixExists(url, false) {
-			fatalIf(probe.NewError(errors.New("See 'mc tree -h' for help")),
-				"'"+url+"' is not a valid 'alias[/bucket-name ...]'")
+		if _, _, err := url2Stat(url, false, nil); err != nil && !isURLPrefixExists(url, false) {
+			fatalIf(err.Trace(url), "Unable to tree `"+url+"`.")
 		}
 	}
 }


### PR DESCRIPTION
Return appropriate errors for `mc tree` to be consistent with `mc ls`

```
praveen@localhost:~/go/src/github.com/minio/mc$ ./mc ls play/testbck
mc: <ERROR> Unable to stat `play/testbck`. Bucket `testbck` does not exist.
praveen@localhost:~/go/src/github.com/minio/mc$ ./mc tree play/testbck
mc: <ERROR> Unable to tree `play/testbck`. Bucket `testbck` does not exist.

```