### PR TITLE
Make NewS3Config and NewAdminFactory Public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ prime/
 stage/
 mc
 .run*
+.idea/

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -31,8 +31,8 @@ import (
 	"github.com/minio/minio/pkg/madmin"
 )
 
-// newAdminFactory encloses New function with client cache.
-func newAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) {
+// NewAdminFactory encloses New function with client cache.
+func NewAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) {
 	clientCache := make(map[uint32]*madmin.AdminClient)
 	mutex := &sync.Mutex{}
 
@@ -124,7 +124,7 @@ func newAdminClient(aliasedURL string) (*madmin.AdminClient, *probe.Error) {
 		return nil, probe.NewError(fmt.Errorf("No valid configuration found for '%s' host alias", urlStrFull))
 	}
 
-	s3Config := newS3Config(urlStrFull, hostCfg)
+	s3Config := NewS3Config(urlStrFull, hostCfg)
 
 	s3Client, err := s3AdminNew(s3Config)
 	if err != nil {
@@ -135,4 +135,4 @@ func newAdminClient(aliasedURL string) (*madmin.AdminClient, *probe.Error) {
 
 // s3AdminNew returns an initialized minioAdmin structure. If debug is enabled,
 // it also enables an internal trace transport.
-var s3AdminNew = newAdminFactory()
+var s3AdminNew = NewAdminFactory()

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -415,7 +415,7 @@ func newClientFromAlias(alias, urlStr string) (Client, *probe.Error) {
 		return fsClient, nil
 	}
 
-	s3Config := newS3Config(urlStr, hostCfg)
+	s3Config := NewS3Config(urlStr, hostCfg)
 
 	s3Client, err := s3New(s3Config)
 	if err != nil {

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -205,7 +205,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 // signature auto-probe when needed.
 func BuildS3Config(url, accessKey, secretKey, api, lookup string) (*Config, *probe.Error) {
 
-	s3Config := newS3Config(url, &hostConfigV9{
+	s3Config := NewS3Config(url, &hostConfigV9{
 		AccessKey: accessKey,
 		SecretKey: secretKey,
 		URL:       url,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -126,9 +126,9 @@ func splitStr(path, sep string, n int) []string {
 	return splits
 }
 
-// newS3Config simply creates a new Config struct using the passed
+// NewS3Config simply creates a new Config struct using the passed
 // parameters.
-func newS3Config(urlStr string, hostCfg *hostConfigV9) *Config {
+func NewS3Config(urlStr string, hostCfg *hostConfigV9) *Config {
 	// We have a valid alias and hostConfig. We populate the
 	// credentials from the match found in the config file.
 	s3Config := new(Config)


### PR DESCRIPTION
This PR makes `newAdminClient` and `NewAdminFactory` public so they can be leveraged by `mcs`