### PR TITLE
Fix encrypt-key flag parsing

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -54,6 +54,10 @@ func getDecodedKey(sseKeys string) (key string, err *probe.Error) {
 // Validate the key
 func parseKey(sseKeys string) (sse string, err *probe.Error) {
 	encryptString := strings.SplitN(sseKeys, "=", 2)
+	if len(encryptString) < 2 {
+		return "", probe.NewError(errors.New("SSE-C prefix should be of the form prefix1=key1,... "))
+	}
+
 	secretValue := encryptString[1]
 	if len(secretValue) == 32 {
 		return sseKeys, nil


### PR DESCRIPTION
```
➜  minio git:(ab8666673) ✗ mc cp /etc/issue dminio2/twa/ --encrypt-key dminio1/
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/minio/mc/cmd.parseKey(0x7ffd40afbf66, 0x8, 0xd32aea, 0x1, 0x0)
	/home/kp/code/src/github.com/minio/mc/cmd/common-methods.go:57 +0x1b8
github.com/minio/mc/cmd.getDecodedKey(0x7ffd40afbf66, 0x8, 0xc0003d56e0, 0x7ffd40afbf66, 0x8)
	/home/kp/code/src/github.com/minio/mc/cmd/common-methods.go:45 +0xe0
github.com/minio/mc/cmd.getEncKeys(0xc0000a41a0, 0xc0000a41a0, 0xd3754b)
	/home/kp/code/src/github.com/minio/mc/cmd/common-methods.go:84 +0x251
github.com/minio/mc/cmd.mainCopy(0xc0000a41a0, 0x0, 0xa41a0)
	/home/kp/code/src/github.com/minio/mc/cmd/cp-main.go:495 +0x43
github.com/minio/cli.HandleAction(0xc15d20, 0xd897e0, 0xc0000a41a0, 0xc0003d5600, 0x0)
	/home/kp/go/pkg/mod/github.com/minio/cli@v1.22.0/app.go:498 +0xc8
github.com/minio/cli.Command.Run(0xd32cad, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0xd3bceb, 0xc, 0x0, ...)
	/home/kp/go/pkg/mod/github.com/minio/cli@v1.22.0/command.go:225 +0x991
github.com/minio/cli.(*App).Run(0xc0002c01a0, 0xc0000301e0, 0x6, 0x6, 0x0, 0x0)
	/home/kp/go/pkg/mod/github.com/minio/cli@v1.22.0/app.go:261 +0x6ab
github.com/minio/mc/cmd.Main(0xc0000301e0, 0x6, 0x6)
	/home/kp/code/src/github.com/minio/mc/cmd/main.go:113 +0x29c
main.main()
	/home/kp/code/src/github.com/minio/mc/main.go:34 +0x45
```