### PR TITLE
mc sql: Use compression parameter

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -532,7 +532,9 @@ func selectObjectInputOpts(selOpts SelectObjectOpts, object string) minio.Select
 			i.JSON = &minio.JSONInputOptions{Type: minio.JSONLinesType}
 		}
 	}
-	i.CompressionType = selectCompressionType(selOpts, object)
+	if i.CompressionType == "" {
+		i.CompressionType = selectCompressionType(selOpts, object)
+	}
 	return i
 }
 

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v6"
 	"github.com/minio/minio/pkg/mimedb"
 )
 
@@ -363,8 +364,9 @@ func getSQLOpts(ctx *cli.Context, csvHdrs []string) (s SelectObjectOpts) {
 	os := getOutputSerializationOpts(ctx, csvHdrs)
 
 	return SelectObjectOpts{
-		InputSerOpts:  is,
-		OutputSerOpts: os,
+		InputSerOpts:    is,
+		OutputSerOpts:   os,
+		CompressionType: minio.SelectCompressionType(ctx.String("compression")),
 	}
 }
 


### PR DESCRIPTION
The compression parameter is not actually used, but always guessed from the file extension.

Only guess the compression type if it is not explicitly set.

Uploading a file called `out.csv.geezipd`:

Before:
```
λ mc sql -e="SELECT * from s3object LIMIT 1" --compression=GZIP --csv-input "rd=\n,fh=USE,fd=;" local/test/out.csv.geezipd
�""���k↔��Xs��W.v�      ��)��{2#��,r���:�|D▲�.��f♫��→�i�p�2l�♫��ʭ���Q��v▲�5ر�c
```
(content actually not un-gzipped)

After:
```
λ mc sql -e="SELECT * from s3object LIMIT 1" --compression=GZIP --csv-input "rd=\n,fh=USE,fd=;" local/test/out.csv.geezipd
"281,1285,159625,159627,2637,20000827.0117590018,1239029,1663,-6.7535419,1533,0.53597438,8"
```

We leave validation of the compression value to the server.