### PR TITLE
Optionally print disk usage as plain integer

### DIFF
--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -70,13 +70,15 @@ EXAMPLES:
 // Structured message depending on the type of console.
 type duMessage struct {
 	Prefix string `json:"prefix"`
-	Size   string `json:"size"`
+	Size   int64  `json:"size"`
 	Status string `json:"status"`
 }
 
 // Colorized message for console printing.
 func (r duMessage) String() string {
-	return fmt.Sprintf("%s\t%s", console.Colorize("Size", r.Size),
+	humanSize := strings.Join(strings.Fields(humanize.IBytes(uint64(r.Size))), "")
+
+	return fmt.Sprintf("%s\t%s", console.Colorize("Size", humanSize),
 		console.Colorize("Prefix", r.Prefix))
 }
 
@@ -141,7 +143,7 @@ func du(urlStr string, depth int, encKeyDB map[string][]prefixSSEPair) (int64, e
 
 		printMsg(duMessage{
 			Prefix: strings.Trim(u.Path, "/"),
-			Size:   strings.Join(strings.Fields(humanize.IBytes(uint64(size))), ""),
+			Size:   size,
 			Status: "success",
 		})
 	}


### PR DESCRIPTION
Providing the `--plain-bytes` option to `mc du` will print usage as an integer number of bytes, without humanization.

I believe this would be helpful for using the output directly in scripts or with tools like ElasticSearch, especially when combined with the `--json` flag.

I couldn't find any precedent for unit tests for a command like this --- please point me at them if I missed them :-)