### PR TITLE
resolve build issues on illumos

### DIFF
--- a/pkg/disk/stat_other.go
+++ b/pkg/disk/stat_other.go
@@ -1,4 +1,4 @@
-// +build openbsd
+// +build openbsd solaris
 
 /*
  * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.


### PR DESCRIPTION
The Go minio client does not build on illumos. There are a couple issues blocking the Go client from building on illumos.

1) The minio/minio version pulled in by `mc` needs to include minio/minio#9036. In this PR I updated the minio/minio dep to include this commit. Let me know if it would be better to bring this up to the latest master commit instead (or any other commit).

2) The `disk` package doesn't have a solaris implementation. Luckily the OpenBSD implementation works just fine on illumos. I have tested this PR's change on illumos with a simple program and verified the results are correct:
```
$ cat main.go
package main

import (
        "fmt"
        "github.com/minio/mc/pkg/disk"
)

func main() {
        st, err := disk.GetFileSystemAttrs("main.go")
        if err != nil {
                fmt.Println(err)
                return
        }
        fmt.Println(st)
}

$ go run main.go
atime:1582752070/ctime:1582752070/gid:1/gname:other/mode:33188/mtime:1582752070/uid:1000/uname:kkantor

$ uname -a
SunOS rust.kkantor.com 5.11 joyent_20191122T201258Z i86pc i386 i86pc illumos
```

Let me know if any of these changes aren't acceptable. Linking the openbsd `disk` implementation to the solaris target in particular feels really dirty. Another option would be to create a `stat_other.go` file to hold the openbsd and solaris implementation.