### PR TITLE
mc cp -continue: Fix escape/colorization of JSON

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	json "github.com/minio/mc/pkg/colorjson"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio/pkg/console"
 )

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -275,8 +275,8 @@ func doPrepareCopyURLs(session *sessionV8, trapCh <-chan bool, cancelCopy contex
 				session.Delete()
 				fatalIf(probe.NewError(e), "Unable to prepare URL for copying. Error in JSON marshaling.")
 			}
-
-			fmt.Fprintln(dataFP, string(jsonData))
+			dataFP.Write(jsonData)
+			dataFP.Write([]byte{'\n'})
 			if !globalQuiet && !globalJSON {
 				scanBar(cpURLs.SourceContent.URL.String())
 			}


### PR DESCRIPTION
Fix issues where characters are escaped improperly, breaking the `mc cp -continue` functionality.

Example:

```
mc: <ERROR> Unable to unmarshal {"SourceAlias":"","SourceContent":{"URL":{"Type":1,"Scheme":"","Host":"","Path":"d:\\compress\\webdevdata.org-2015-01-07-subset\\02\\juanpi.com_02ffda791f3c3baa5d94e6cd177b0aed.gzip","SchemeSeparator":"","Separator":92},"Time":"2015-01-07T12:47:33+01:00","Size":23504,"Type":438,"StorageClass":"","Metadata":null,"UserMetadata":null,"ETag":"","Expires":"0001-01-01T00:00:00Z","EncryptionHeaders":null,"Retention":false,"Err":null},"TargetAlias":"local2","TargetContent":{"URL":{"Type":0,"Scheme":"http","Host":"localhost:9001","Path":"/bucket4/02/juanpi.com_02ffda791f3c3baa5d94e6cd177b0aed.gzip","SchemeSeparator":"://","Separator":47},"Time":"0001-01-01T00:00:00Z","Size":0,"Type":0,"StorageClass":"","Metadata":null,"UserMetadata":null,"ETag":"","Expires":"0001-01-01T00:00:00Z","EncryptionHeaders":null,"Retention":false,"Err":null},"TotalCount":0,"TotalSize":0} JSON decoder out of sync - data changing underfoot?
```

Here `fmt.Fprintln` has added extra escapes to the `\` character and there was color escape codes all through the JSON.

So the data looked like this:
```
{"[34;1mSourceAlias[0m":"[32m[0m","[34;1mSourceContent[0m":{"[34;1mURL[0m":{"[34;1mType[0m":[31m1[0m,"[34;1mScheme[0m":"[32m[0m","[34;1mHost[0m":"[32m[0m","[34;1mPath[0m":"[32me:\\up\\10gb\\2011\\www.mattmahoney.net\\dc\\11ninke.html[0m","[34;1mSchemeSeparator[0m":"[32m[0m","[34;1mSeparator[0m":[31m92[0m},"[34;1mTime[0m":"2011-06-13T04:59:42+02:00","[34;1mSize[0m":[31m234[0m,"[34;1mType[0m":[31m438[0m,"[34;1mStorageClass[0m":"[32m[0m","[34;1mMetadata[0m":[1;30;1mnull[0m,"[34;1mUserMetadata[0m":[1;30;1mnull[0m,"[34;1mETag[0m":"[32m[0m","[34;1mExpires[0m":"0001-01-01T00:00:00Z","[34;1mEncryptionHeaders[0m":[1;30;1mnull[0m,"[34;1mRetention[0m":[31mfalse[0m,"[34;1mErr[0m":[1;30;1mnull[0m},"[34;1mTargetAlias[0m":"[32mlocal2[0m","[34;1mTargetContent[0m":{"[34;1mURL[0m":{"[34;1mType[0m":[31m0[0m,"[34;1mScheme[0m":"[32mhttp[0m","[34;1mHost[0m":"[32mlocalhost:9001[0m","[34;1mPath[0m":"[32m/10gb/2011/www.mattmahoney.net/dc/11ninke.html[0m","[34;1mSchemeSeparator[0m":"[32m://[0m","[34;1mSeparator[0m":[31m47[0m},"[34;1mTime[0m":"0001-01-01T00:00:00Z","[34;1mSize[0m":[31m0[0m,"[34;1mType[0m":[31m0[0m,"[34;1mStorageClass[0m":"[32m[0m","[34;1mMetadata[0m":[1;30;1mnull[0m,"[34;1mUserMetadata[0m":[1;30;1mnull[0m,"[34;1mETag[0m":"[32m[0m","[34;1mExpires[0m":"0001-01-01T00:00:00Z","[34;1mEncryptionHeaders[0m":[1;30;1mnull[0m,"[34;1mRetention[0m":[31mfalse[0m,"[34;1mErr[0m":[1;30;1mnull[0m},"[34;1mTotalCount[0m":[31m0[0m,"[34;1mTotalSize[0m":[31m0[0m} 
```
Add the encoded JSON as raw bytes instead.