### PR TITLE
Ensure 64bit alignment on 32bit builds for atomics

### DIFF
--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -36,14 +36,17 @@ const (
 
 // ParallelManager - helps manage parallel workers to run tasks
 type ParallelManager struct {
+	// Calculate sent bytes.
+	// Keep this as first element of struct because it guarantees 64bit
+	// alignment on 32 bit machines. atomic.* functions crash if operand is not
+	// aligned at 64bit. See https://github.com/golang/go/issues/599
+	sentBytes int64
+
 	// Synchronize workers
 	wg *sync.WaitGroup
 
 	// Current threads number
 	workersNum uint32
-
-	// Calculate sent bytes.
-	sentBytes int64
 
 	// Channel to receive tasks to run
 	queueCh chan func() URLs

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -59,9 +59,12 @@ func NewQuietStatus(hook io.Reader) Status {
 
 // QuietStatus will only show the progress and summary
 type QuietStatus struct {
-	*accounter
-	hook   io.Reader
+	// Keep this as first element of struct because it guarantees 64bit
+	// alignment on 32 bit machines. atomic.* functions crash if operand is not
+	// aligned at 64bit. See https://github.com/golang/go/issues/599
 	counts int64
+	*accounter
+	hook io.Reader
 }
 
 // Read implements the io.Reader interface
@@ -151,9 +154,12 @@ func NewProgressStatus(hook io.Reader) Status {
 
 // ProgressStatus shows a progressbar
 type ProgressStatus struct {
-	*progressBar
-	hook   io.Reader
+	// Keep this as first element of struct because it guarantees 64bit
+	// alignment on 32 bit machines. atomic.* functions crash if operand is not
+	// aligned at 64bit. See https://github.com/golang/go/issues/599
 	counts int64
+	*progressBar
+	hook io.Reader
 }
 
 // Read implements the io.Reader interface


### PR DESCRIPTION
Keep elements that are used with atomic.* functions as first element
of struct because it guarantees 64bit alignment on 32 bit machines.
atomic.* functions crash if operand is not aligned at 64bit.
See https://github.com/golang/go/issues/599

This should fix https://github.com/minio/mc/issues/3064.
