### PR TITLE
Extraneous line in 'mc admin info' output

### DIFF
--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -166,7 +166,9 @@ func (u clusterStruct) String() (msg string) {
 			msg += fmt.Sprintf("   Drives: %s %s\n", dispNoOfDisks, console.Colorize("Info", "OK "))
 
 		}
-		msg += "\n"
+		if u.Info.Buckets.Count != 0 {
+			msg += "\n"
+		}
 	}
 
 	// Summary on used space, total no of buckets and


### PR DESCRIPTION
Removes the extraneous line in 'mc admin info' output when bucket count is 0.