### PR TITLE
Add sa command to support service accounts

### DIFF
--- a/cmd/admin-user-sa-generate.go
+++ b/cmd/admin-user-sa-generate.go
@@ -41,9 +41,9 @@ PARENT-USER:
   The parent user.
 
 POLICY_FILE:
-  The path of the policy to apply for the new service account.
-  When unspecified, the policy of the parent user will be evaluated
-  instead for all type of service accounts requests.
+  Optional path of the policy to apply for the new service account.
+  When not specified, the policy of the parent user is inherited, please
+  check 'mc admin user info <parent_user>' for the relevant policy.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}

--- a/cmd/admin-user-sa-generate.go
+++ b/cmd/admin-user-sa-generate.go
@@ -50,7 +50,10 @@ FLAGS:
   {{end}}
 
 EXAMPLES:
-  1. Add a new service account under the name of 'foobar' to MinIO server.
+  1. Create a new service account from 'foobar' to MinIO server.
+     {{.Prompt}} {{.HelpName}} myminio foobar
+
+  2. Create a new service account with restrained policy specified by /tmp/policy.json.
      {{.Prompt}} {{.HelpName}} myminio foobar /tmp/policy.json
 `,
 }

--- a/cmd/admin-user-sa-generate.go
+++ b/cmd/admin-user-sa-generate.go
@@ -1,0 +1,120 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/minio/cli"
+	json "github.com/minio/mc/pkg/colorjson"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio/pkg/console"
+)
+
+var adminUserSAGenerateCmd = cli.Command{
+	Name:   "generate",
+	Usage:  "generate a new service account",
+	Action: mainAdminUserSAGenerate,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET PARENT-USER [POLICY_FILE]
+
+PARENT-USER:
+  The parent user.
+
+POLICY_FILE:
+  The path of the policy to apply for the new service account.
+  When unspecified, the policy of the parent user will be evaluated
+  instead for all type of service accounts requests.
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+
+EXAMPLES:
+  1. Add a new service account under the name of 'foobar' to MinIO server.
+     {{.Prompt}} {{.HelpName}} myminio foobar /tmp/policy.json
+`,
+}
+
+func checkAdminUserSAGenerateSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) < 2 || len(ctx.Args()) > 3 {
+		cli.ShowCommandHelpAndExit(ctx, "generate", 1) // last argument is exit code
+	}
+}
+
+// saMessage container for content message structure
+type saMessage struct {
+	AccessKey    string `json:"accessKey,omitempty"`
+	SecretKey    string `json:"secretKey,omitempty"`
+	SessionToken string `json:"sessionToken,omitempty"`
+}
+
+func (u saMessage) String() string {
+	dot := console.Colorize("SA", "‣ ")
+	msg := dot + console.Colorize("SA", "Access Key: ") + console.Colorize("AccessKey", u.AccessKey) + "\n"
+	msg += dot + console.Colorize("SA", "Secret Key: ") + console.Colorize("SecretKey", u.SecretKey) + "\n"
+	msg += dot + console.Colorize("SA", "Session Token: ") + console.Colorize("SessionToken", u.SessionToken)
+
+	return msg
+}
+
+func (u saMessage) JSON() string {
+	jsonMessageBytes, e := json.MarshalIndent(u, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(jsonMessageBytes)
+}
+
+func mainAdminUserSAGenerate(ctx *cli.Context) error {
+	setSACommandColors()
+	checkAdminUserSAGenerateSyntax(ctx)
+
+	// Get the alias parameter from cli
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	parentUser := args.Get(1)
+	policyDocPath := args.Get(2)
+
+	var policyDoc []byte
+	var e error
+
+	if len(policyDocPath) > 0 {
+		policyDoc, e = ioutil.ReadFile(policyDocPath)
+		fatalIf(probe.NewError(e).Trace(args...), "Cannot load the policy document")
+	}
+
+	creds, e := client.AddServiceAccount(globalContext, parentUser, string(policyDoc))
+	fatalIf(probe.NewError(e).Trace(args...), "Cannot add new service account")
+
+	printMsg(saMessage{
+		AccessKey:    creds.AccessKey,
+		SecretKey:    creds.SecretKey,
+		SessionToken: creds.SessionToken,
+	})
+
+	return nil
+}

--- a/cmd/admin-user-sa-show.go
+++ b/cmd/admin-user-sa-show.go
@@ -1,0 +1,78 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var adminUserSAShowCmd = cli.Command{
+	Name:   "show",
+	Usage:  "show the credentials of the specified service account",
+	Action: mainAdminUserSAShow,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET SERVICE-ACCOUNT-ACCESS-KEY
+
+SERVICE-ACCOUNT-ACCESS-KEY:
+  The access key of the service account.
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Show the credentials of the service account 'SKA762Z7UPIFS5OL1CO4'.
+     {{.Prompt}} {{.HelpName}} myminio/ SKA762Z7UPIFS5OL1CO4
+`,
+}
+
+func checkAdminUserSAShowSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 2 {
+		cli.ShowCommandHelpAndExit(ctx, "show", 1) // last argument is exit code
+	}
+}
+
+func mainAdminUserSAShow(ctx *cli.Context) error {
+	setSACommandColors()
+	checkAdminUserSAShowSyntax(ctx)
+
+	// Get the alias parameter from cli
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	serviceAccountKey := args.Get(1)
+
+	creds, e := client.GetServiceAccount(globalContext, serviceAccountKey)
+	fatalIf(probe.NewError(e).Trace(args...), "Cannot show the credentials of the specified service account")
+
+	printMsg(saMessage{
+		AccessKey:    creds.AccessKey,
+		SecretKey:    creds.SecretKey,
+		SessionToken: creds.SessionToken,
+	})
+
+	return nil
+}

--- a/cmd/admin-user-sa.go
+++ b/cmd/admin-user-sa.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Client (C) 2018 MinIO, Inc.
+ * MinIO Client (C) 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,32 @@
 
 package cmd
 
-import "github.com/minio/cli"
+import (
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/minio/pkg/console"
+)
 
-var adminUserCmd = cli.Command{
-	Name:   "user",
-	Usage:  "manage users",
-	Action: mainAdminUser,
+var adminUserSACmd = cli.Command{
+	Name:   "sa",
+	Usage:  "manage service accounts",
+	Action: mainAdminUserSA,
 	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
-		adminUserAddCmd,
-		adminUserDisableCmd,
-		adminUserEnableCmd,
-		adminUserRemoveCmd,
-		adminUserListCmd,
-		adminUserInfoCmd,
-		adminUserSACmd,
+		adminUserSAGenerateCmd,
+		adminUserSAShowCmd,
 	},
-	HideHelpCommand: true,
 }
 
-// mainAdminUser is the handle for "mc admin config" command.
-func mainAdminUser(ctx *cli.Context) error {
+func setSACommandColors() {
+	console.SetColor("SA", color.New(color.FgCyan, color.Bold))
+	console.SetColor("AccessKey", color.New(color.FgYellow))
+	console.SetColor("SecretKey", color.New(color.FgRed))
+	console.SetColor("SessionToken", color.New(color.FgBlue))
+}
+
+func mainAdminUserSA(ctx *cli.Context) error {
 	cli.ShowCommandHelp(ctx, ctx.Args().First())
 	return nil
 	// Sub-commands like "get", "set" have their own main.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-isatty v0.0.7
 	github.com/mattn/go-runewidth v0.0.5 // indirect
 	github.com/minio/cli v1.22.0
-	github.com/minio/minio v0.0.0-20200321002836-bf545dc3203b
+	github.com/minio/minio v0.0.0-20200321170220-27b8f18cce9b
 	github.com/minio/minio-go/v6 v6.0.51-0.20200319192131-097caa7760c7
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03D
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
 github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
+github.com/go-ini/ini v1.52.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -257,6 +258,8 @@ github.com/minio/minio v0.0.0-20200312144740-ed4bd20a7cfc h1:JvRNAEmHghf0mPluxNL
 github.com/minio/minio v0.0.0-20200312144740-ed4bd20a7cfc/go.mod h1:QbCnTGb/blyNjrkyxB9ecKxtuWWUdcHShqED1bItwa0=
 github.com/minio/minio v0.0.0-20200321002836-bf545dc3203b h1:8TWH16dqfdsSddYC29tBgRpTLxITy0LN/Dg5VFZezdY=
 github.com/minio/minio v0.0.0-20200321002836-bf545dc3203b/go.mod h1:cUjzu4ZZy1YdtUjCSBWsxoa+z2NqCRohj6EyFIQA3gE=
+github.com/minio/minio v0.0.0-20200321170220-27b8f18cce9b h1:tz+JNZ3kibon/xg5lrEMR7tirgEi57bekJkqLfaIlZI=
+github.com/minio/minio v0.0.0-20200321170220-27b8f18cce9b/go.mod h1:cUjzu4ZZy1YdtUjCSBWsxoa+z2NqCRohj6EyFIQA3gE=
 github.com/minio/minio-go/v6 v6.0.45/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=
 github.com/minio/minio-go/v6 v6.0.50-0.20200306231101-b882ba63d570 h1:GLTZoRC6rhCTucnkJAQ63LhMU2S4CM71MRc9gfX7ohE=
 github.com/minio/minio-go/v6 v6.0.50-0.20200306231101-b882ba63d570/go.mod h1:qD0lajrGW49lKZLtXKtCB4X/qkMf0a5tBvN2PaZg7Gg=


### PR DESCRIPTION
A new command is added to `mc admin user` command called svc
and that's to create new services accounts from existing users.

It is also possible to show credentials of the existing service
accounts.

`mc admin user svc generate` and `mc admin user svc show`
