### PR TITLE
Fix mirroring of PutObjectRetention event

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -463,6 +463,7 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, cancelMirror context.Cance
 					// hence ignore the event to avoid copying it.
 					continue
 				}
+				sourceContent.Retention = event.Type == EventCreatePutRetention
 				mirrorURL.SourceContent = sourceContent
 				if event.Size == 0 {
 					targetClient, err := newClient(targetPath)


### PR DESCRIPTION
mirroring of retention being set on source was being received on target as a ObjectCreated event rather than a ObjectCreated:PutRetention event - the field marking retention on source was being overwritten by metadata stat.

to repro:
```
1. start mc mirror on 2 sites with object locking enabled on the bucket being mirrored (mc mb --with-lock myminio/testbucket)
2. mc watch myminio
3. mc watch myminio1
4. mc mirror myminio/testbucket myminio1/testbucket --watch 
5. mc cp /etc/issue myminio/testbucket [ should generate ObjectCreated event]
6. mc retention myminio/testbucket/issue COMPLIANCE 3d [ should see ObjectCreated:PutRetention ] on the target
```