### PR TITLE
doc: Remove example related to object locked bucket

### DIFF
--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -138,10 +138,7 @@ EXAMPLES:
   15. Move a text file to an object storage and preserve the file system attribute as metadata.
       {{.Prompt}} {{.HelpName}} -a myobject.txt play/mybucket
 
-  16. Move a text file to an object storage with object lock mode set to 'GOVERNANCE' with retention date.
-      {{.Prompt}} {{.HelpName}} --attr "x-amz-object-lock-mode=GOVERNANCE;x-amz-object-lock-retain-until-date=2020-01-11T01:57:02Z" locked.txt play/locked-bucket/
-
-  17. Move a text file to an object storage and disable multipart upload feature.
+  16. Move a text file to an object storage and disable multipart upload feature.
       {{.Prompt}} {{.HelpName}} --disable-multipart myobject.txt play/mybucket
 `,
 }


### PR DESCRIPTION
mv does not support this command for object locked buckets.