### PR TITLE
Stops showing usage info if no of Buckets is zero

### DIFF
--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -172,10 +172,11 @@ func (u clusterStruct) String() (msg string) {
 	// Summary on used space, total no of buckets and
 	// total no of objects at the Cluster level
 	usedTotal := humanize.IBytes(uint64(u.Info.Usage.Size))
-	msg += fmt.Sprintf("%s Used, %s, %s", usedTotal,
-		english.Plural(u.Info.Buckets.Count, "Bucket", ""),
-		english.Plural(u.Info.Objects.Count, "Object", ""))
-
+	if u.Info.Buckets.Count > 0 {
+		msg += fmt.Sprintf("%s Used, %s, %s", usedTotal,
+			english.Plural(u.Info.Buckets.Count, "Bucket", ""),
+			english.Plural(u.Info.Objects.Count, "Object", ""))
+	}
 	if backendType != "FS" {
 		// Summary on total no of online and total
 		// number of offline disks at the Cluster level


### PR DESCRIPTION
When there is no usage, we don't  need to show any info in the regular `mc admin info <alias>` output.
It is good enough to check if the number of buckets is  zero or not to decide if the usage info will be shown.