### PR TITLE
'mc admin heal' created bucket when the bucket doesn't exist

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -202,6 +202,18 @@ func mainAdminHeal(ctx *cli.Context) error {
 	splits := splitStr(aliasedURL, "/", 3)
 	bucket, prefix := splits[1], splits[2]
 
+	clnt, err := newClient(aliasedURL)
+	if err != nil {
+		fatalIf(err.Trace(clnt.GetURL().String()), "Unable to create client for URL ", aliasedURL)
+		return nil
+	}
+	for content := range clnt.List(false, false, false, DirNone) {
+		if content.Err != nil {
+			fatalIf(content.Err.Trace(clnt.GetURL().String()), "Unable to heal bucket `"+bucket+"`.")
+			return nil
+		}
+	}
+
 	// Return the background heal status when the user
 	// doesn't pass a bucket or --recursive flag.
 	if bucket == "" && !ctx.Bool("recursive") {


### PR DESCRIPTION
Fixes the issue where a bucket is created when user runs:
`mc admin heal <alias>/<non-existing-bucket-name>`
I've introduced an extra check to see if bucket exists or not before moving forward with heal process. That check enables mc command to spit out an error message, letting user know `"mc: <ERROR>  Bucket <bucket-name> does not exist."`.