### PR TITLE
Extraneous line in 'mc admin info' output

### DIFF
--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -166,7 +166,9 @@ func (u clusterStruct) String() (msg string) {
 			msg += fmt.Sprintf("   Drives: %s %s\n", dispNoOfDisks, console.Colorize("Info", "OK "))
 
 		}
-		msg += "\n"
+		if u.Info.Buckets.Count != 0 {
+			msg += "\n"
+		}
 	}
 
 	// Summary on used space, total no of buckets and

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -172,10 +172,11 @@ func (u clusterStruct) String() (msg string) {
 	// Summary on used space, total no of buckets and
 	// total no of objects at the Cluster level
 	usedTotal := humanize.IBytes(uint64(u.Info.Usage.Size))
-	msg += fmt.Sprintf("%s Used, %s, %s", usedTotal,
-		english.Plural(u.Info.Buckets.Count, "Bucket", ""),
-		english.Plural(u.Info.Objects.Count, "Object", ""))
-
+	if u.Info.Buckets.Count > 0 {
+		msg += fmt.Sprintf("%s Used, %s, %s", usedTotal,
+			english.Plural(u.Info.Buckets.Count, "Bucket", ""),
+			english.Plural(u.Info.Objects.Count, "Object", ""))
+	}
 	if backendType != "FS" {
 		// Summary on total no of online and total
 		// number of offline disks at the Cluster level


### PR DESCRIPTION
Removes the extraneous line in 'mc admin info' output when bucket count is 0.