### PR TITLE
Customizes service help for Windows users

### DIFF
--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -39,7 +39,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Get server configuration of a MinIO server/cluster.
-     $ {{.HelpName}} play/
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 

--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -44,7 +44,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Set server configuration of a MinIO server/cluster.
-     $ cat myconfig | {{.HelpName}} myminio/
+     {{.Prompt}} cat myconfig | {{.HelpName}} myminio/
 `,
 }
 

--- a/cmd/admin-group-add.go
+++ b/cmd/admin-group-add.go
@@ -45,9 +45,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Add users 'fivecent' and 'tencent' to the group 'allcents':
-     $ set +o history
-     $ {{.HelpName}} myminio allcents fivecent tencent
-     $ set -o history
+     {{.Prompt}} {{.HelpName}} myminio allcents fivecent tencent
 `,
 }
 

--- a/cmd/admin-group-disable.go
+++ b/cmd/admin-group-disable.go
@@ -37,6 +37,6 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Disable group 'allcents':
-     $ {{.HelpName}} myminio allcents
+     {{.Prompt}} {{.HelpName}} myminio allcents
 `,
 }

--- a/cmd/admin-group-enable.go
+++ b/cmd/admin-group-enable.go
@@ -43,7 +43,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Enable group 'allcents':
-     $ {{.HelpName}} myminio allcents
+     {{.Prompt}} {{.HelpName}} myminio allcents
 `,
 }
 

--- a/cmd/admin-group-info.go
+++ b/cmd/admin-group-info.go
@@ -40,7 +40,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Get info on group 'allcents':
-     $ {{.HelpName}} myminio allcents
+     {{.Prompt}} {{.HelpName}} myminio allcents
 `,
 }
 

--- a/cmd/admin-group-list.go
+++ b/cmd/admin-group-list.go
@@ -40,7 +40,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List groups:
-     $ {{.HelpName}} myminio
+     {{.Prompt}} {{.HelpName}} myminio
 `,
 }
 

--- a/cmd/admin-group-remove.go
+++ b/cmd/admin-group-remove.go
@@ -41,9 +41,9 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Remove members 'tencent' and 'fivecent' from group 'allcents':
-     $ {{.HelpName}} myminio allcents tencent fivecent
+     {{.Prompt}} {{.HelpName}} myminio allcents tencent fivecent
   2. Remove group 'allcents':
-     $ {{.HelpName}} myminio allcents
+     {{.Prompt}} {{.HelpName}} myminio allcents
 `,
 }
 

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -85,28 +85,28 @@ SCAN MODES:
 
 EXAMPLES:
   1. To format newly replaced disks in a MinIO server with alias 'myminio'
-     $ {{.HelpName}} myminio
+     {{.Prompt}} {{.HelpName}} myminio
 
   2. Heal 'testbucket' in a MinIO server with alias 'myminio'
-     $ {{.HelpName}} myminio/testbucket/
+     {{.Prompt}} {{.HelpName}} myminio/testbucket/
 
   3. Heal all objects under 'dir' prefix
-     $ {{.HelpName}} --recursive myminio/testbucket/dir/
+     {{.Prompt}} {{.HelpName}} --recursive myminio/testbucket/dir/
 
   4. Issue a dry-run heal operation to inspect objects health but not heal them
-     $ {{.HelpName}} --dry-run myminio
+     {{.Prompt}} {{.HelpName}} --dry-run myminio
 
   5. Issue a dry-run heal operation to inspect objects health under 'dir' prefix
-     $ {{.HelpName}} --recursive --dry-run myminio/testbucket/dir/
+     {{.Prompt}} {{.HelpName}} --recursive --dry-run myminio/testbucket/dir/
 
   6. Force start a running heal sequence (meaning it will force kill the running heal sequence and start a new one)
-     $ {{.HelpName}} --force-start myminio/testbucket/dir/
+     {{.Prompt}} {{.HelpName}} --force-start myminio/testbucket/dir/
 		
   7. Force stop a running heal sequence (meaning it will force kill the running heal sequence)
-     $ {{.HelpName}} --force-stop myminio/testbucket/dir/
+     {{.Prompt}} {{.HelpName}} --force-stop myminio/testbucket/dir/
 		
   8. Issue a dry-run heal operation to inspect objects health under 'dir' prefix
-     $ {{.HelpName}} --dry-run myminio/testbucket/dir/
+     {{.Prompt}} {{.HelpName}} --dry-run myminio/testbucket/dir/
 `,
 }
 

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -53,7 +53,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Get server information of the 'play' MinIO server.
-       $ {{.HelpName}} play/
+       {{.Prompt}} {{.HelpName}} play/
 
 `,
 }

--- a/cmd/admin-monitor.go
+++ b/cmd/admin-monitor.go
@@ -59,7 +59,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Get server cpu and mem statistics of the 'play' server.
-     $ {{.HelpName}} play/
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 

--- a/cmd/admin-policy-add.go
+++ b/cmd/admin-policy-add.go
@@ -49,7 +49,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Add a new canned policy 'writeonly'.
-     $ {{.HelpName}} myminio writeonly /tmp/writeonly.json
+     {{.Prompt}} {{.HelpName}} myminio writeonly /tmp/writeonly.json
  `,
 }
 

--- a/cmd/admin-policy-info.go
+++ b/cmd/admin-policy-info.go
@@ -45,7 +45,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Show information on a given policy.
-     $ {{.HelpName}} myminio writeonly
+     {{.Prompt}} {{.HelpName}} myminio writeonly
 `,
 }
 

--- a/cmd/admin-policy-list.go
+++ b/cmd/admin-policy-list.go
@@ -40,7 +40,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List all policies on MinIO server.
-     $ {{.HelpName}} myminio
+     {{.Prompt}} {{.HelpName}} myminio
 `,
 }
 

--- a/cmd/admin-policy-remove.go
+++ b/cmd/admin-policy-remove.go
@@ -43,7 +43,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Remove 'writeonly' policy on MinIO server.
-     $ {{.HelpName}} myminio writeonly
+     {{.Prompt}} {{.HelpName}} myminio writeonly
 `,
 }
 

--- a/cmd/admin-profile-start.go
+++ b/cmd/admin-profile-start.go
@@ -51,7 +51,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
     1. Start CPU profile
-       $ {{.HelpName}} --type cpu myminio/
+       {{.Prompt}} {{.HelpName}} --type cpu myminio/
 
 `,
 }

--- a/cmd/admin-profile-stop.go
+++ b/cmd/admin-profile-stop.go
@@ -45,7 +45,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
     2. Download latest profile data in the current directory
-       $ {{.HelpName}} myminio/
+       {{.Prompt}} {{.HelpName}} myminio/
 `,
 }
 

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -44,7 +44,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Restart MinIO server represented by its alias 'play'.
-     $ {{.HelpName}} play/
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 

--- a/cmd/admin-service-status.go
+++ b/cmd/admin-service-status.go
@@ -49,7 +49,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Check if the 'play' MinIO server is online and show its uptime.
-     $ {{.HelpName}} play/
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 

--- a/cmd/admin-service-stop.go
+++ b/cmd/admin-service-stop.go
@@ -42,7 +42,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Stop MinIO server represented by its alias 'play'.
-     $ {{.HelpName}} play/
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 

--- a/cmd/admin-top-locks.go
+++ b/cmd/admin-top-locks.go
@@ -45,7 +45,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Get a list of the 10 oldest locks on a MinIO cluster.
-     $ {{.HelpName}} myminio/
+     {{.Prompt}} {{.HelpName}} myminio/
 `,
 }
 

--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -66,10 +66,10 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Show console trace for a Minio server with alias 'play'
-		$ {{.HelpName}} play -v -a
+		{{.Prompt}} {{.HelpName}} play -v -a
 
   2. Show trace only for failed requests for a Minio server with alias 'myminio'
-		$ {{.HelpName}} myminio -v -e 
+		{{.Prompt}} {{.HelpName}} myminio -v -e 
  `,
 }
 

--- a/cmd/admin-user-add-policy.go
+++ b/cmd/admin-user-add-policy.go
@@ -43,7 +43,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Set a policy 'writeonly' to 'foobar' on MinIO server.
-     $ {{.HelpName}} myminio foobar writeonly
+     {{.Prompt}} {{.HelpName}} myminio foobar writeonly
 `,
 }
 

--- a/cmd/admin-user-add.go
+++ b/cmd/admin-user-add.go
@@ -47,6 +47,14 @@ EXAMPLES:
      $ set +o history
      $ {{.HelpName}} myminio foobar foo12345 writeonly
      $ set -o history
+
+  2. On Windows, add a new user 'foobar' to MinIO server with policy 'writeonly'.
+     For security reasons, disable Windows history activity (go to
+     "Settings/Privacy/Activity history") momentarily.
+     - Click and deselect "Store my activity on this device" and "Send my activity
+     history to Microsoft" check boxes to disable history activity.
+     C:\> {{.HelpName}} myminio foobar foo12345 writeonly
+     - Click and select "Store my activity on this device" check box to enable history activity.
 `,
 }
 

--- a/cmd/admin-user-disable.go
+++ b/cmd/admin-user-disable.go
@@ -41,7 +41,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Disable a user 'foobar' on MinIO server.
-     $ {{.HelpName}} myminio foobar
+     {{.Prompt}} {{.HelpName}} myminio foobar
 `,
 }
 

--- a/cmd/admin-user-enable.go
+++ b/cmd/admin-user-enable.go
@@ -41,7 +41,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Enable a disabled user 'foobar' on MinIO server.
-     $ {{.HelpName}} myminio foobar
+     {{.Prompt}} {{.HelpName}} myminio foobar
 `,
 }
 

--- a/cmd/admin-user-list.go
+++ b/cmd/admin-user-list.go
@@ -40,7 +40,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List all users on MinIO server.
-     $ {{.HelpName}} myminio
+     {{.Prompt}} {{.HelpName}} myminio
 `,
 }
 

--- a/cmd/admin-user-remove.go
+++ b/cmd/admin-user-remove.go
@@ -40,7 +40,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Remove a user 'foobar' on MinIO server.
-     $ {{.HelpName}} myminio foobar
+     {{.Prompt}} {{.HelpName}} myminio foobar
 `,
 }
 

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -59,16 +59,16 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
   1. Stream an object from Amazon S3 cloud storage to mplayer standard input.
-     $ {{.HelpName}} s3/mysql-backups/kubecon-mysql-operator.mpv | mplayer -
+     {{.Prompt}} {{.HelpName}} s3/mysql-backups/kubecon-mysql-operator.mpv | mplayer -
 
   2. Concatenate contents of file1.txt and stdin to standard output.
-     $ {{.HelpName}} file1.txt - > file.txt
+     {{.Prompt}} {{.HelpName}} file1.txt - > file.txt
 
   3. Concatenate multiple files to one.
-     $ {{.HelpName}} part.* > complete.img
+     {{.Prompt}} {{.HelpName}} part.* > complete.img
 
   4. Save an encrypted object from Amazon S3 cloud storage to a local file.
-     $ {{.HelpName}} --encrypt-key 's3/mysql-backups=32byteslongsecretkeymustbegiven1' s3/mysql-backups/backups-201810.gz > /mnt/data/recent.gz
+     {{.Prompt}} {{.HelpName}} --encrypt-key 's3/mysql-backups=32byteslongsecretkeymustbegiven1' s3/mysql-backups/backups-201810.gz > /mnt/data/recent.gz
 `,
 }
 

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -55,22 +55,29 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Add MinIO service under "myminio" alias. For security reasons turn off bash history momentarily.
+  1. Add MinIO service under "myminio" alias. For security reasons, turn off bash history momentarily.
      $ set +o history
      $ {{.HelpName}} myminio http://localhost:9000 minio minio123
      $ set -o history
 
-  2. Add MinIO service under "myminio" alias, to use dns style bucket lookup. For security reasons 
+  2. Add MinIO service under "myminio" alias, to use dns style bucket lookup. For security reasons, 
      turn off bash history momentarily.
      $ set +o history
      $ {{.HelpName}} myminio http://localhost:9000 minio minio123 --api "s3v4" --lookup "dns"
      $ set -o history
 
-  3. Add Amazon S3 storage service under "mys3" alias. For security reasons turn off bash history momentarily.
+  3. Add Amazon S3 storage service under "mys3" alias. For security reasons, turn off bash history momentarily.
      $ set +o history
      $ {{.HelpName}} mys3 https://s3.amazonaws.com \
                  BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
-     $ set -o history
+	 $ set -o history
+	 
+  4. On Windows, add MinIO service under "myminio" alias. For security reasons, disable Windows
+     history activity (go to "Settings/Privacy/Activity history") momentarily.
+     - Click and deselect "Store my activity on this device" and "Send my activity history to Microsoft"
+       check boxes to disable history activity.
+     C:\> {{.HelpName}} myminio http://localhost:9000 minio minio123 --api "s3v4" --lookup "dns"
+     - Click and select "Store my activity on this device" check box to enable history activity.
 `,
 }
 

--- a/cmd/config-host-list.go
+++ b/cmd/config-host-list.go
@@ -44,10 +44,10 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List all hosts.
-     $ {{.HelpName}}
+     {{.Prompt}} {{.HelpName}}
 
   2. List a specific host.
-     $ {{.HelpName}} s3
+     {{.Prompt}} {{.HelpName}} s3
 `,
 }
 

--- a/cmd/config-host-remove.go
+++ b/cmd/config-host-remove.go
@@ -41,7 +41,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Remove "goodisk" from config.
-     $ {{.HelpName}} goodisk
+     {{.Prompt}} {{.HelpName}} goodisk
 
 `,
 }

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -89,40 +89,40 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
   01. Copy a list of objects from local file system to Amazon S3 cloud storage.
-      $ {{.HelpName}} Music/*.ogg s3/jukebox/
+      {{.Prompt}} {{.HelpName}} Music/*.ogg s3/jukebox/
 
   02. Copy a folder recursively from MinIO cloud storage to Amazon S3 cloud storage.
-      $ {{.HelpName}} --recursive play/mybucket/burningman2011/ s3/mybucket/
+      {{.Prompt}} {{.HelpName}} --recursive play/mybucket/burningman2011/ s3/mybucket/
 
   03. Copy multiple local folders recursively to MinIO cloud storage.
-      $ {{.HelpName}} --recursive backup/2014/ backup/2015/ play/archive/
+      {{.Prompt}} {{.HelpName}} --recursive backup/2014/ backup/2015/ play/archive/
 
   04. Copy a bucket recursively from aliased Amazon S3 cloud storage to local filesystem on Windows.
-      $ {{.HelpName}} --recursive s3\documents\2014\ C:\Backups\2014
+      {{.Prompt}} {{.HelpName}} --recursive s3\documents\2014\ C:\Backups\2014
 
   05. Copy files older than 7 days and 10 hours from MinIO cloud storage to Amazon S3 cloud storage.
-      $ {{.HelpName}} --older-than 7d10h play/mybucket/burningman2011/ s3/mybucket/
+      {{.Prompt}} {{.HelpName}} --older-than 7d10h play/mybucket/burningman2011/ s3/mybucket/
 
   06. Copy files newer than 7 days and 10 hours from MinIO cloud storage to a local path.
-      $ {{.HelpName}} --newer-than 7d10h play/mybucket/burningman2011/ ~/latest/
+      {{.Prompt}} {{.HelpName}} --newer-than 7d10h play/mybucket/burningman2011/ ~/latest/
 
   07. Copy an object with name containing unicode characters to Amazon S3 cloud storage.
-      $ {{.HelpName}} 本語 s3/andoria/
+      {{.Prompt}} {{.HelpName}} 本語 s3/andoria/
 
   08. Copy a local folder with space separated characters to Amazon S3 cloud storage.
-      $ {{.HelpName}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
+      {{.Prompt}} {{.HelpName}} --recursive 'workdir/documents/May 2014/' s3/miniocloud
 
   09. Copy a folder with encrypted objects recursively from Amazon S3 to MinIO cloud storage.
-      $ {{.HelpName}} --recursive --encrypt-key "s3/documents/=32byteslongsecretkeymustbegiven1,myminio/documents/=32byteslongsecretkeymustbegiven2" s3/documents/ myminio/documents/
+      {{.Prompt}} {{.HelpName}} --recursive --encrypt-key "s3/documents/=32byteslongsecretkeymustbegiven1,myminio/documents/=32byteslongsecretkeymustbegiven2" s3/documents/ myminio/documents/
 
   10. Copy a list of objects from local file system to MinIO cloud storage with specified metadata.
-      $ {{.HelpName}} --attr key1=value1,key2=value2 Music/*.mp4 play/mybucket/
+      {{.Prompt}} {{.HelpName}} --attr key1=value1,key2=value2 Music/*.mp4 play/mybucket/
 			
   11. Copy a folder recursively from MinIO cloud storage to Amazon S3 cloud storage with specified metadata.
-      $ {{.HelpName}} --attr Cache-Control=max-age=90000,min-fresh=9000\;key1=value1\;key2=value2 --recursive play/mybucket/burningman2011/ s3/mybucket/
+      {{.Prompt}} {{.HelpName}} --attr Cache-Control=max-age=90000,min-fresh=9000\;key1=value1\;key2=value2 --recursive play/mybucket/burningman2011/ s3/mybucket/
 
   12. Copy a text file to an object storage and assign REDUCED_REDUNDANCY storage-class to the uploaded object.
-      $ {{.HelpName}} --storage-class REDUCED_REDUNDANCY myobject.txt play/mybucket
+      {{.Prompt}} {{.HelpName}} --storage-class REDUCED_REDUNDANCY myobject.txt play/mybucket
  `,
 }
 

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -58,10 +58,10 @@ LEGEND:
 
 EXAMPLES:
   1. Compare a local folder with a folder on Amazon S3 cloud storage.
-     $ {{.HelpName}} ~/Photos s3/mybucket/Photos
+     {{.Prompt}} {{.HelpName}} ~/Photos s3/mybucket/Photos
 
   2. Compare two folders on a local filesystem.
-     $ {{.HelpName}} ~/Photos /Media/Backup/Photos
+     {{.Prompt}} {{.HelpName}} ~/Photos /Media/Backup/Photos
 `,
 }
 

--- a/cmd/event-add.go
+++ b/cmd/event-add.go
@@ -65,13 +65,13 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. Enable bucket notification with a specific arn
-     $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
+     {{.Prompt}} {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
 
    2. Enable bucket notification with filters parameters
-     $ {{.HelpName}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue --event put,delete,get --prefix photos/ --suffix .jpg
+     {{.Prompt}} {{.HelpName}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue --event put,delete,get --prefix photos/ --suffix .jpg
    
    3. Ignore duplicate bucket notification with -p flag
-     $ {{.HelpName}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue -p --event put,delete,get --prefix photos/ --suffix .jpg 	 
+     {{.Prompt}} {{.HelpName}} s3/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue -p --event put,delete,get --prefix photos/ --suffix .jpg 	 
 `,
 }
 

--- a/cmd/event-list.go
+++ b/cmd/event-list.go
@@ -47,10 +47,10 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List notification configurations associated to a specific arn
-    $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
+    {{.Prompt}} {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
 
   2. List all notification configurations
-    $ {{.HelpName}} s3/mybucket
+    {{.Prompt}} {{.HelpName}} s3/mybucket
 `,
 }
 

--- a/cmd/event-remove.go
+++ b/cmd/event-remove.go
@@ -52,10 +52,10 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Remove bucket notification associated to a specific arn
-    $ {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
+    {{.Prompt}} {{.HelpName}} myminio/mybucket arn:aws:sqs:us-west-2:444455556666:your-queue
 
   2. Remove all bucket notifications. --force flag is mandatory here
-    $ {{.HelpName}} myminio/mybucket --force
+    {{.Prompt}} {{.HelpName}} myminio/mybucket --force
 `,
 }
 

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -121,35 +121,35 @@ FORMAT
 
 EXAMPLES:
   01. Find all "foo.jpg" in all buckets under "s3" account.
-      $ {{.HelpName}} s3 --name "foo.jpg"
+      {{.Prompt}} {{.HelpName}} s3 --name "foo.jpg"
 
   02. Find all objects with ".txt" extension under "s3/mybucket".
-      $ {{.HelpName}} s3/mybucket --name "*.txt"
+      {{.Prompt}} {{.HelpName}} s3/mybucket --name "*.txt"
 
   03. Find only the object names without the directory component under "s3/mybucket".
-      $ {{.HelpName}} s3/mybucket --name "*" -print {base}
+      {{.Prompt}} {{.HelpName}} s3/mybucket --name "*" -print {base}
 
   04. Find all images with ".jpg" extension under "s3/photos", prefixed with "album".
-      $ {{.HelpName}} s3/photos --name "*.jpg" --path "*/album*/*"
+      {{.Prompt}} {{.HelpName}} s3/photos --name "*.jpg" --path "*/album*/*"
 
   05. Find all images with ".jpg", ".png", and ".gif" extensions, using regex under "s3/photos".
-      $ {{.HelpName}} s3/photos --regex "(?i)\.(jpg|png|gif)$"
+      {{.Prompt}} {{.HelpName}} s3/photos --regex "(?i)\.(jpg|png|gif)$"
 
   06. Find all images with ".jpg" extension under "s3/bucket" and copy to "play/bucket" *continuously*.
-      $ {{.HelpName}} s3/bucket --name "*.jpg" --watch --exec "mc cp {} play/bucket"
+      {{.Prompt}} {{.HelpName}} s3/bucket --name "*.jpg" --watch --exec "mc cp {} play/bucket"
 
   07. Find and generate public URLs valid for 7 days, for all objects between 64 MB, and 1 GB in size under "s3" account.
-      $ {{.HelpName}} s3 --larger 64MB --smaller 1GB --print {url}
+      {{.Prompt}} {{.HelpName}} s3 --larger 64MB --smaller 1GB --print {url}
 
   08. Find all objects created in the last week under "s3/bucket".
-      $ {{.HelpName}} s3/bucket --newer-than 7d
+      {{.Prompt}} {{.HelpName}} s3/bucket --newer-than 7d
 
   09. Find all objects which were created are older than 2 days, 5 hours and 10 minutes and exclude the ones with ".jpg"
       extension under "s3".
-      $ {{.HelpName}} s3 --older-than 2d5h10m --ignore "*.jpg"
+      {{.Prompt}} {{.HelpName}} s3 --older-than 2d5h10m --ignore "*.jpg"
 
   10. List all objects up to 3 levels sub-directory deep under "s3/bucket".
-      $ {{.HelpName}} s3/bucket --maxdepth 3
+      {{.Prompt}} {{.HelpName}} s3/bucket --maxdepth 3
 `,
 }
 

--- a/cmd/head-main.go
+++ b/cmd/head-main.go
@@ -64,10 +64,10 @@ NOTE:
 
 EXAMPLES:
   1. Display only first line from a 'gzip' compressed object on Amazon S3.
-     $ {{.HelpName}} -n 1 s3/csv-data/population.csv.gz
+     {{.Prompt}} {{.HelpName}} -n 1 s3/csv-data/population.csv.gz
 
   2. Display only first line from server encrypted object on Amazon S3.
-     $ {{.HelpName}} -n 1 --encrypt-key 's3/csv-data=32byteslongsecretkeymustbegiven1' s3/csv-data/population.csv
+     {{.Prompt}} {{.HelpName}} -n 1 --encrypt-key 's3/csv-data=32byteslongsecretkeymustbegiven1' s3/csv-data/population.csv
 `,
 }
 

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -56,22 +56,22 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List buckets on Amazon S3 cloud storage.
-     $ {{.HelpName}} s3
+     {{.Prompt}} {{.HelpName}} s3
 
   2. List buckets and all its contents from Amazon S3 cloud storage recursively.
-     $ {{.HelpName}} --recursive s3
+     {{.Prompt}} {{.HelpName}} --recursive s3
 
   3. List all contents of mybucket on Amazon S3 cloud storage.
-     $ {{.HelpName}} s3/mybucket/
+     {{.Prompt}} {{.HelpName}} s3/mybucket/
 
   4. List all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.
-     $ {{.HelpName}} s3\mybucket\
+     {{.Prompt}} {{.HelpName}} s3\mybucket\
 
   5. List files recursively on a local filesystem on Microsoft Windows.
-     $ {{.HelpName}} --recursive C:\Users\Worf\
+     {{.Prompt}} {{.HelpName}} --recursive C:\Users\Worf\
 
   6. List incomplete (previously failed) uploads of objects on Amazon S3.
-     $ {{.HelpName}} --incomplete s3/mybucket
+     {{.Prompt}} {{.HelpName}} --incomplete s3/mybucket
 `,
 }
 

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -56,22 +56,22 @@ FLAGS:
   {{end}}{{end}}
 EXAMPLES:
   1. Create a bucket on Amazon S3 cloud storage.
-     $ {{.HelpName}} s3/mynewbucket
+     {{.Prompt}} {{.HelpName}} s3/mynewbucket
 
   2. Create a new bucket on Google Cloud Storage.
-     $ {{.HelpName}} gcs/miniocloud
+     {{.Prompt}} {{.HelpName}} gcs/miniocloud
 
   3. Create a new bucket on Amazon S3 cloud storage in region 'us-west-2'.
-     $ {{.HelpName}} --region=us-west-2 s3/myregionbucket
+     {{.Prompt}} {{.HelpName}} --region=us-west-2 s3/myregionbucket
 
   4. Create a new directory including its missing parents (equivalent to 'mkdir -p').
-     $ {{.HelpName}} /tmp/this/new/dir1
+     {{.Prompt}} {{.HelpName}} /tmp/this/new/dir1
 
   5. Create multiple directories including its missing parents (behavior similar to 'mkdir -p').
-     $ {{.HelpName}} /mnt/sdb/mydisk /mnt/sdc/mydisk /mnt/sdd/mydisk
+     {{.Prompt}} {{.HelpName}} /mnt/sdb/mydisk /mnt/sdc/mydisk /mnt/sdd/mydisk
 
   6. Ignore if bucket/directory already exists.
-     $ {{.HelpName}} --ignore-existing myminio/mynewbucket
+     {{.Prompt}} {{.HelpName}} --ignore-existing myminio/mynewbucket
 `,
 }
 

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -112,40 +112,40 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
   01. Mirror a bucket recursively from MinIO cloud storage to a bucket on Amazon S3 cloud storage.
-      $ {{.HelpName}} play/photos/2014 s3/backup-photos
+      {{.Prompt}} {{.HelpName}} play/photos/2014 s3/backup-photos
 
   02. Mirror a local folder recursively to Amazon S3 cloud storage.
-      $ {{.HelpName}} backup/ s3/archive
+      {{.Prompt}} {{.HelpName}} backup/ s3/archive
 
   03. Only mirror files that are newer than 7 days, 10 hours and 30 minutes to Amazon S3 cloud storage.
-      $ {{.HelpName}} --newer-than "7d10h30m" backup/ s3/archive
+      {{.Prompt}} {{.HelpName}} --newer-than "7d10h30m" backup/ s3/archive
 
   04. Mirror a bucket from aliased Amazon S3 cloud storage to a folder on Windows.
-      $ {{.HelpName}} s3\documents\2014\ C:\backup\2014
+      {{.Prompt}} {{.HelpName}} s3\documents\2014\ C:\backup\2014
 
   05. Mirror a bucket from aliased Amazon S3 cloud storage to a local folder use '--overwrite' to overwrite destination.
-      $ {{.HelpName}} --overwrite s3/miniocloud miniocloud-backup
+      {{.Prompt}} {{.HelpName}} --overwrite s3/miniocloud miniocloud-backup
 
   06. Mirror a bucket from MinIO cloud storage to a bucket on Amazon S3 cloud storage and remove any extraneous
       files on Amazon S3 cloud storage.
-      $ {{.HelpName}} --remove play/photos/2014 s3/backup-photos/2014
+      {{.Prompt}} {{.HelpName}} --remove play/photos/2014 s3/backup-photos/2014
 
   07. Continuously mirror a local folder recursively to MinIO cloud storage. '--watch' continuously watches for
       new objects, uploads and removes extraneous files on Amazon S3 cloud storage.
-      $ {{.HelpName}} --remove --watch /var/lib/backups play/backups
+      {{.Prompt}} {{.HelpName}} --remove --watch /var/lib/backups play/backups
 
   08. Mirror a bucket from aliased Amazon S3 cloud storage to a local folder.
       Exclude all .* files and *.temp files when mirroring.
-      $ {{.HelpName}} --exclude ".*" --exclude "*.temp" s3/test ~/test
+      {{.Prompt}} {{.HelpName}} --exclude ".*" --exclude "*.temp" s3/test ~/test
 
   09. Mirror objects newer than 10 days from bucket test to a local folder.
-      $ {{.HelpName}} --newer-than 10d s3/test ~/localfolder
+      {{.Prompt}} {{.HelpName}} --newer-than 10d s3/test ~/localfolder
 
   10. Mirror objects older than 30 days from Amazon S3 bucket test to a local folder.
-      $ {{.HelpName}} --older-than 30d s3/test ~/test
+      {{.Prompt}} {{.HelpName}} --older-than 30d s3/test ~/test
 
   11. Mirror server encrypted objects from MinIO cloud storage to a bucket on Amazon S3 cloud storage
-      $ {{.HelpName}} --encrypt-key "minio/photos=32byteslongsecretkeymustbegiven1,s3/archive=32byteslongsecretkeymustbegiven2" minio/photos/ s3/archive/
+      {{.Prompt}} {{.HelpName}} --encrypt-key "minio/photos=32byteslongsecretkeymustbegiven1,s3/archive=32byteslongsecretkeymustbegiven2" minio/photos/ s3/archive/
 `,
 }
 

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -55,16 +55,16 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
   1. Write contents of stdin to a file on local filesystem.
-     $ {{.HelpName}} /tmp/hello-world.go
+     {{.Prompt}} {{.HelpName}} /tmp/hello-world.go
 
   2. Write contents of stdin to an object on Amazon S3 cloud storage.
-     $ {{.HelpName}} s3/personalbuck/meeting-notes.txt
+     {{.Prompt}} {{.HelpName}} s3/personalbuck/meeting-notes.txt
 
   3. Copy an ISO image to an object on Amazon S3 cloud storage.
-     $ cat debian-8.2.iso | {{.HelpName}} s3/opensource-isos/gnuos.iso
+     {{.Prompt}} cat debian-8.2.iso | {{.HelpName}} s3/opensource-isos/gnuos.iso
 
   4. Stream MySQL database dump to Amazon S3 directly.
-     $ mysqldump -u root -p ******* accountsdb | {{.HelpName}} s3/sql-backups/backups/accountsdb-oct-9-2015.sql
+     {{.Prompt}} mysqldump -u root -p ******* accountsdb | {{.HelpName}} s3/sql-backups/backups/accountsdb-oct-9-2015.sql
 `,
 }
 

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -67,28 +67,28 @@ FILE:
 
 EXAMPLES:
   1. Set bucket to "download" on Amazon S3 cloud storage.
-     $ {{.HelpName}} download s3/burningman2011
+     {{.Prompt}} {{.HelpName}} download s3/burningman2011
 
   2. Set bucket to "public" on Amazon S3 cloud storage.
-     $ {{.HelpName}} public s3/shared
+     {{.Prompt}} {{.HelpName}} public s3/shared
 
   3. Set bucket to "upload" on Amazon S3 cloud storage.
-     $ {{.HelpName}} upload s3/incoming
+     {{.Prompt}} {{.HelpName}} upload s3/incoming
 
   4. Set a prefix to "public" on Amazon S3 cloud storage.
-     $ {{.HelpName}} public s3/public-commons/images
+     {{.Prompt}} {{.HelpName}} public s3/public-commons/images
 
   5. Set a prefix to the policy file path on Amazon S3 cloud storage.
-     $ {{.HelpName}} /path/to/policy.json s3/public-commons/images
+     {{.Prompt}} {{.HelpName}} /path/to/policy.json s3/public-commons/images
 
   6. Get bucket permissions.
-     $ {{.HelpName}} s3/shared
+     {{.Prompt}} {{.HelpName}} s3/shared
 
   7. List policies set to a specified bucket.
-     $ {{.HelpName}} list s3/shared
+     {{.Prompt}} {{.HelpName}} list s3/shared
 
   8. List public object URLs recursively.
-     $ {{.HelpName}} --recursive links s3/shared/
+     {{.Prompt}} {{.HelpName}} --recursive links s3/shared/
 `,
 }
 

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -59,16 +59,16 @@ FLAGS:
   {{end}}{{end}}
 EXAMPLES:
   1. Remove an empty bucket on Amazon S3 cloud storage
-     $ {{.HelpName}} s3/mybucket
+     {{.Prompt}} {{.HelpName}} s3/mybucket
 	 
   2. Remove a directory hierarchy.
-     $ {{.HelpName}} /tmp/this/new/dir1
+     {{.Prompt}} {{.HelpName}} /tmp/this/new/dir1
 	 
   3. Remove bucket 'jazz-songs' and all its contents
-     $ {{.HelpName}} --force s3/jazz-songs
+     {{.Prompt}} {{.HelpName}} --force s3/jazz-songs
 
   4. Remove all buckets and objects recursively from S3 host
-     $ {{.HelpName}} --force --dangerous s3
+     {{.Prompt}} {{.HelpName}} --force --dangerous s3
 `,
 }
 

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -88,34 +88,34 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
   01. Remove a file.
-      $ {{.HelpName}} 1999/old-backup.tgz
+      {{.Prompt}} {{.HelpName}} 1999/old-backup.tgz
 
   02. Perform a fake remove operation.
-      $ {{.HelpName}} --fake 1999/old-backup.tgz
+      {{.Prompt}} {{.HelpName}} --fake 1999/old-backup.tgz
 
   03. Remove all objects recursively from bucket 'jazz-songs' matching the prefix 'louis'.
-      $ {{.HelpName}} --recursive --force s3/jazz-songs/louis/
+      {{.Prompt}} {{.HelpName}} --recursive --force s3/jazz-songs/louis/
 
   04. Remove all objects older than '90' days recursively from bucket 'jazz-songs' matching the prefix 'louis'.
-      $ {{.HelpName}} --recursive --force --older-than 90d s3/jazz-songs/louis/
+      {{.Prompt}} {{.HelpName}} --recursive --force --older-than 90d s3/jazz-songs/louis/
 
   05. Remove all objects newer than 7 days and 10 hours recursively from bucket 'pop-songs'
-      $ {{.HelpName}} --recursive --force --newer-than 7d10h s3/pop-songs/
+      {{.Prompt}} {{.HelpName}} --recursive --force --newer-than 7d10h s3/pop-songs/
 
   06. Remove all objects read from STDIN.
-      $ {{.HelpName}} --force --stdin
+      {{.Prompt}} {{.HelpName}} --force --stdin
 
   07. Remove all objects recursively from Amazon S3 cloud storage.
-      $ {{.HelpName}} --recursive --force --dangerous s3
+      {{.Prompt}} {{.HelpName}} --recursive --force --dangerous s3
 
   08. Remove all buckets and objects older than '90' days recursively from host
-      $ {{.HelpName}} --recursive --dangerous --force --older-than 90d s3
+      {{.Prompt}} {{.HelpName}} --recursive --dangerous --force --older-than 90d s3
 
   09. Drop all incomplete uploads on the bucket 'jazz-songs'.
-      $ {{.HelpName}} --incomplete --recursive --force s3/jazz-songs/
+      {{.Prompt}} {{.HelpName}} --incomplete --recursive --force s3/jazz-songs/
 
   10. Remove an encrypted object from Amazon S3 cloud storage.
-      $ {{.HelpName}} --encrypt-key "s3/sql-backups/=32byteslongsecretkeymustbegiven1" s3/sql-backups/1999/old-backup.tgz
+      {{.Prompt}} {{.HelpName}} --encrypt-key "s3/sql-backups/=32byteslongsecretkeymustbegiven1" s3/sql-backups/1999/old-backup.tgz
 `,
 }
 

--- a/cmd/session-clear.go
+++ b/cmd/session-clear.go
@@ -52,13 +52,13 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Clear session.
-     $ {{.HelpName}} ygVIpSJs
+     {{.Prompt}} {{.HelpName}} ygVIpSJs
 
   2. Clear all sessions.
-     $ {{.HelpName}} all
+     {{.Prompt}} {{.HelpName}} all
 
   3. Forcefully clear an obsolete session.
-     $ {{.HelpName}} ygVIpSJs --force
+     {{.Prompt}} {{.HelpName}} ygVIpSJs --force
 `,
 }
 

--- a/cmd/session-list.go
+++ b/cmd/session-list.go
@@ -42,7 +42,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. List sessions.
-     $ {{.HelpName}}
+     {{.Prompt}} {{.HelpName}}
 `,
 }
 

--- a/cmd/session-resume.go
+++ b/cmd/session-resume.go
@@ -48,7 +48,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Resume session.
-     $ {{.HelpName}} ygVIpSJs
+     {{.Prompt}} {{.HelpName}} ygVIpSJs
 `,
 }
 

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -52,16 +52,16 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Share this object with 7 days default expiry.
-     $ {{.HelpName}} s3/backup/2006-Mar-1/backup.tar.gz
+     {{.Prompt}} {{.HelpName}} s3/backup/2006-Mar-1/backup.tar.gz
 
   2. Share this object with 10 minutes expiry.
-     $ {{.HelpName}} --expire=10m s3/backup/2006-Mar-1/backup.tar.gz
+     {{.Prompt}} {{.HelpName}} --expire=10m s3/backup/2006-Mar-1/backup.tar.gz
 
   3. Share all objects under this folder with 5 days expiry.
-     $ {{.HelpName}} --expire=120h s3/backup/2006-Mar-1/
+     {{.Prompt}} {{.HelpName}} --expire=120h s3/backup/2006-Mar-1/
 
   4. Share all objects under this bucket and all its folders and sub-folders with 5 days expiry.
-     $ {{.HelpName}} --recursive --expire=120h s3/backup/
+     {{.Prompt}} {{.HelpName}} --recursive --expire=120h s3/backup/
 `,
 }
 

--- a/cmd/share-list-main.go
+++ b/cmd/share-list-main.go
@@ -47,10 +47,10 @@ COMMAND:
 
 EXAMPLES:
   1. List previously shared downloads, that haven't expired yet.
-      $ {{.HelpName}} download
+      {{.Prompt}} {{.HelpName}} download
 
   2. List previously shared uploads, that haven't expired yet.
-      $ {{.HelpName}} upload
+      {{.Prompt}} {{.HelpName}} upload
 `,
 }
 

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -54,16 +54,16 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Generate a curl command to allow upload access for a single object. Command expires in 7 days (default).
-     $ {{.HelpName}} s3/backup/2006-Mar-1/backup.tar.gz
+     {{.Prompt}} {{.HelpName}} s3/backup/2006-Mar-1/backup.tar.gz
 
   2. Generate a curl command to allow upload access to a folder. Command expires in 120 hours.
-     $ {{.HelpName}} --expire=120h s3/backup/2007-Mar-2/
+     {{.Prompt}} {{.HelpName}} --expire=120h s3/backup/2007-Mar-2/
 
   3. Generate a curl command to allow upload access of only '.png' images to a folder. Command expires in 2 hours.
-     $ {{.HelpName}} --expire=2h --content-type=image/png s3/backup/2007-Mar-2/
+     {{.Prompt}} {{.HelpName}} --expire=2h --content-type=image/png s3/backup/2007-Mar-2/
 
   4. Generate a curl command to allow upload access to any objects matching the key prefix 'backup/'. Command expires in 2 hours.
-     $ {{.HelpName}} --recursive --expire=2h s3/backup/2007-Mar-2/backup/
+     {{.Prompt}} {{.HelpName}} --recursive --expire=2h s3/backup/2007-Mar-2/backup/
 `,
 }
 

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -95,28 +95,28 @@ SERIALIZATION OPTIONS:
 
 EXAMPLES:
   1. Run a query on a set of objects recursively on AWS S3.
-     $ {{.HelpName}} --recursive --query "select * from S3Object" s3/personalbucket/my-large-csvs/
+     {{.Prompt}} {{.HelpName}} --recursive --query "select * from S3Object" s3/personalbucket/my-large-csvs/
 
   2. Run a query on an object on Minio.
-     $ {{.HelpName}} --query "select count(s.power) from S3Object" myminio/iot-devices/power-ratio.csv
+     {{.Prompt}} {{.HelpName}} --query "select count(s.power) from S3Object" myminio/iot-devices/power-ratio.csv
 
   3. Run a query on an encrypted object with customer provided keys.
-     $ {{.HelpName}} --encrypt-key "myminio/iot-devices=32byteslongsecretkeymustbegiven1" \
+     {{.Prompt}} {{.HelpName}} --encrypt-key "myminio/iot-devices=32byteslongsecretkeymustbegiven1" \
 	      --query "select count(s.power) from S3Object s" myminio/iot-devices/power-ratio-encrypted.csv
 
   4. Run a query on an object on MinIO in gzip format using ; as field delimiter,
      newline as record delimiter and file header to be used
-     $ {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
+     {{.Prompt}} {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
 	      --query "select count(s.power) from S3Object" myminio/iot-devices/power-ratio.csv.gz
 
   5. Run a query on an object on MinIO in gzip format using ; as field delimiter,
      newline as record delimiter and file header to be used
-     $ {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
+     {{.Prompt}} {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
               --json-output "rd=\n\n" --query "select * from S3Object" myminio/iot-devices/data.csv
 
   6. Run same query as in 5., but specify csv output headers. If --csv-output-headers is
      specified as "", first row of csv is interpreted as header
-     $ {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
+     {{.Prompt}} {{.HelpName}} --compression GZIP --csv-input "rd=\n,fh=USE,fd=;" \
                      --csv-output "rd=\n" --csv-output-header "device_id,uptime,lat,lon" \
                      --query "select * from S3Object" myminio/iot-devices/data.csv
 `,

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -55,16 +55,16 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
   1. Stat all contents of mybucket on Amazon S3 cloud storage.
-     $ {{.HelpName}} s3/mybucket/
+     {{.Prompt}} {{.HelpName}} s3/mybucket/
 
   2. Stat all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.
-     $ {{.HelpName}} s3\mybucket\
+     {{.Prompt}} {{.HelpName}} s3\mybucket\
 
   3. Stat files recursively on a local filesystem on Microsoft Windows.
-     $ {{.HelpName}} --recursive C:\Users\Worf\
+     {{.Prompt}} {{.HelpName}} --recursive C:\Users\Worf\
 
   4. Stat encrypted files on Amazon S3 cloud storage.
-     $ {{.HelpName}} --encrypt-key "s3/personal-docs/=32byteslongsecretkeymustbegiven1" s3/personal-docs/2018-account_report.docx
+     {{.Prompt}} {{.HelpName}} --encrypt-key "s3/personal-docs/=32byteslongsecretkeymustbegiven1" s3/personal-docs/2018-account_report.docx
 `,
 }
 

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -88,19 +88,19 @@ FLAGS:
   {{end}}
 EXAMPLES:
    1. List all buckets and directories on MinIO object storage server in tree format.
-      $ {{.HelpName}} myminio
+      {{.Prompt}} {{.HelpName}} myminio
 
    2. List all directories in "mybucket" on MinIO object storage server in tree format.
-      $ {{.HelpName}} myminio/mybucket/
+      {{.Prompt}} {{.HelpName}} myminio/mybucket/
 
    3. List all directories in "mybucket" on MinIO object storage server hosted on Microsoft Windows in tree format.
-      $ {{.HelpName}} myminio\mybucket\
+      {{.Prompt}} {{.HelpName}} myminio\mybucket\
 
    4. List all directories and objects in "mybucket" on MinIO object storage server in tree format.
-      $ {{.HelpName}} --files myminio/mybucket/
+      {{.Prompt}} {{.HelpName}} --files myminio/mybucket/
 
    5. List all directories upto depth level '2' in tree format.
-      $ {{.HelpName}} --depth 2 myminio/mybucket/
+      {{.Prompt}} {{.HelpName}} --depth 2 myminio/mybucket/
 `,
 }
 

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -69,7 +69,7 @@ EXIT STATUS:
 
 EXAMPLES:
   1. Check and update mc:
-     $ {{.HelpName}}
+     {{.Prompt}} {{.HelpName}}
 `,
 }
 

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -53,7 +53,7 @@ FLAGS:
   {{end}}{{end}}
 EXAMPLES:
   1. Prints the MinIO Client version:
-     $ {{.HelpName}}
+     {{.Prompt}} {{.HelpName}}
 `,
 }
 

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -70,19 +70,19 @@ FLAGS:
   {{end}}{{end}}
 EXAMPLES:
   1. Watch new S3 operations on a MinIO server
-     $ {{.HelpName}} play/testbucket
+     {{.Prompt}} {{.HelpName}} play/testbucket
 
   2. Watch new events for a specific prefix "output/"  on MinIO server.
-     $ {{.HelpName}} --prefix "output/" play/testbucket
+     {{.Prompt}} {{.HelpName}} --prefix "output/" play/testbucket
 
   3. Watch new events for a specific suffix ".jpg" on MinIO server.
-     $ {{.HelpName}} --suffix ".jpg" play/testbucket
+     {{.Prompt}} {{.HelpName}} --suffix ".jpg" play/testbucket
 
   4. Watch new events on a specific prefix and suffix on MinIO server.
-     $ {{.HelpName}} --suffix ".jpg" --prefix "photos/" play/testbucket
+     {{.Prompt}} {{.HelpName}} --suffix ".jpg" --prefix "photos/" play/testbucket
 
   5. Watch for events on local directory.
-     $ {{.HelpName}} /usr/share
+     {{.Prompt}} {{.HelpName}} /usr/share
 `,
 }
 


### PR DESCRIPTION
Fixes #2776

Existing `mc` help examples were not making any distinction between Linux and Windows OS. All examples were in Linux format. 
This change adjusts only the prompt information (`$ ` vs `C:\> `), since the path separator does not matter, that is Windows and MinIO accepts both Unix/Linux style separator `/` and Windows style separator, `\`.
And there were no Environment Variable definitions to adjust in the `mc` help content.