### PR TITLE
Update Docker Alpine base image to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN  \
      git clone https://github.com/minio/mc && cd mc && \
      go install -v -ldflags "$(go run buildscripts/gen-ldflags.go)"
 
-FROM alpine:3.9
+FROM alpine:3.10
 
 COPY --from=0 /go/bin/mc /usr/bin/mc
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 MAINTAINER MinIO Inc <dev@min.io>
 


### PR DESCRIPTION
This pr updates Docker Alpine image to last stable version (3.10)