### PR TITLE
copyobject: Do not ignore storage class in the target

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -467,6 +467,16 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 			err = putTargetRetention(ctx, targetAlias, targetURL.String(), metadata)
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}
+
+		// Get metadata from target content as well
+		for k, v := range urls.TargetContent.Metadata {
+			metadata[k] = v
+		}
+		// Get userMetadata from target content as well
+		for k, v := range urls.TargetContent.UserMetadata {
+			metadata[k] = v
+		}
+
 		err = copySourceToTargetURL(targetAlias, targetURL.String(), sourcePath, mode, until,
 			legalHold, length, progress, srcSSE, tgtSSE, filterMetadata(metadata), urls.DisableMultipart)
 	} else {


### PR DESCRIPTION
If storage class or any other attribute is specified, it gets ignored if the resulting operation is a copyobject. This PR fixes that by heaving similar to when happens in the case of PutObject 

Fixes #3230