### PR TITLE
Update flag in cp-main.go

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -63,7 +63,7 @@ var (
 		},
 		cli.BoolFlag{
 			Name:  "continue, c",
-			Usage: "create or resume copy session.",
+			Usage: "create or resume copy session",
 		},
 	}
 )


### PR DESCRIPTION
Removing full stop  in continue to  be consistent with other description.
```
--attr value                       add custom metadata for the object
--continue, -c                     create or resume copy session
```