### PR TITLE
Rectify usage section of policy help

### DIFF
--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -51,9 +51,10 @@ var policyCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} [FLAGS] PERMISSION TARGET
-  {{.HelpName}} [FLAGS] FILE TARGET
-  {{.HelpName}} [FLAGS] TARGET
+  {{.HelpName}} set [FLAGS] PERMISSION TARGET
+  {{.HelpName}} set-json [FLAGS] FILE TARGET
+  {{.HelpName}} get [FLAGS] TARGET
+  {{.HelpName}} get-json [FLAGS] TARGET
   {{.HelpName}} list [FLAGS] TARGET
 {{if .VisibleFlags}}
 FLAGS:


### PR DESCRIPTION
The new help for policy : 
```
Name:
  mc policy - manage anonymous access to buckets and objects

USAGE:
  mc policy set [FLAGS] PERMISSION TARGET
  mc policy set-json [FLAGS] FILE TARGET
  mc policy get [FLAGS] TARGET
  mc policy get-json [FLAGS] TARGET
  mc policy list [FLAGS] TARGET

```
Closes #2958 