### PR TITLE
No 'Removing ...' messages for prefixes(dirs)

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -266,7 +266,7 @@ func removeRecursive(url string, isIncomplete bool, isFake bool, olderThan, newe
 		urlString := content.URL.Path
 
 		if !content.Time.IsZero() {
-			// Skip objects older than --older-than parameter if specified
+			// Skip objects older than --older-than parameter, if specified
 			if olderThan != "" && isOlder(content.Time, olderThan) {
 				continue
 			}
@@ -275,6 +275,9 @@ func removeRecursive(url string, isIncomplete bool, isFake bool, olderThan, newe
 			if newerThan != "" && isNewer(content.Time, newerThan) {
 				continue
 			}
+		} else {
+			// Skip prefix levels.
+			continue
 		}
 
 		printMsg(rmMessage{


### PR DESCRIPTION
Fixes #2800 

The problem here was those `mc rm ...`  command output messages generated for object prefix subsections and they show up for each subsection regardless of it is removed or not. 

Prefixes with their subsections look like Unix/Linux filesystem hierarchical directories, but in reality they are just part of the name of the  object. That is, prefix and an object name are actually a single/atomic entity and when an object is removed, the full object name, `prefix+objectName`, is removed.

It is misleading to show the subsections of a prefix in `mc rm ...` command output, as if they are independent entities, like sub-directories, that can be removed or kept. 
The most confusing scenario of all is when remove messages are spitted out for each prefix subsections, which is already removed with the object.

So, we've decided to clean-up all prefix related messages from `mc rm ...` command's output.

Here is an example:
Let's assume I have the following bucket (`ersan`) and some objects with `myminio` as my target alias.
```
$ mc ls -r myminio/ersan
[2019-10-08 14:30:31 PDT]     26B delete/deleteMe
[2019-10-08 14:19:56 PDT]     26B file100
[2019-10-08 14:19:56 PDT]     26B file200
[2019-10-08 14:19:56 PDT]     26B file300
[2019-10-08 14:30:31 PDT]     26B old/a/b/delete/deleteMe
[2019-10-08 14:19:56 PDT]     26B old/a/file400
```
After the above 2 `deleteMe` objects, created at a time `--newer than X minutes`, are removed;
```
$ mc rm -r --newer-than Xm --force myminio/ersan
Removing `myminio/ersan/delete/deleteMe`.
Removing `myminio/ersan/old/a/b/delete/deleteMe`.
```
Notice there are no messages about removal of objects' prefix subsections like, before. 
Those confusing `"Removing myminio/ersan/delete/."` kinds of messages are gone with this fix. 

So, the bucket content is listed as;
```
$ mc ls -r myminio/ersan
[2019-10-08 14:19:56 PDT]     26B file100
[2019-10-08 14:19:56 PDT]     26B file200
[2019-10-08 14:19:56 PDT]     26B file300
[2019-10-08 14:19:56 PDT]     26B old/a/file400
```