### PR TITLE
Fix typo in error message

### DIFF
--- a/cmd/admin-user-remove.go
+++ b/cmd/admin-user-remove.go
@@ -66,7 +66,7 @@ func mainAdminUserRemove(ctx *cli.Context) error {
 	fatalIf(err, "Unable to initialize admin connection.")
 
 	e := client.RemoveUser(args.Get(1))
-	fatalIf(probe.NewError(e).Trace(args...), "Cannot remove new user")
+	fatalIf(probe.NewError(e).Trace(args...), "Cannot remove %s", args.Get(1))
 
 	printMsg(userMessage{
 		op:        "remove",


### PR DESCRIPTION
Change the error message from `Cannot remove new user` to `Cannot remove <User>`,
when a non-existent user is removed.