### PR TITLE
Set S3Client struct as public

### DIFF
--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -168,14 +168,14 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	conf.AccessKey = "WLGDGYAQYIGI833EV05A"
 	conf.SecretKey = "BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"
 	conf.Signature = "S3v4"
-	s3c, err := s3New(conf)
+	s3c, err := S3New(conf)
 	c.Assert(err, IsNil)
 
 	err = s3c.MakeBucket("us-east-1", true, false)
 	c.Assert(err, IsNil)
 
 	conf.HostURL = server.URL + string(s3c.GetURL().Separator)
-	s3c, err = s3New(conf)
+	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
 	for content := range s3c.List(false, false, false, DirNone) {
@@ -184,7 +184,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	}
 
 	conf.HostURL = server.URL + "/bucket"
-	s3c, err = s3New(conf)
+	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
 	for content := range s3c.List(false, false, false, DirNone) {
@@ -193,7 +193,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	}
 
 	conf.HostURL = server.URL + "/bucket/"
-	s3c, err = s3New(conf)
+	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
 	for content := range s3c.List(false, false, false, DirNone) {
@@ -216,7 +216,7 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	conf.AccessKey = "WLGDGYAQYIGI833EV05A"
 	conf.SecretKey = "BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"
 	conf.Signature = "S3v4"
-	s3c, err := s3New(conf)
+	s3c, err := S3New(conf)
 	c.Assert(err, IsNil)
 
 	var reader io.Reader

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -417,7 +417,7 @@ func newClientFromAlias(alias, urlStr string) (Client, *probe.Error) {
 
 	s3Config := newS3Config(urlStr, hostCfg)
 
-	s3Client, err := s3New(s3Config)
+	s3Client, err := S3New(s3Config)
 	if err != nil {
 		return nil, err.Trace(alias, urlStr)
 	}

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -171,7 +171,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 		Debug:     globalDebug,
 	}
 
-	s3Client, err := s3New(s3Config)
+	s3Client, err := S3New(s3Config)
 	if err != nil {
 		return "", err
 	}
@@ -183,7 +183,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 		default:
 			// Attempt with signature v2, since v4 seem to have failed.
 			s3Config.Signature = "s3v2"
-			s3Client, err = s3New(s3Config)
+			s3Client, err = S3New(s3Config)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/event-add.go
+++ b/cmd/event-add.go
@@ -123,7 +123,7 @@ func mainEventAdd(ctx *cli.Context) error {
 		fatalIf(err.Trace(), "Cannot parse the provided url.")
 	}
 
-	s3Client, ok := client.(*s3Client)
+	s3Client, ok := client.(*S3Client)
 	if !ok {
 		fatalIf(errDummy().Trace(), "The provided url doesn't point to a S3 server.")
 	}

--- a/cmd/event-list.go
+++ b/cmd/event-list.go
@@ -115,7 +115,7 @@ func mainEventList(ctx *cli.Context) error {
 		fatalIf(err.Trace(), "Cannot parse the provided url.")
 	}
 
-	s3Client, ok := client.(*s3Client)
+	s3Client, ok := client.(*S3Client)
 	if !ok {
 		fatalIf(errDummy().Trace(), "The provided url doesn't point to a S3 server.")
 	}

--- a/cmd/event-remove.go
+++ b/cmd/event-remove.go
@@ -106,7 +106,7 @@ func mainEventRemove(ctx *cli.Context) error {
 		fatalIf(err.Trace(), "Cannot parse the provided url.")
 	}
 
-	s3Client, ok := client.(*s3Client)
+	s3Client, ok := client.(*S3Client)
 	if !ok {
 		fatalIf(errDummy().Trace(), "The provided url doesn't point to a S3 server.")
 	}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -30,61 +30,61 @@ func TestMatchFind(t *testing.T) {
 	// tests are run in the same order as this list.
 	var listFindContexts = []*findContext{
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			ignorePattern: "*.go",
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			namePattern: "console",
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			pathPattern: "*console*",
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			regexPattern: `^(\d+\.){3}\d+$`,
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			olderThan: "1d",
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			newerThan: "32000d",
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			largerSize: 1024 * 1024,
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			smallerSize: 1024,
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 			ignorePattern: "*.txt",
 		},
 		{
-			clnt: &s3Client{
+			clnt: &S3Client{
 				targetURL: &clientURL{},
 			},
 		},

--- a/cmd/lock-main.go
+++ b/cmd/lock-main.go
@@ -100,7 +100,7 @@ func lock(urlStr string, mode *minio.RetentionMode, validity *uint, unit *minio.
 		fatalIf(err.Trace(), "Cannot parse the provided url.")
 	}
 
-	s3Client, ok := client.(*s3Client)
+	s3Client, ok := client.(*S3Client)
 	if !ok {
 		fatalIf(errDummy().Trace(), "The provided url doesn't point to a S3 server.")
 	}


### PR DESCRIPTION
This PR changes `s3Client` and `s3New` to public, those will be used by mcs.
All functions used by the struct were also modified.