### PR TITLE
Fixes copy filesytem to objectstore regression

### DIFF
--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -191,10 +192,17 @@ func makeCopyContentTypeC(sourceAlias string, sourceURL ClientURL, sourceContent
 	newSourceSuffix := filepath.ToSlash(newSourceURL.Path)
 	if pathSeparatorIndex > 1 {
 		sourcePrefix := filepath.ToSlash(sourceURL.Path[:pathSeparatorIndex])
-		// do not preserve unix cp behavior when copying from filesytem to
+		// do not preserve unix cp behavior when copying a filesytem dir to
 		// objectstore.
 		if sourceAlias == "" && targetAlias != "" {
-			sourcePrefix = sourceURL.Path
+			// Check if sourceURL.Path is a directory or not
+			fileInfo, err := os.Stat(sourceURL.Path)
+			if err != nil {
+				return URLs{Error: probe.NewError(err)}
+			}
+			if fileInfo.IsDir() {
+				sourcePrefix = sourceURL.Path
+			}
 		}
 		newSourceSuffix = strings.TrimPrefix(newSourceSuffix, sourcePrefix)
 	}


### PR DESCRIPTION
Fixes #3153 

This is a regression fix caused by PR #3115 

PR#3115 was also supposed to check not only if the copy happens between local filesystem and the object store, but also if the object is a directory recursively copied from the local filesystem.