### PR TITLE
mc cp: Fix prefix handling in TypeC

### DIFF
--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -191,6 +191,11 @@ func makeCopyContentTypeC(sourceAlias string, sourceURL clientURL, sourceContent
 	newSourceSuffix := filepath.ToSlash(newSourceURL.Path)
 	if pathSeparatorIndex > 1 {
 		sourcePrefix := filepath.ToSlash(sourceURL.Path[:pathSeparatorIndex])
+		// do not preserve unix cp behavior when copying from filesytem to
+		// objectstore.
+		if sourceAlias == "" && targetAlias != "" {
+			sourcePrefix = sourceURL.Path
+		}
 		newSourceSuffix = strings.TrimPrefix(newSourceSuffix, sourcePrefix)
 	}
 	newTargetURL := urlJoinPath(targetURL, newSourceSuffix)


### PR DESCRIPTION
for copy from filesystem to objectstorage.

Avoid prefixing dirname to file on target side
when doing a `mc cp /tmp/dir myminio/bucket --r`
 to make `mc mirror` and `mc cp` behavior consistent
```
with master
➜  mc ls myminio/images     
[2020-03-12 19:13:55 PDT]     26B a.txt
[2020-03-12 19:13:55 PDT]     26B b.txt
➜  mc cp /tmp/data/small myminio/images --r
...mall/b.txt:  130 B / 130 B ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 8.36 KiB/s 0s➜  data mc ls myminio/images 
[2020-03-12 19:14:29 PDT]      0B small/
```
```
with this fix
➜  mc ls /tmp/data/small
[2020-03-11 17:13:47 PDT]     26B a.txt
[2020-03-11 17:13:54 PDT]     26B b.txt
➜  mc cp /tmp/data/small myminio/images --r
...mall/b.txt:  130 B / 130 B ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 7.73 KiB/s 0s

```