### PR TITLE
s3: Use head API before listing in client.Stat()

### DIFF
--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -152,7 +152,7 @@ func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error 
 		// downloaded object is equal to the original one. FS files
 		// are ignored since some of them have zero size though they
 		// have contents like files under /proc.
-		client, content, err := url2Stat(sourceURL, false, false, encKeyDB)
+		client, content, err := url2Stat(sourceURL, false, encKeyDB)
 		if err == nil && client.GetURL().Type == objectStorage {
 			size = content.Size
 		}

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -210,7 +210,7 @@ func (s *TestSuite) TestStatBucket(c *C) {
 	c.Assert(err, IsNil)
 	err = fsClient.MakeBucket("us-east-1", true, false)
 	c.Assert(err, IsNil)
-	_, err = fsClient.Stat(false, false, false, nil)
+	_, err = fsClient.Stat(false, false, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -334,7 +334,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	content, err := fsClient.Stat(false, false, false, nil)
+	content, err := fsClient.Stat(false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(content.Size, Equals, int64(dataLen))
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1300,7 +1300,7 @@ func (c *S3Client) listObjectWrapper(bucket, object string, isRecursive bool, do
 	return c.api.ListObjectsV2(bucket, object, isRecursive, doneCh)
 }
 
-func (c *S3Client) statInComplete(bucket, object string) (*ClientContent, *probe.Error) {
+func (c *S3Client) statIncompleteUpload(bucket, object string) (*ClientContent, *probe.Error) {
 	nonRecursive := false
 	objectMetadata := &ClientContent{}
 	// Prefix to pass to minio-go listing in order to fetch a given object/directory
@@ -1352,7 +1352,7 @@ func (c *S3Client) Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (
 
 	// If the request is for incomplete upload stat, handle it here.
 	if isIncomplete {
-		return c.statInComplete(bucket, object)
+		return c.statIncompleteUpload(bucket, object)
 	}
 
 	// The following code tries to calculate if a given prefix/object does really exist

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -179,7 +179,7 @@ func url2Stat(urlStr string, isFetchMeta, fileAttr bool, encKeyDB map[string][]p
 	alias, _ := url2Alias(urlStr)
 	sse := getSSE(urlStr, encKeyDB[alias])
 
-	content, err = client.Stat(false, isFetchMeta, fileAttr, sse)
+	content, err = client.Stat(false, fileAttr, sse)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -171,7 +171,7 @@ func urlJoinPath(url1, url2 string) string {
 }
 
 // url2Stat returns stat info for URL.
-func url2Stat(urlStr string, isFetchMeta, fileAttr bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *ClientContent, err *probe.Error) {
+func url2Stat(urlStr string, fileAttr bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *ClientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -46,7 +46,7 @@ const defaultMultipartThreadsNum = 4
 // Client - client interface
 type Client interface {
 	// Common operations
-	Stat(isIncomplete, isFetchMeta, isPreserve bool, sse encrypt.ServerSide) (content *ClientContent, err *probe.Error)
+	Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (content *ClientContent, err *probe.Error)
 	List(isRecursive, isIncomplete, isFetchMeta bool, showDir DirOpt) <-chan *ClientContent
 
 	// Bucket operations

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -174,7 +174,7 @@ func getSourceStream(alias string, urlStr string, fetchStat bool, sse encrypt.Se
 	}
 	metadata = make(map[string]string)
 	if fetchStat {
-		st, err := sourceClnt.Stat(false, true, false, sse)
+		st, err := sourceClnt.Stat(false, false, sse)
 		if err != nil {
 			return nil, nil, err.Trace(alias, urlStr)
 		}
@@ -311,7 +311,7 @@ func getAllMetadata(sourceAlias, sourceURLStr string, srcSSE encrypt.ServerSide,
 	if err != nil {
 		return nil, err.Trace(sourceAlias, sourceURLStr)
 	}
-	st, err := sourceClnt.Stat(false, true, false, srcSSE)
+	st, err := sourceClnt.Stat(false, false, srcSSE)
 	if err != nil {
 		return nil, err.Trace(sourceAlias, sourceURLStr)
 	}
@@ -478,7 +478,7 @@ func getFileAttrMeta(sURLs URLs, encKeyDB map[string][]prefixSSEPair) (string, *
 		return "", err.Trace(sourceURL.String())
 	}
 
-	sourceMeta, err := srcClt.Stat(false, true, true, srcSSE)
+	sourceMeta, err := srcClt.Stat(false, true, srcSSE)
 	if err != nil {
 		return "", err.Trace(sourceURL.String())
 	}

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -107,7 +107,7 @@ func getEncKeys(ctx *cli.Context) (map[string][]prefixSSEPair, *probe.Error) {
 func isAliasURLDir(aliasURL string, keys map[string][]prefixSSEPair) bool {
 	// If the target url exists, check if it is a directory
 	// and return immediately.
-	_, targetContent, err := url2Stat(aliasURL, false, false, keys)
+	_, targetContent, err := url2Stat(aliasURL, false, keys)
 	if err == nil {
 		return targetContent.Type.IsDir()
 	}

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -178,7 +178,7 @@ func probeS3Signature(accessKey, secretKey, url string) (string, *probe.Error) {
 			return "", err
 		}
 
-		if _, err := s3Client.Stat(false, false, false, nil); err != nil {
+		if _, err := s3Client.Stat(false, false, nil); err != nil {
 			e := err.ToGoError()
 			if _, ok := e.(BucketDoesNotExist); ok {
 				// Bucket doesn't exist, means signature probing worked successfully.

--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -44,7 +44,7 @@ func checkCopySyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair, isMv
 
 	// Verify if source(s) exists.
 	for _, srcURL := range srcURLs {
-		_, _, err := url2Stat(srcURL, false, false, encKeyDB)
+		_, _, err := url2Stat(srcURL, false, encKeyDB)
 		if err != nil {
 			console.Fatalf("Unable to validate source %s\n", srcURL)
 		}
@@ -103,7 +103,7 @@ func checkCopySyntaxTypeA(srcURLs []string, tgtURL string, keys map[string][]pre
 		fatalIf(errInvalidArgument().Trace(), "Invalid number of source arguments.")
 	}
 	srcURL := srcURLs[0]
-	_, srcContent, err := url2Stat(srcURL, false, false, keys)
+	_, srcContent, err := url2Stat(srcURL, false, keys)
 	fatalIf(err.Trace(srcURL), "Unable to stat source `"+srcURL+"`.")
 
 	if !srcContent.Type.IsRegular() {
@@ -118,7 +118,7 @@ func checkCopySyntaxTypeB(srcURLs []string, tgtURL string, keys map[string][]pre
 		fatalIf(errInvalidArgument().Trace(), "Invalid number of source arguments.")
 	}
 	srcURL := srcURLs[0]
-	_, srcContent, err := url2Stat(srcURL, false, false, keys)
+	_, srcContent, err := url2Stat(srcURL, false, keys)
 	fatalIf(err.Trace(srcURL), "Unable to stat source `"+srcURL+"`.")
 
 	if !srcContent.Type.IsRegular() {
@@ -126,7 +126,7 @@ func checkCopySyntaxTypeB(srcURLs []string, tgtURL string, keys map[string][]pre
 	}
 
 	// Check target.
-	if _, tgtContent, err := url2Stat(tgtURL, false, false, keys); err == nil {
+	if _, tgtContent, err := url2Stat(tgtURL, false, keys); err == nil {
 		if !tgtContent.Type.IsDir() {
 			fatalIf(errInvalidArgument().Trace(tgtURL), "Target `"+tgtURL+"` is not a folder.")
 		}
@@ -141,14 +141,14 @@ func checkCopySyntaxTypeC(srcURLs []string, tgtURL string, isRecursive bool, key
 	}
 
 	// Check target.
-	if _, tgtContent, err := url2Stat(tgtURL, false, false, keys); err == nil {
+	if _, tgtContent, err := url2Stat(tgtURL, false, keys); err == nil {
 		if !tgtContent.Type.IsDir() {
 			fatalIf(errInvalidArgument().Trace(tgtURL), "Target `"+tgtURL+"` is not a folder.")
 		}
 	}
 
 	for _, srcURL := range srcURLs {
-		c, srcContent, err := url2Stat(srcURL, false, false, keys)
+		c, srcContent, err := url2Stat(srcURL, false, keys)
 		// incomplete uploads are not necessary for copy operation, no need to verify for them.
 		isIncomplete := false
 		if err != nil {
@@ -186,7 +186,7 @@ func checkCopySyntaxTypeC(srcURLs []string, tgtURL string, isRecursive bool, key
 func checkCopySyntaxTypeD(srcURLs []string, tgtURL string, keys map[string][]prefixSSEPair, isMvCmd bool) {
 	// Source can be anything: file, dir, dir...
 	// Check target if it is a dir
-	if _, tgtContent, err := url2Stat(tgtURL, false, false, keys); err == nil {
+	if _, tgtContent, err := url2Stat(tgtURL, false, keys); err == nil {
 		if !tgtContent.Type.IsDir() {
 			fatalIf(errInvalidArgument().Trace(tgtURL), "Target `"+tgtURL+"` is not a folder.")
 		}

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -53,7 +53,7 @@ const (
 func guessCopyURLType(sourceURLs []string, targetURL string, isRecursive bool, keys map[string][]prefixSSEPair) (copyURLsType, *probe.Error) {
 	if len(sourceURLs) == 1 { // 1 Source, 1 Target
 		sourceURL := sourceURLs[0]
-		_, sourceContent, err := url2Stat(sourceURL, false, false, keys)
+		_, sourceContent, err := url2Stat(sourceURL, false, keys)
 		if err != nil {
 			return copyURLsTypeInvalid, err
 		}
@@ -88,7 +88,7 @@ func prepareCopyURLsTypeA(sourceURL string, targetURL string, encKeyDB map[strin
 	// Find alias and expanded clientURL.
 	targetAlias, targetURL, _ := mustExpandAlias(targetURL)
 
-	_, sourceContent, err := url2Stat(sourceURL, false, false, encKeyDB)
+	_, sourceContent, err := url2Stat(sourceURL, false, encKeyDB)
 	if err != nil {
 		// Source does not exist or insufficient privileges.
 		return URLs{Error: err.Trace(sourceURL)}
@@ -121,7 +121,7 @@ func prepareCopyURLsTypeB(sourceURL string, targetURL string, encKeyDB map[strin
 	// Find alias and expanded clientURL.
 	targetAlias, targetURL, _ := mustExpandAlias(targetURL)
 
-	_, sourceContent, err := url2Stat(sourceURL, false, false, encKeyDB)
+	_, sourceContent, err := url2Stat(sourceURL, false, encKeyDB)
 	if err != nil {
 		// Source does not exist or insufficient privileges.
 		return URLs{Error: err.Trace(sourceURL)}

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -123,7 +123,7 @@ func checkDiffSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	// Diff only works between two directories, verify them below.
 
 	// Verify if firstURL is accessible.
-	_, firstContent, err := url2Stat(firstURL, false, false, encKeyDB)
+	_, firstContent, err := url2Stat(firstURL, false, encKeyDB)
 	if err != nil {
 		fatalIf(err.Trace(firstURL), fmt.Sprintf("Unable to stat '%s'.", firstURL))
 	}
@@ -134,7 +134,7 @@ func checkDiffSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	}
 
 	// Verify if secondURL is accessible.
-	_, secondContent, err := url2Stat(secondURL, false, false, encKeyDB)
+	_, secondContent, err := url2Stat(secondURL, false, encKeyDB)
 	if err != nil {
 		fatalIf(err.Trace(secondURL), fmt.Sprintf("Unable to stat '%s'.", secondURL))
 	}

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -170,7 +170,7 @@ func checkFindSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 
 	// Extract input URLs and validate.
 	for _, url := range args {
-		_, _, err := url2Stat(url, false, false, encKeyDB)
+		_, _, err := url2Stat(url, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, false) {
 			// Bucket name empty is a valid error for 'find myminio' unless we are using watch, treat it as such.
 			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !ctx.Bool("watch") {

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -420,7 +420,7 @@ func getShareURL(path string) string {
 	clnt, err := newClientFromAlias(targetAlias, targetURLFull)
 	fatalIf(err.Trace(targetAlias, targetURLFull), "Unable to initialize client instance from alias.")
 
-	content, err := clnt.Stat(false, false, false, nil)
+	content, err := clnt.Stat(false, false, nil)
 	fatalIf(err.Trace(targetURLFull, targetAlias), "Unable to lookup file/object.")
 
 	// Skip if its a directory.

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -91,7 +91,7 @@ func checkListSyntax(ctx *cli.Context) {
 	isIncomplete := ctx.Bool("incomplete")
 
 	for _, url := range URLs {
-		_, _, err := url2Stat(url, false, false, nil)
+		_, _, err := url2Stat(url, false, nil)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			// Bucket name empty is a valid error for 'ls myminio',
 			// treat it as such.

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -133,7 +133,7 @@ func mainList(ctx *cli.Context) error {
 
 		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 			var st *ClientContent
-			st, err = clnt.Stat(isIncomplete, false, false, nil)
+			st, err = clnt.Stat(isIncomplete, false, nil)
 			if st != nil && err == nil && st.Type.IsDir() {
 				targetURL = targetURL + string(clnt.GetURL().Separator)
 				clnt, err = newClient(targetURL)

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -456,7 +456,7 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, cancelMirror context.Cance
 					}
 					shouldQueue := false
 					if !mj.isOverwrite {
-						_, err = targetClient.Stat(false, false, false, tgtSSE)
+						_, err = targetClient.Stat(false, false, tgtSSE)
 						if err == nil {
 							continue
 						} // doesn't exist
@@ -482,7 +482,7 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, cancelMirror context.Cance
 						mj.statusCh <- mirrorURL.WithError(err)
 						return
 					}
-					_, err = targetClient.Stat(false, false, false, tgtSSE)
+					_, err = targetClient.Stat(false, false, tgtSSE)
 					if err == nil {
 						if mirrorURL.SourceContent.Retention {
 							shouldQueue = true

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -70,7 +70,7 @@ func checkMirrorSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 
 	/****** Generic rules *******/
 	if !ctx.Bool("watch") {
-		_, srcContent, err := url2Stat(srcURL, false, false, encKeyDB)
+		_, srcContent, err := url2Stat(srcURL, false, encKeyDB)
 		// incomplete uploads are not necessary for copy operation, no need to verify for them.
 		isIncomplete := false
 		if err != nil && !isURLPrefixExists(srcURL, isIncomplete) {

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -215,7 +215,7 @@ func mainRemoveBucket(ctx *cli.Context) error {
 			cErr = exitStatus(globalErrorExitStatus)
 			continue
 		}
-		_, err = clnt.Stat(false, false, false, nil)
+		_, err = clnt.Stat(false, false, nil)
 		if err != nil {
 			switch err.ToGoError().(type) {
 			case BucketNameEmpty:

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -122,11 +122,10 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 
 	// Generate share URL for each target.
 	isIncomplete := false
-	isFetchMeta := false
 	// Channel which will receive objects whose URLs need to be shared
 	objectsCh := make(chan *ClientContent)
 
-	content, err := clnt.Stat(isIncomplete, isFetchMeta, false, nil)
+	content, err := clnt.Stat(isIncomplete, false, nil)
 	if err != nil {
 		return err.Trace(clnt.GetURL().String())
 	}

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -93,7 +93,7 @@ func checkShareDownloadSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEP
 	isRecursive := ctx.Bool("recursive")
 	if !isRecursive {
 		for _, url := range ctx.Args() {
-			_, _, err := url2Stat(url, false, false, encKeyDB)
+			_, _, err := url2Stat(url, false, encKeyDB)
 			if err != nil {
 				fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 			}

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -89,7 +89,7 @@ func checkStatSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	isIncomplete := false
 
 	for _, url := range URLs {
-		_, _, err := url2Stat(url, false, false, encKeyDB)
+		_, _, err := url2Stat(url, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 		}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -176,7 +176,7 @@ func statURL(targetURL string, isIncomplete, isRecursive bool, encKeyDB map[stri
 			return nil, errTargetNotFound(targetURL).Trace(url, standardizedURL)
 		}
 
-		_, stat, err := url2Stat(url, true, true, encKeyDB)
+		_, stat, err := url2Stat(url, true, encKeyDB)
 		if err != nil {
 			stat = content
 		}

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -119,7 +119,7 @@ func checkTreeSyntax(ctx *cli.Context) {
 	}
 
 	for _, url := range args {
-		if _, _, err := url2Stat(url, false, false, nil); err != nil && !isURLPrefixExists(url, false) {
+		if _, _, err := url2Stat(url, false, nil); err != nil && !isURLPrefixExists(url, false) {
 			fatalIf(err.Trace(url), "Unable to tree `"+url+"`.")
 		}
 	}


### PR DESCRIPTION
Stat() is supposed to return valid information for existing
objects and existing prefixes as well.

The current mechanism issues a listing request and searches
for the object or prefix in the returned list, but this could take
time if there are lot of entries under a parent prefix.

The new commit changes the internal behavior but not the
functional output. It issues a HEAD request first, if there
is no object then assumes it is a prefix and does listing
in order to find it.

Fixes https://github.com/minio/mc/issues/3148