### PR TITLE
Fix zh_CN doc about policy errors

### DIFF
--- a/docs/zh_CN/minio-client-complete-guide.md
+++ b/docs/zh_CN/minio-client-complete-guide.md
@@ -651,7 +651,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is ‘none’
 设置``mybucket/myphotos/2020/``子文件夹可匿名下载的策略。现在，这个文件夹下的对象可被公开访问。比如：``mybucket/myphotos/2020/yourobjectname``可通过这个URL [https://play.min.io/mybucket/myphotos/2020/yourobjectname](https://play.min.io/mybucket/myphotos/2020/yourobjectname)访问。
 
 ```
-mc policy download play/mybucket/myphotos/2020/
+mc policy set download play/mybucket/myphotos/2020/
 Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'download'
 ```
 
@@ -660,7 +660,7 @@ Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'download'
 删除所有*mybucket/myphotos/2020/*这个子文件夹下的匿名存储桶策略。
 
 ```
-mc policy none play/mybucket/myphotos/2020/
+mc policy set none play/mybucket/myphotos/2020/
 Access permission for ‘play/mybucket/myphotos/2020/’ is set to 'none'
 ```
 


### PR DESCRIPTION
```sh
mc policy download play/mybucket/myphotos/2020/
```
and

```sh
mc policy none play/mybucket/myphotos/2020/
```
**Error, missing `set`**



```sh
❯ mc policy -h                                                                              2019.10.10 at  15:47:23
Name:
  mc policy - manage anonymous access to buckets and objects

USAGE:
  mc policy [FLAGS] PERMISSION TARGET
  mc policy [FLAGS] FILE TARGET
  mc policy [FLAGS] TARGET
  mc policy list [FLAGS] TARGET

FLAGS:
  --recursive, -r               list recursively
  --config-dir value, -C value  path to configuration folder (default: "/Users/yiranzai/.mc")
  --quiet, -q                   disable progress bar display
  --no-color                    disable color theme
  --json                        enable JSON formatted output
  --debug                       enable debug output
  --insecure                    disable SSL certificate verification
  --help, -h                    show help

PERMISSION:
  Allowed policies are: [none, download, upload, public].

FILE:
  A valid S3 policy JSON filepath.

EXAMPLES:
   1. Set bucket to "download" on Amazon S3 cloud storage.
      $ mc policy set download s3/burningman2011

   2. Set bucket to "public" on Amazon S3 cloud storage.
      $ mc policy set public s3/shared

   3. Set bucket to "upload" on Amazon S3 cloud storage.
      $ mc policy set upload s3/incoming

   4. Set policy to "public" for bucket with prefix on Amazon S3 cloud storage.
      $ mc policy set public s3/public-commons/images

   5. Set a custom prefix based bucket policy on Amazon S3 cloud storage using a JSON file.
      $ mc policy set-json /path/to/policy.json s3/public-commons/images

   6. Get bucket permissions.
      $ mc policy get s3/shared

   7. Get bucket permissions in JSON format.
      $ mc policy get-json s3/shared

   8. List policies set to a specified bucket.
      $ mc policy list s3/shared

   9. List public object URLs recursively.
      $ mc policy --recursive links s3/shared/
```