### PR TITLE
README: update minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mc.exe --help
 ```
 
 ## Install from Source
-Source installation is only intended for developers and advanced users. If you do not have a working Golang environment, please follow [How to install Golang](https://golang.org/doc/install). Minimum version required is [go1.12](https://golang.org/dl/#stable)
+Source installation is only intended for developers and advanced users. If you do not have a working Golang environment, please follow [How to install Golang](https://golang.org/doc/install). Minimum version required is [go1.13](https://golang.org/dl/#stable)
 
 ```sh
 GO111MODULE=on go get github.com/minio/mc


### PR DESCRIPTION
PR #2888 bumped the minimum go version from 1.12 to 1.13 but did not
update README.md to reflect the change. This commit updates the readme
to be in line with the code.

Attempting to build `mc` from source on go 1.12 yields this error:
```
$ GO111MODULE=on go get github.com/minio/mc
go: finding github.com/minio/mc latest
package github.com/minio/mc: build constraints exclude all Go files in /home/andy/go/pkg/mod/github.com/minio/mc@v0.0.0-20191004065813-f79aefa79713
```