### PR TITLE
Canonicalize metadata received as part of events

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -424,10 +424,10 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 	}
 
 	for k, v := range urls.SourceContent.UserMetadata {
-		metadata[k] = v
+		metadata[http.CanonicalHeaderKey(k)] = v
 	}
 	for k, v := range urls.SourceContent.Metadata {
-		metadata[k] = v
+		metadata[http.CanonicalHeaderKey(k)] = v
 	}
 
 	// Optimize for server side copy if the host is same.


### PR DESCRIPTION
If the user does `mc retention source/bucket/object governance 1d` on an object without a lock

and `mc mirror --watch -a source/bucket target/bucket` is currently running,

 the metadata received as part of the event is in lower case, mc is only checking for `canonicalized` version and this causes `putobjectretention` to fail. Canonicalizing the metadata received, fixes the issue.

