### PR TITLE
Skip sql select call if object does not exist

### DIFF
--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -446,7 +446,10 @@ func mainSQL(ctx *cli.Context) error {
 	URLs := ctx.Args()
 	writeHdr := true
 	for _, url := range URLs {
-		if !isAliasURLDir(url, encKeyDB) {
+		if _, targetContent, err := url2Stat(url, false, encKeyDB); err != nil {
+			errorIf(err.Trace(url), "Unable to run sql for "+url+".")
+			continue
+		} else if !targetContent.Type.IsDir() {
 			if writeHdr {
 				query, csvHdrs, selOpts = getAndValidateArgs(ctx, encKeyDB, url)
 			}


### PR DESCRIPTION
selectobject API was issued in `mc sql` even if the object does not exist. This PR skips selectobject call if the object does not exist