### PR TITLE
mirror object lock configuration to dest bucket

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -37,6 +37,7 @@ import (
 	"github.com/minio/mc/pkg/hookreader"
 	"github.com/minio/mc/pkg/ioutils"
 	"github.com/minio/mc/pkg/probe"
+	minio "github.com/minio/minio-go/v6"
 	"github.com/minio/minio-go/v6/pkg/encrypt"
 )
 
@@ -997,6 +998,16 @@ func (f *fsClient) MakeBucket(region string, ignoreExisting, withLock bool) *pro
 		return probe.NewError(e)
 	}
 	return nil
+}
+
+// Set object lock configuration of bucket.
+func (f *fsClient) SetObjectLockConfig(mode *minio.RetentionMode, validity *uint, unit *minio.ValidityUnit) *probe.Error {
+	return probe.NewError(APINotImplemented{API: "SetObjectLockConfig", APIType: "filesystem"})
+}
+
+// Get object lock configuration of bucket.
+func (f *fsClient) GetObjectLockConfig() (mode *minio.RetentionMode, validity *uint, unit *minio.ValidityUnit, perr *probe.Error) {
+	return nil, nil, nil, probe.NewError(APINotImplemented{API: "GetObjectLockConfig", APIType: "filesystem"})
 }
 
 // GetAccessRules - unsupported API

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -50,6 +50,8 @@ type Client interface {
 
 	// Bucket operations
 	MakeBucket(region string, ignoreExisting, withLock bool) *probe.Error
+	SetObjectLockConfig(mode *minio.RetentionMode, validity *uint, unit *minio.ValidityUnit) *probe.Error
+	GetObjectLockConfig() (mode *minio.RetentionMode, validity *uint, unit *minio.ValidityUnit, perr *probe.Error)
 
 	// Access policy operations.
 	GetAccess() (access string, policyJSON string, error *probe.Error)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.5 // indirect
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio v0.0.0-20191119214813-7cdb67680e72
-	github.com/minio/minio-go/v6 v6.0.41
+	github.com/minio/minio-go/v6 v6.0.42
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/profile v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,8 @@ github.com/minio/minio-go/v6 v6.0.39 h1:9qmKCTBpQpMdGlDAbs3mbb4mmL45/lwRUvHL1VLh
 github.com/minio/minio-go/v6 v6.0.39/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=
 github.com/minio/minio-go/v6 v6.0.41 h1:ybV6itOYLsjCpp4+QjE4gokic/xhJU7D7wRzxqPHTio=
 github.com/minio/minio-go/v6 v6.0.41/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=
+github.com/minio/minio-go/v6 v6.0.42 h1:aIAm+bMIOWCr634eZQdWGxelaVXA8/y2tOBrG9wV8+Y=
+github.com/minio/minio-go/v6 v6.0.42/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=
 github.com/minio/parquet-go v0.0.0-20190318185229-9d767baf1679 h1:OMKaN/82sBHUZPvjYNBFituHExa1OGY63eACDGtetKs=
 github.com/minio/parquet-go v0.0.0-20190318185229-9d767baf1679/go.mod h1:J+goXSuzlte5imWMqb6cUWC/tbYYysUHctwmKXomYzM=
 github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16/go.mod h1:2FMWW+8GMoPweT6+pI63m9YE3Lmw4J71hV56Chs1E/U=


### PR DESCRIPTION
if bucket does not exist on the target side.

This PR will allow Object lock configuration on the source bucket to be mirrored to destination bucket if bucket does not exist on the target site.
In addition object retention headers will also be mirrored if retention headers are set on source object