### PR TITLE
mirror: check if bucket exists before creating it

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -851,7 +851,7 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 				}
 			}
 		}
-	} else {
+	} else if _, err := dstClt.Stat(false, false, nil); err != nil {
 		withLock := false
 		mode, validity, unit, err := srcClt.GetObjectLockConfig()
 		if err == nil {


### PR DESCRIPTION
Also, check if bucket exists before trying to create it in mirror

Fixes #3228