### PR TITLE
fix avoid multiple HEAD operations

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -931,8 +931,8 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, metada
 		delete(metadata, AmzObjectLockMode)
 	}
 
-	retainUntilDateStr, ok := metadata[AmzObjectLockRetainUntilDate]
 	retainUntilDate := timeSentinel
+	retainUntilDateStr, ok := metadata[AmzObjectLockRetainUntilDate]
 	if ok {
 		delete(metadata, AmzObjectLockRetainUntilDate)
 		if t, e := time.Parse(time.RFC3339, retainUntilDateStr); e == nil {
@@ -952,14 +952,17 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, metada
 		ServerSideEncryption: sse,
 		DisableMultipart:     disableMultipart,
 	}
-	if retainUntilDate != timeSentinel {
+
+	if !retainUntilDate.IsZero() && !retainUntilDate.Equal(timeSentinel) {
 		opts.RetainUntilDate = &retainUntilDate
 		opts.SendContentMd5 = true
 	}
+
 	if lockModeStr != "" {
 		opts.Mode = &lockMode
 		opts.SendContentMd5 = true
 	}
+
 	if lh, ok := metadata[AmzObjectLockLegalHold]; ok {
 		delete(metadata, AmzObjectLockLegalHold)
 		opts.LegalHold = minio.LegalHoldStatus(strings.ToUpper(lh))

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -311,16 +311,6 @@ func (mj *mirrorJob) doMirror(ctx context.Context, cancelMirror context.CancelFu
 		}
 	}
 
-	if mj.isPreserve {
-		attrValue, pErr := getFileAttrMeta(sURLs, mj.encKeyDB)
-		if pErr != nil {
-			return sURLs.WithError(pErr)
-		}
-		if attrValue != "" {
-			sURLs.TargetContent.Metadata["mc-attrs"] = attrValue
-		}
-	}
-
 	// Initialize additional target user metadata.
 	sURLs.TargetContent.UserMetadata = mj.userMetadata
 
@@ -333,7 +323,7 @@ func (mj *mirrorJob) doMirror(ctx context.Context, cancelMirror context.CancelFu
 		TotalCount: sURLs.TotalCount,
 		TotalSize:  sURLs.TotalSize,
 	})
-	return uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.encKeyDB)
+	return uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.encKeyDB, mj.isPreserve)
 }
 
 // Update progress status

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.5 // indirect
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio v0.0.0-20200415191640-bde0f444dbab
-	github.com/minio/minio-go/v6 v6.0.53
+	github.com/minio/minio-go/v6 v6.0.54-0.20200417072347-d624b8a802c5
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/profile v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/minio/minio v0.0.0-20200415191640-bde0f444dbab h1:9hlqghJl3e3HorXa6AD
 github.com/minio/minio v0.0.0-20200415191640-bde0f444dbab/go.mod h1:v8oQPMMaTkjDwp5cOz1WCElA4Ik+X+0y4On+VMk0fis=
 github.com/minio/minio-go/v6 v6.0.53 h1:8jzpwiOzZ5Iz7/goFWqNZRICbyWYShbb5rARjrnSCNI=
 github.com/minio/minio-go/v6 v6.0.53/go.mod h1:DIvC/IApeHX8q1BAMVCXSXwpmrmM+I+iBvhvztQorfI=
+github.com/minio/minio-go/v6 v6.0.54-0.20200417072347-d624b8a802c5 h1:oYoTfDzXSBQiSyUXECIJrFjTlIV0mFH1kGNPEf6jb6Q=
+github.com/minio/minio-go/v6 v6.0.54-0.20200417072347-d624b8a802c5/go.mod h1:DIvC/IApeHX8q1BAMVCXSXwpmrmM+I+iBvhvztQorfI=
 github.com/minio/parquet-go v0.0.0-20200414234858-838cfa8aae61/go.mod h1:4trzEJ7N1nBTd5Tt7OCZT5SEin+WiAXpdJ/WgPkESA8=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=


### PR DESCRIPTION
- Get() already has the metadata to preserve
- Stat() doesn't need to be sent multiple times
  do preserve attributes, use it once.