### PR TITLE
fixes cp not preserving ownership and other attrs

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -678,12 +678,12 @@ function test_cat_object_with_sse_error()
     log_success "$start_time" "${FUNCNAME[0]}"
 }
 
-# Test mc cp command with preserve file system attributes
+# Test "mc cp -a" command to see if it preserves file system attributes
 function test_copy_object_preserve_filesystem_attr()
 {
     show "${FUNCNAME[0]}"
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp -a "${FILE_1_MB}" "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"
-    diff -bB <("${MC_CMD[@]}"   --json stat "${FILE_1_MB}"  |  jq -r '.metadata."mc-attrs"')  >/dev/null 2>&1 <("${MC_CMD[@]}"   --json stat "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"  |  jq -r '.metadata."X-Amz-Meta-Mc-Attrs"')  >/dev/null 2>&1
+    diff -bB <("${MC_CMD[@]}"   --json stat "${FILE_1_MB}"  |  jq -r '.metadata."X-Amz-Meta-Mc-Attrs"')  >/dev/null 2>&1 <("${MC_CMD[@]}"   --json stat "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"  |  jq -r '.metadata."X-Amz-Meta-Mc-Attrs"')  >/dev/null 2>&1
     assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to put object with file system attribute"
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm "${SERVER_ALIAS}/${BUCKET_NAME}/${object_name}"
     log_success "$start_time" "${FUNCNAME[0]}"


### PR DESCRIPTION
Fixes #3187 

When the preserve attributes flag, `-a`, and functionality was introduced, the assumption was that metadata index is going to be `"mc-attrs"`, however, it is `"X-Amz-Meta-Mc-Attrs"`.
The fix is to accept both indexes as valid values.