### PR TITLE
Add mc command for vault info

### DIFF
--- a/cmd/admin-info-etcd.go
+++ b/cmd/admin-info-etcd.go
@@ -1,0 +1,169 @@
+/*
+ * MinIO Client (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/console"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio/pkg/madmin"
+)
+
+const (
+	etcd         = "BoldGreen"
+	etcdDegraded = "BoldYellow"
+	etcdFail     = "BoldRed"
+)
+
+var adminInfoEtcd = cli.Command{
+	Name:   "etcd",
+	Usage:  "display MinIO server etcd information",
+	Action: mainAdminETCDInfo,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+	{{.HelpName}} - {{.Usage}}
+  
+  USAGE:
+	{{.HelpName}} TARGET
+  
+  FLAGS:
+	{{range .VisibleFlags}}{{.}}
+	{{end}}
+  EXAMPLES:
+	1. Get server CPU information of the 'play' MinIO server.
+		 $ {{.HelpName}} play/
+  
+  `,
+}
+
+// serverMonitorMessage holds service status info along with
+// cpu, mem, net and disk monitoristics
+type serverEtcdMessage struct {
+	Monitor string           `json:"status"`
+	Service string           `json:"service"`
+	Addr    string           `json:"address"`
+	Err     string           `json:"error"`
+	ETCD    *madmin.ETCDInfo `json:"etcd,omitempty"`
+}
+
+func (s serverEtcdMessage) JSON() string {
+	s.Monitor = "success"
+	if s.Err != "" {
+		s.Monitor = "fail"
+	}
+	statusJSONBytes, e := json.MarshalIndent(s, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON")
+
+	return string(statusJSONBytes)
+}
+
+func (s serverEtcdMessage) String() string {
+	msg := ""
+	dot := "●"
+	msg += fmt.Sprintf("%s %s        \n", console.Colorize(etcd, dot), console.Colorize(etcd, " ETCD Info"))
+	msg += fmt.Sprintf("   EndPoint          : %s\n", s.ETCD.ETCDEndpoint)
+	msg += fmt.Sprintf("   Domain            : %s\n", s.ETCD.Domain)
+	msg += fmt.Sprintf("   Public IPs        : %s\n", s.ETCD.PublicIPs)
+
+	if s.Err != "" || s.Service == "off" {
+		msg += fmt.Sprintf("   ETCD Status       : %s\n", console.Colorize(etcdFail, "offline"))
+		msg += fmt.Sprintf("   Error             : %s\n", console.Colorize(etcdFail, s.Err))
+		return msg
+	}
+	msg += fmt.Sprintf("   ETCD Status       : %s\n", console.Colorize(etcd, "online"))
+	return msg
+}
+func mainAdminETCDInfo(ctx *cli.Context) error {
+	checkAdminEtcdInfoSyntax(ctx)
+
+	// set the console colors
+	console.SetColor(etcd, color.New(color.FgGreen, color.Bold))
+	console.SetColor(etcdDegraded, color.New(color.FgYellow, color.Bold))
+	console.SetColor(etcdFail, color.New(color.FgRed, color.Bold))
+
+	// Get the alias
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO admin client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Cannot get a configured admin connection.")
+
+	printOfflineErrorMessage := func(err error) {
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		printMsg(serverEtcdMessage{
+			Addr:    aliasedURL,
+			Service: "off",
+			Err:     errMsg,
+		})
+	}
+
+	processErr := func(e error) error {
+		switch e.(type) {
+		case *json.SyntaxError:
+			printOfflineErrorMessage(e)
+			return e
+		case *url.Error:
+			printOfflineErrorMessage(e)
+			return e
+		default:
+			// If the error is not nil and unrecognized, just print it and exit
+			fatalIf(probe.NewError(e), "Cannot get service status.")
+		}
+		return nil
+	}
+
+	etcdInfo, e := client.ServerETCDInfo()
+	if err := processErr(e); err != nil {
+		// exit immediately if error encountered
+		return nil
+	}
+
+	if etcdInfo.Error != "" {
+		printMsg(serverEtcdMessage{
+			Service: "off",
+			Addr:    aliasedURL,
+			Err:     etcdInfo.Error,
+			ETCD:    &etcdInfo,
+		})
+	} else {
+		printMsg(serverEtcdMessage{
+			Service: "on",
+			Addr:    aliasedURL,
+			ETCD:    &etcdInfo,
+		})
+	}
+	return nil
+}
+
+// checkAdminMonitorSyntax - validate all the passed arguments
+func checkAdminEtcdInfoSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 || len(ctx.Args()) > 1 {
+
+		exit := globalErrorExitStatus
+		cli.ShowCommandHelpAndExit(ctx, "etcd", exit)
+	}
+}

--- a/cmd/admin-info-vault.go
+++ b/cmd/admin-info-vault.go
@@ -1,0 +1,183 @@
+/*
+ * MinIO Client (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/console"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio/pkg/madmin"
+)
+
+const (
+	vault         = "BoldGreen"
+	vaultDegraded = "BoldYellow"
+	vaultFail     = "BoldRed"
+)
+
+var adminInfoVault = cli.Command{
+	Name:   "vault",
+	Usage:  "display MinIO server cpu information",
+	Action: mainAdminVaultInfo,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+   {{.HelpName}} - {{.Usage}}
+ 
+ USAGE:
+   {{.HelpName}} TARGET
+ 
+ FLAGS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}
+ EXAMPLES:
+   1. Get server CPU information of the 'play' MinIO server.
+		$ {{.HelpName}} play/
+ 
+ `,
+}
+
+// serverMonitorMessage holds service status info along with
+// cpu, mem, net and disk monitoristics
+type serverVaultMessage struct {
+	Monitor string            `json:"status"`
+	Service string            `json:"service"`
+	Addr    string            `json:"address"`
+	Err     string            `json:"error"`
+	Vault   *madmin.VaultInfo `json:"vault,omitempty"`
+}
+
+func (s serverVaultMessage) JSON() string {
+	s.Monitor = "success"
+	if s.Err != "" {
+		s.Monitor = "fail"
+	}
+	statusJSONBytes, e := json.MarshalIndent(s, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON")
+
+	return string(statusJSONBytes)
+}
+
+func (s serverVaultMessage) String() string {
+	msg := ""
+	dot := "●"
+	msg += fmt.Sprintf("%s %s        \n", console.Colorize(vault, dot), console.Colorize(vault, " Vault Info"))
+	msg += fmt.Sprintf("   EndPoint          : %s\n", s.Vault.Endpoint)
+	msg += fmt.Sprintf("   Name              : %s\n", s.Vault.Name)
+	msg += fmt.Sprintf("   Type              : %s\n", s.Vault.Type)
+
+	if s.Err != "" || s.Service == "off" {
+		msg += fmt.Sprintf("   Vault Status      : %s\n", console.Colorize(vaultFail, "offline"))
+		msg += fmt.Sprintf("   Error             : %s\n", console.Colorize(vaultFail, s.Err))
+		return msg
+	}
+	msg += fmt.Sprintf("   Vault Status      : %s\n", console.Colorize(vault, "online"))
+	if s.Vault.Perm.EncryptionErr != "" {
+
+		msg += fmt.Sprintf("   Encryption Error  : %s\n", console.Colorize(vaultFail, s.Vault.Perm.EncryptionErr))
+	} else {
+		msg += fmt.Sprintf("   Encryption        : %s\n", console.Colorize(vault, "OK"))
+	}
+
+	if s.Vault.Perm.DecryptionErr != "" {
+
+		msg += fmt.Sprintf("   Decryption Error  : %s\n", console.Colorize(vaultFail, s.Vault.Perm.DecryptionErr))
+	} else {
+		msg += fmt.Sprintf("   Decryption        : %s\n", console.Colorize(vault, "OK"))
+	}
+
+	return msg
+}
+func mainAdminVaultInfo(ctx *cli.Context) error {
+	checkAdminVaultInfoSyntax(ctx)
+
+	// set the console colors
+	console.SetColor(vault, color.New(color.FgGreen, color.Bold))
+	console.SetColor(vaultDegraded, color.New(color.FgYellow, color.Bold))
+	console.SetColor(vaultFail, color.New(color.FgRed, color.Bold))
+
+	// Get the alias
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO admin client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Cannot get a configured admin connection.")
+
+	printOfflineErrorMessage := func(err error) {
+		errMsg := ""
+		if err != nil {
+			errMsg = err.Error()
+		}
+		printMsg(serverVaultMessage{
+			Addr:    aliasedURL,
+			Service: "off",
+			Err:     errMsg,
+		})
+	}
+
+	processErr := func(e error) error {
+		switch e.(type) {
+		case *json.SyntaxError:
+			printOfflineErrorMessage(e)
+			return e
+		case *url.Error:
+			printOfflineErrorMessage(e)
+			return e
+		default:
+			// If the error is not nil and unrecognized, just print it and exit
+			fatalIf(probe.NewError(e), "Cannot get service status.")
+		}
+		return nil
+	}
+
+	vaultInfo, e := client.ServerVaultInfo()
+	if err := processErr(e); err != nil {
+		// exit immediately if error encountered
+		return nil
+	}
+
+	if vaultInfo.Error != "" {
+		printMsg(serverVaultMessage{
+			Service: "off",
+			Addr:    aliasedURL,
+			Err:     vaultInfo.Error,
+			Vault:   &vaultInfo,
+		})
+	} else {
+		printMsg(serverVaultMessage{
+			Service: "on",
+			Addr:    aliasedURL,
+			Vault:   &vaultInfo,
+		})
+	}
+	return nil
+}
+
+// checkAdminMonitorSyntax - validate all the passed arguments
+func checkAdminVaultInfoSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 || len(ctx.Args()) > 1 {
+
+		exit := globalErrorExitStatus
+		cli.ShowCommandHelpAndExit(ctx, "vault", exit)
+	}
+}

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -28,6 +28,8 @@ var adminInfoCmd = cli.Command{
 		adminInfoServer,
 		adminInfoCPU,
 		adminInfoMem,
+		adminInfoVault,
+		adminInfoEtcd,
 	},
 	HideHelpCommand: true,
 }


### PR DESCRIPTION
To be tested when [PR Vault-info ](https://github.com/minio/minio/pull/8102)  and [PR etcd-info](https://github.com/minio/minio/pull/8104) are merged . 

How is it tested : 
**For Vault Info** :
 Case 1: Vault server up and running
```   
$ ./mc admin info vault myminio
●  Vault Info        
   EndPoint          : http://127.0.0.1:8200
   Name              : my-minio-key
   Type              : approle
   Vault Status      : online
   Encryption        : OK
   Decryption        : OK

```
Case 2 : Vault Server not running but configured.
```
$ mc admin info vault myminio
●  Vault Info        
   EndPoint          : http://127.0.0.1:8200
   Name              : my-minio-key
   Type              : approle
   Vault Status      : offline
   Error             : Post http://127.0.0.1:8200: dial tcp 127.0.0.1:8200: connect: connection refused
```

Case 3: Vault server not configured 
```
mc admin info vault myminio
mc: <ERROR> Cannot get service status. Server side encryption specified but KMS is not configured.
```

**For ETCD Info** :
Case 1: ETCD server up and running 
``` 
$ mc admin info etcd myminio
●  ETCD Info        
   EndPoint          : http://0.0.0.0:2379
   Domain            : localhost
   Public IPs        : 192.168.86.176
   ETCD Status       : online
```

Case 2 : ETCD server down but configured 
``` 
$ mc admin info etcd myminio
●  ETCD Info        
   EndPoint          : http://0.0.0.0:2379
   Domain            : localhost
   Public IPs        : 192.168.86.176
   ETCD Status       : offline
   Error             : not connected to target server/service
```
Case 3 : ETCD server not configured 
``` 
$ mc admin info etcd myminio
mc: <ERROR> Cannot get service status. ETCD is not configured.
```