### PR TITLE
'rm -r' honors prefix for object and directory names, matching 'ls -r' output

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1272,7 +1272,7 @@ func (c *s3Client) Stat(isIncomplete, isFetchMeta, isPreserve bool, sse encrypt.
 		if objectStat.Err != nil {
 			return nil, probe.NewError(objectStat.Err)
 		}
-		if strings.HasSuffix(objectStat.Key, string(c.targetURL.Separator)) {
+		if strings.HasSuffix(prefix, string(c.targetURL.Separator)) {
 			objectMetadata.URL = *c.targetURL
 			objectMetadata.Type = os.ModeDir
 			if isFetchMeta {
@@ -1286,7 +1286,8 @@ func (c *s3Client) Stat(isIncomplete, isFetchMeta, isPreserve bool, sse encrypt.
 				objectMetadata.Expires = stat.Expires
 			}
 			return objectMetadata, nil
-		} else if objectStat.Key == object {
+		} else if strings.Contains(objectStat.Key, object) {
+			// Object name could be either full-name or a prefix
 			objectMetadata.URL = *c.targetURL
 			objectMetadata.Time = objectStat.LastModified
 			objectMetadata.Size = objectStat.Size

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -95,7 +95,9 @@ func checkListSyntax(ctx *cli.Context) {
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			// Bucket name empty is a valid error for 'ls myminio',
 			// treat it as such.
-			if _, ok := err.ToGoError().(BucketNameEmpty); ok {
+			_, buckNameEmpty := err.ToGoError().(BucketNameEmpty)
+			_, noPath := err.ToGoError().(PathNotFound)
+			if buckNameEmpty || noPath {
 				continue
 			}
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
@@ -132,7 +134,7 @@ func mainList(ctx *cli.Context) error {
 		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 			var st *clientContent
 			st, err = clnt.Stat(isIncomplete, false, false, nil)
-			if err == nil && st.Type.IsDir() {
+			if st != nil && err == nil && st.Type.IsDir() {
 				targetURL = targetURL + string(clnt.GetURL().Separator)
 				clnt, err = newClient(targetURL)
 				fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -256,7 +256,7 @@ func removeRecursive(url string, isIncomplete bool, isFake bool, olderThan, newe
 	errorCh := clnt.Remove(isIncomplete, isRemoveBucket, contentCh)
 
 	isRecursive := true
-	for content := range clnt.List(isRecursive, isIncomplete, false, DirLast) {
+	for content := range clnt.List(isRecursive, isIncomplete, false, DirNone) {
 		if content.Err != nil {
 			errorIf(content.Err.Trace(url), "Failed to remove `"+url+"` recursively.")
 			switch content.Err.ToGoError().(type) {


### PR DESCRIPTION
Fixes #3005
`mc rm -r --force` command fails to remove all matching files/objects, when multiple objecs are needed to be removed by providing a prefix.