### PR TITLE
Add options to preserve file system attributes

### DIFF
--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -152,7 +152,7 @@ func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error 
 		// downloaded object is equal to the original one. FS files
 		// are ignored since some of them have zero size though they
 		// have contents like files under /proc.
-		client, content, err := url2Stat(sourceURL, false, encKeyDB)
+		client, content, err := url2Stat(sourceURL, false, false, encKeyDB)
 		if err == nil && client.GetURL().Type == objectStorage {
 			size = content.Size
 		}

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -210,7 +210,7 @@ func (s *TestSuite) TestStatBucket(c *C) {
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1", true)
 	c.Assert(err, IsNil)
-	_, err = fsClient.Stat(false, false, nil)
+	_, err = fsClient.Stat(false, false, false, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -334,7 +334,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	content, err := fsClient.Stat(false, false, nil)
+	content, err := fsClient.Stat(false, false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(content.Size, Equals, int64(dataLen))
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1115,7 +1115,7 @@ func (c *s3Client) listObjectWrapper(bucket, object string, isRecursive bool, do
 }
 
 // Stat - send a 'HEAD' on a bucket or object to fetch its metadata.
-func (c *s3Client) Stat(isIncomplete, isFetchMeta bool, sse encrypt.ServerSide) (*clientContent, *probe.Error) {
+func (c *s3Client) Stat(isIncomplete, isFetchMeta, isPreserve bool, sse encrypt.ServerSide) (*clientContent, *probe.Error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	bucket, object := c.url2BucketAndObject()
@@ -1605,7 +1605,7 @@ func (c *s3Client) listIncompleteRecursiveInRoutineDirOpt(contentCh chan *client
 	} else if strings.HasSuffix(object, string(c.targetURL.Separator)) {
 		// Get stat of given object is a directory.
 		isIncomplete := true
-		content, perr := c.Stat(isIncomplete, false, nil)
+		content, perr := c.Stat(isIncomplete, false, false, nil)
 		cContent = content
 		if perr != nil {
 			contentCh <- &clientContent{Err: perr.Trace(bucket)}
@@ -1744,7 +1744,7 @@ func (c *s3Client) listRecursiveInRoutineDirOpt(contentCh chan *clientContent, d
 		// Get stat of given object is a directory.
 		isIncomplete := false
 		isFetchMeta := false
-		content, perr := c.Stat(isIncomplete, isFetchMeta, nil)
+		content, perr := c.Stat(isIncomplete, isFetchMeta, false, nil)
 		cContent = content
 		if perr != nil {
 			contentCh <- &clientContent{Err: perr.Trace(bucket)}

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -171,7 +171,7 @@ func urlJoinPath(url1, url2 string) string {
 }
 
 // url2Stat returns stat info for URL.
-func url2Stat(urlStr string, isFetchMeta bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *clientContent, err *probe.Error) {
+func url2Stat(urlStr string, isFetchMeta, fileAttr bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *clientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
@@ -179,7 +179,7 @@ func url2Stat(urlStr string, isFetchMeta bool, encKeyDB map[string][]prefixSSEPa
 	alias, _ := url2Alias(urlStr)
 	sse := getSSE(urlStr, encKeyDB[alias])
 
-	content, err = client.Stat(false, isFetchMeta, sse)
+	content, err = client.Stat(false, isFetchMeta, fileAttr, sse)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -45,7 +45,7 @@ const defaultMultipartThreadsNum = 4
 // Client - client interface
 type Client interface {
 	// Common operations
-	Stat(isIncomplete, isFetchMeta bool, sse encrypt.ServerSide) (content *clientContent, err *probe.Error)
+	Stat(isIncomplete, isFetchMeta, isPreserve bool, sse encrypt.ServerSide) (content *clientContent, err *probe.Error)
 	List(isRecursive, isIncomplete bool, showDir DirOpt) <-chan *clientContent
 
 	// Bucket operations

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -159,7 +159,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 		return "", err
 	}
 
-	if _, err = s3Client.Stat(false, false, nil); err != nil {
+	if _, err = s3Client.Stat(false, false, false, nil); err != nil {
 		switch err.ToGoError().(type) {
 		case BucketDoesNotExist:
 			// Bucket doesn't exist, means signature probing worked V4.
@@ -170,7 +170,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 			if err != nil {
 				return "", err
 			}
-			if _, err = s3Client.Stat(false, false, nil); err != nil {
+			if _, err = s3Client.Stat(false, false, false, nil); err != nil {
 				switch err.ToGoError().(type) {
 				case BucketDoesNotExist:
 					// Bucket doesn't exist, means signature probing worked with V2.

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -53,7 +53,7 @@ const (
 func guessCopyURLType(sourceURLs []string, targetURL string, isRecursive bool, keys map[string][]prefixSSEPair) (copyURLsType, *probe.Error) {
 	if len(sourceURLs) == 1 { // 1 Source, 1 Target
 		sourceURL := sourceURLs[0]
-		_, sourceContent, err := url2Stat(sourceURL, false, keys)
+		_, sourceContent, err := url2Stat(sourceURL, false, false, keys)
 		if err != nil {
 			return copyURLsTypeInvalid, err
 		}
@@ -88,7 +88,7 @@ func prepareCopyURLsTypeA(sourceURL string, targetURL string, encKeyDB map[strin
 	// Find alias and expanded clientURL.
 	targetAlias, targetURL, _ := mustExpandAlias(targetURL)
 
-	_, sourceContent, err := url2Stat(sourceURL, false, encKeyDB)
+	_, sourceContent, err := url2Stat(sourceURL, false, false, encKeyDB)
 	if err != nil {
 		// Source does not exist or insufficient privileges.
 		return URLs{Error: err.Trace(sourceURL)}
@@ -121,7 +121,7 @@ func prepareCopyURLsTypeB(sourceURL string, targetURL string, encKeyDB map[strin
 	// Find alias and expanded clientURL.
 	targetAlias, targetURL, _ := mustExpandAlias(targetURL)
 
-	_, sourceContent, err := url2Stat(sourceURL, false, encKeyDB)
+	_, sourceContent, err := url2Stat(sourceURL, false, false, encKeyDB)
 	if err != nil {
 		// Source does not exist or insufficient privileges.
 		return URLs{Error: err.Trace(sourceURL)}

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -125,7 +125,7 @@ func checkDiffSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	// Diff only works between two directories, verify them below.
 
 	// Verify if firstURL is accessible.
-	_, firstContent, err := url2Stat(firstURL, false, encKeyDB)
+	_, firstContent, err := url2Stat(firstURL, false, false, encKeyDB)
 	if err != nil {
 		fatalIf(err.Trace(firstURL), fmt.Sprintf("Unable to stat '%s'.", firstURL))
 	}
@@ -136,7 +136,7 @@ func checkDiffSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	}
 
 	// Verify if secondURL is accessible.
-	_, secondContent, err := url2Stat(secondURL, false, encKeyDB)
+	_, secondContent, err := url2Stat(secondURL, false, false, encKeyDB)
 	if err != nil {
 		fatalIf(err.Trace(secondURL), fmt.Sprintf("Unable to stat '%s'.", secondURL))
 	}

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -170,7 +170,7 @@ func checkFindSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 
 	// Extract input URLs and validate.
 	for _, url := range args {
-		_, _, err := url2Stat(url, false, encKeyDB)
+		_, _, err := url2Stat(url, false, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, false) {
 			// Bucket name empty is a valid error for 'find myminio' unless we are using watch, treat it as such.
 			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !ctx.Bool("watch") {

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -423,7 +423,7 @@ func getShareURL(path string) string {
 	clnt, err := newClientFromAlias(targetAlias, targetURLFull)
 	fatalIf(err.Trace(targetAlias, targetURLFull), "Unable to initialize client instance from alias.")
 
-	content, err := clnt.Stat(false, false, nil)
+	content, err := clnt.Stat(false, false, false, nil)
 	fatalIf(err.Trace(targetURLFull, targetAlias), "Unable to lookup file/object.")
 
 	// Skip if its a directory.

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -91,7 +91,7 @@ func checkListSyntax(ctx *cli.Context) {
 	isIncomplete := ctx.Bool("incomplete")
 
 	for _, url := range URLs {
-		_, _, err := url2Stat(url, false, nil)
+		_, _, err := url2Stat(url, false, false, nil)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			// Bucket name empty is a valid error for 'ls myminio',
 			// treat it as such.
@@ -131,7 +131,7 @@ func mainList(ctx *cli.Context) error {
 
 		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 			var st *clientContent
-			st, err = clnt.Stat(isIncomplete, false, nil)
+			st, err = clnt.Stat(isIncomplete, false, false, nil)
 			if err == nil && st.Type.IsDir() {
 				targetURL = targetURL + string(clnt.GetURL().Separator)
 				clnt, err = newClient(targetURL)

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -215,7 +215,7 @@ func mainRemoveBucket(ctx *cli.Context) error {
 			cErr = exitStatus(globalErrorExitStatus)
 			continue
 		}
-		_, err = clnt.Stat(false, false, nil)
+		_, err = clnt.Stat(false, false, false, nil)
 		if err != nil {
 			switch err.ToGoError().(type) {
 			case BucketNameEmpty:

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -93,7 +93,7 @@ func checkShareDownloadSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEP
 	isRecursive := ctx.Bool("recursive")
 	if !isRecursive {
 		for _, url := range ctx.Args() {
-			_, _, err := url2Stat(url, false, encKeyDB)
+			_, _, err := url2Stat(url, false, false, encKeyDB)
 			if err != nil {
 				fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 			}
@@ -126,7 +126,7 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 	// Channel which will receive objects whose URLs need to be shared
 	objectsCh := make(chan *clientContent)
 
-	content, err := clnt.Stat(isIncomplete, isFetchMeta, nil)
+	content, err := clnt.Stat(isIncomplete, isFetchMeta, false, nil)
 	if err != nil {
 		return err.Trace(clnt.GetURL().String())
 	}

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -89,7 +89,7 @@ func checkStatSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	isIncomplete := false
 
 	for _, url := range URLs {
-		_, _, err := url2Stat(url, false, encKeyDB)
+		_, _, err := url2Stat(url, false, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 		}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -165,7 +165,7 @@ func statURL(targetURL string, isIncomplete, isRecursive bool, encKeyDB map[stri
 			return nil, errTargetNotFound(targetURL)
 		}
 
-		_, stat, err := url2Stat(url, true, encKeyDB)
+		_, stat, err := url2Stat(url, true, true, encKeyDB)
 		if err != nil {
 			stat = content
 		}

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -119,7 +119,7 @@ func checkTreeSyntax(ctx *cli.Context) {
 	}
 
 	for _, url := range args {
-		if _, _, err := url2Stat(url, false, nil); err != nil && !isURLPrefixExists(url, false) {
+		if _, _, err := url2Stat(url, false, false, nil); err != nil && !isURLPrefixExists(url, false) {
 			fatalIf(err.Trace(url), "Unable to tree `"+url+"`.")
 		}
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -318,3 +318,34 @@ func isURLContains(srcURL, tgtURL, sep string) bool {
 	}
 	return false
 }
+
+// ErrInvalidFileSystemAttribute reflects invalid fily system attribute
+var ErrInvalidFileSystemAttribute = errors.New("Error in parsing file system attribute")
+
+// Returns a map by parsing the value of X-Amz-Meta-Mc-Attrs/X-Amz-Meta-s3Cmd-Attrs
+func parseAttribute(attrs string) (map[string]string, error) {
+	var err error
+	attribute := make(map[string]string)
+	param := strings.Split(attrs, "/")
+	for _, val := range param {
+		attr := strings.TrimSpace(val)
+		if attr == "" {
+			err = ErrInvalidFileSystemAttribute
+		} else {
+			attrVal := strings.Split(attr, ":")
+			if len(attrVal) == 2 {
+				attribute[strings.TrimSpace(attrVal[0])] = strings.TrimSpace(attrVal[1])
+			} else if len(attrVal) == 1 {
+				attribute[attrVal[0]] = ""
+			} else {
+				err = ErrInvalidFileSystemAttribute
+			}
+		}
+	}
+
+	if err != nil {
+		return nil, ErrInvalidFileSystemAttribute
+	}
+
+	return attribute, nil
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -159,3 +159,48 @@ func TestParseEncryptionKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestParseAttribute(t *testing.T) {
+	metaDataCases := []struct {
+		input  string
+		output map[string]string
+		err    error
+		status bool
+	}{
+		// // When blank value is passed.
+		{"", nil, ErrInvalidFileSystemAttribute, false},
+		//  When space is passed.
+		{"  ", nil, ErrInvalidFileSystemAttribute, false},
+		// When / is passed.
+		{"/", nil, ErrInvalidFileSystemAttribute, false},
+		// When "atime:" is passed.
+		{"atime:/", nil, ErrInvalidFileSystemAttribute, false},
+		// When "atime:" is passed.
+		{"atime", map[string]string{"atime": ""}, nil, true},
+		//  When "atime:" is passed.
+		{"atime:", map[string]string{"atime": ""}, nil, true},
+		// Passing a valid value
+		{"atime:1/ctime:1/gid:1/gname:a/md:/mode:3/mtime:1/uid:1/uname:a", map[string]string{"atime": "1", "ctime": "1", "gid": "1", "gname": "a", "md": "", "mode": "3", "mtime": "1", "uid": "1", "uname": "a"}, nil, true},
+	}
+
+	for idx, testCase := range metaDataCases {
+		metaData, errMeta := parseAttribute(testCase.input)
+		if testCase.status == true {
+			if errMeta != nil {
+				t.Fatalf("Test %d: generated error not matching, expected = `%s`, found = `%s`", idx+1, testCase.err, errMeta)
+			}
+			if !reflect.DeepEqual(metaData, testCase.output) {
+				t.Fatalf("Test %d: generated Map not matching, expected = `%s`, found = `%s`", idx+1, testCase.input, metaData)
+			}
+		}
+		if testCase.status == false {
+			if !reflect.DeepEqual(metaData, testCase.output) {
+				t.Fatalf("Test %d: generated Map not matching, expected = `%s`, found = `%s`", idx+1, testCase.input, metaData)
+			}
+			if errMeta != testCase.err {
+				t.Fatalf("Test %d: generated error not matching, expected = `%s`, found = `%s`", idx+1, testCase.err, errMeta)
+			}
+		}
+
+	}
+}

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -562,6 +562,7 @@ FLAGS:
   --older-than value                 copy object(s) older than N days (default: 0)
   --newer-than value                 copy object(s) newer than N days (default: 0)
   --storage-class value, --sc value  set storage class for new object(s) on target
+  --preserve,-a                                 preserve file system attributes and bucket policy rules on target bucket(s)
   --attr                             add custom metadata for the object (format: KeyName1=string;KeyName2=string)
   --encrypt value                    encrypt/decrypt objects (using server-side encryption with server managed keys)
   --encrypt-key value                encrypt/decrypt objects (using server-side encryption with customer provided keys)
@@ -619,6 +620,13 @@ Notice that two different aliases myminio1 and myminio2 are used for the same en
 ```sh
 mc cp --attr Cache-Control=no-cache myscript.js play/mybucket
 myscript.js:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
+```
+
+*Example: Copy a text file to an object storage and preserve the filesyatem attributes.*
+
+```
+mc cp -a myobject.txt play/mybucket
+myobject.txt:    14 B / 14 B  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100.00 % 41 B/s 0
 ```
 
 <a name="rm"></a>
@@ -773,7 +781,7 @@ FLAGS:
   --watch, -w                        watch and synchronize changes
   --remove                           remove extraneous object(s) on target
   --region value                     specify region when creating new bucket(s) on target (default: "us-east-1")
-  -a                                 preserve bucket policy rules on target bucket(s)
+  --preserve, -a                     preserve file system attributes and bucket policy rules on target bucket(s)
   --exclude value                    exclude object(s) that match specified object name pattern
   --older-than value                 filter object(s) older than N days (default: 0)
   --newer-than value                 filter object(s) newer than N days (default: 0)

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -678,6 +678,17 @@ function test_cat_object_with_sse_error()
     log_success "$start_time" "${FUNCNAME[0]}"
 }
 
+# Test mc cp command with preserve file system attributes
+function test_copy_object_preserve_filesystem_attr()
+{
+    show "${FUNCNAME[0]}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp -a "${FILE_1_MB}" "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"
+    diff -bB <("${MC_CMD[@]}"   --json stat "${FILE_1_MB}"  |  jq -r '.metadata."mc-attrs"')  >/dev/null 2>&1 <("${MC_CMD[@]}"   --json stat "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"  |  jq -r '.metadata."X-Amz-Meta-Mc-Attrs"')  >/dev/null 2>&1
+    assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to put object with file system attribute"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"
+    log_success "$start_time" "${FUNCNAME[0]}"
+}
+
 function test_copy_object_with_sse_rewrite()
 {
     # test server side copy and remove operation - target is unencrypted while source is encrypted
@@ -844,6 +855,7 @@ function run_test()
     test_cat_object
     test_mirror_list_objects
     test_mirror_list_objects_storage_class
+    test_copy_object_preserve_filesystem_attr
     test_find
     test_find_empty
     if [ -z "$MINT_MODE" ]; then

--- a/pkg/disk/stat_darwin.go
+++ b/pkg/disk/stat_darwin.go
@@ -1,0 +1,72 @@
+// +build darwin
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// GetFileSystemAttrs return the file system attribute as string; containing mode,
+// uid, gid, uname, Gname, atime, mtime, ctime and md5
+func GetFileSystemAttrs(file string) (string, error) {
+
+	st := syscall.Stat_t{}
+	err := syscall.Stat(file, &st)
+	if err != nil {
+		return "", err
+	}
+
+	var fileAttr strings.Builder
+	fileAttr.WriteString("atime:")
+	fileAttr.WriteString(timespecToTime(st.Atimespec).String())
+	fileAttr.WriteString("/ctime:")
+	fileAttr.WriteString(timespecToTime(st.Ctimespec).String())
+	fileAttr.WriteString("/gid:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Gid)))
+
+	fileAttr.WriteString("/gname:")
+	g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10))
+	if err != nil {
+		return "", err
+	}
+	fileAttr.WriteString(g.Name)
+
+	fileAttr.WriteString("/mode:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Mode)))
+	fileAttr.WriteString("/mtime:")
+	fileAttr.WriteString(timespecToTime(st.Mtimespec).String())
+	fileAttr.WriteString("/uid:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Uid)))
+
+	fileAttr.WriteString("/uname:")
+	i, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10))
+	if err != nil {
+		return "", err
+	}
+	fileAttr.WriteString(i.Username)
+	return fileAttr.String(), nil
+}
+
+func timespecToTime(ts syscall.Timespec) time.Time {
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
+}

--- a/pkg/disk/stat_linux.go
+++ b/pkg/disk/stat_linux.go
@@ -1,0 +1,69 @@
+// +build linux
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package disk fetches file system information for various OS
+package disk
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// GetFileSystemAttrs return the file system attribute as string; containing mode,
+// uid, gid, uname, Gname, atime, mtime, ctime and md5
+func GetFileSystemAttrs(file string) (string, error) {
+	fi, err := os.Stat(file)
+	if err != nil {
+		return "", err
+	}
+	st := fi.Sys().(*syscall.Stat_t)
+
+	var fileAttr strings.Builder
+	fileAttr.WriteString("atime:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Atim.Sec)))
+	fileAttr.WriteString("/ctime:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Ctim.Sec)))
+	fileAttr.WriteString("/gid:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Gid)))
+
+	fileAttr.WriteString("/gname:")
+	g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10))
+	if err != nil {
+		return "", err
+	}
+	fileAttr.WriteString(g.Name)
+
+	fileAttr.WriteString("/mode:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Mode)))
+	fileAttr.WriteString("/mtime:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Mtim.Sec)))
+	fileAttr.WriteString("/uid:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Uid)))
+
+	fileAttr.WriteString("/uname:")
+	i, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10))
+	if err != nil {
+		return "", err
+	}
+	fileAttr.WriteString(i.Username)
+
+	return fileAttr.String(), nil
+}

--- a/pkg/disk/stat_openbsd.go
+++ b/pkg/disk/stat_openbsd.go
@@ -1,0 +1,68 @@
+// +build openbsd
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+import (
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// GetFileSystemAttrs return the file system attribute as string; containing mode,
+// uid, gid, uname, Gname, atime, mtime, ctime and md5
+func GetFileSystemAttrs(file string) (string, error) {
+
+	st := syscall.Stat_t{}
+	err := syscall.Stat(file, &st)
+	if err != nil {
+		return "", err
+	}
+
+	var fileAttr strings.Builder
+	fileAttr.WriteString("atime:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Atim.Sec)))
+	fileAttr.WriteString("/ctime:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Ctim.Sec)))
+	fileAttr.WriteString("/gid:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Gid)))
+
+	fileAttr.WriteString("/gname:")
+	g, err := user.LookupGroupId(strconv.FormatUint(uint64(st.Gid), 10))
+	if err != nil {
+		return "", err
+	}
+	fileAttr.WriteString(g.Name)
+
+	fileAttr.WriteString("/mode:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Mode)))
+	fileAttr.WriteString("/mtime:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Mtim.Sec)))
+	fileAttr.WriteString("/uid:")
+	fileAttr.WriteString(strconv.Itoa(int(st.Uid)))
+
+	fileAttr.WriteString("/uname:")
+	i, err := user.LookupId(strconv.FormatUint(uint64(st.Uid), 10))
+	if err != nil {
+		return "", err
+	}
+	fileAttr.WriteString(i.Username)
+
+	return fileAttr.String(), nil
+}

--- a/pkg/disk/stat_windows.go
+++ b/pkg/disk/stat_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+/*
+ * MinIO Cloud Storage, (C) 2019 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package disk
+
+// GetFileSystemAttrs return the file system attribute as string; containing mode,
+// uid, gid, uname, Gname, atime, mtime, ctime and md5
+func GetFileSystemAttrs(file string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
Have introduced an option `-a` to preserve the file system attribute while copy. For mirror it will preserve the file attributes and bucket policy if any.

Refer https://github.com/minio/mc/issues/2881 for details.

With `a` option in `cp` and `mirror` we try to preserve the file attribute in the following cases : 

**Case 1** :  Moving file from file system to object storage
 In this case the file system attribute is saved as metadata with the tag `X-Amz-Meta-Mc-Attrs` .
**Case 2** :  Moving file from file system to file system
No change in this case
**Case 3** :  Moving file from object storage to file system.
In this case the value of `X-Amz-Meta-Mc-Attrs` (when uploaded through mc) or `X-Amz-Meta-S3cmd-Attrs` (when uploaded through s3cmd)  is read. Then it is parsed to fetch the mod. uid, atime, mtime etc.. and applied to the file using `os.chmod` , `os.Chtime` , `os.Chown` .

**Case 4** :  Moving file from object storage to  object storage.
Object is copied as is. 

**How to test** : Run 
```
1. mc cp -a ~/Downloads/test.csv  myminio/bucket 
2. mc stat myminio/bucket/test.csv
```
Simmilarly test for mirror using the option `-a`

Closes #2881 