### PR TITLE
`mc rb` - accept only bucket or alias as valid

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -489,6 +489,9 @@ func (f *fsClient) Remove(isIncomplete, isRemoveBucket bool, contentCh <-chan *c
 				if os.IsPermission(err) {
 					// Ignore permission error.
 					errorCh <- probe.NewError(PathInsufficientPermission{Path: content.URL.Path})
+				} else if os.IsNotExist(err) && isRemoveBucket {
+					// ignore PathNotFound for dir removal.
+					return
 				} else {
 					errorCh <- probe.NewError(err)
 					return

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"hash/fnv"
 	"io"
 	"net"
@@ -884,6 +885,12 @@ func (c *s3Client) Remove(isIncomplete, isRemoveBucket bool, contentCh <-chan *c
 
 	go func() {
 		defer close(errorCh)
+		if isRemoveBucket {
+			if _, object := c.url2BucketAndObject(); object != "" {
+				errorCh <- probe.NewError(errors.New("cannot delete prefixes with `mc rb` command - Use `mc rm` instead"))
+				return
+			}
+		}
 		for content := range contentCh {
 			// Convert content.URL.Path to objectName for objectsCh.
 			bucket, objectName := c.splitPath(content.URL.Path)


### PR DESCRIPTION
args to this command.

Fixes: #2869

Also fixing a minor bug while deleting directories in file system - a `no such file or directory` message was being displayed even though the directory was deleted
```
/home/kp/Downloads/tmp/dir/abc
└── x  
➜  mc git:(fix-rb) ✗ mc rb ~/Downloads/tmp/dir/abc --force    
mc: <ERROR> Failed to remove `/home/kp/Downloads/tmp/dir/abc`. remove /home/kp/Downloads/tmp/dir/abc: no such file or directory.
```