### PR TITLE
Avoid annoying error when alias has a leading slash

### DIFF
--- a/cmd/admin-prometheus-generate.go
+++ b/cmd/admin-prometheus-generate.go
@@ -138,7 +138,7 @@ func checkAdminPrometheusSyntax(ctx *cli.Context) {
 func generatePrometheusConfig(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
-	alias := args.Get(0)
+	alias := cleanAlias(args.Get(0))
 
 	if !isValidAlias(alias) {
 		fatalIf(errInvalidAlias(alias), "Invalid alias.")

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -101,7 +101,7 @@ func checkConfigHostAddSyntax(ctx *cli.Context, accessKey string, secretKey stri
 			"Incorrect number of arguments for host add command.")
 	}
 
-	alias := args.Get(0)
+	alias := cleanAlias(args.Get(0))
 	url := args.Get(1)
 	api := ctx.String("api")
 	bucketLookup := ctx.String("lookup")
@@ -277,6 +277,7 @@ func mainConfigHostAdd(ctx *cli.Context) error {
 	console.SetColor("HostMessage", color.New(color.FgGreen))
 	var (
 		args   = ctx.Args()
+		alias  = cleanAlias(args.Get(0))
 		url    = trimTrailingSeparator(args.Get(1))
 		api    = ctx.String("api")
 		lookup = ctx.String("lookup")
@@ -287,7 +288,7 @@ func mainConfigHostAdd(ctx *cli.Context) error {
 	s3Config, err := BuildS3Config(url, accessKey, secretKey, api, lookup)
 	fatalIf(err.Trace(ctx.Args()...), "Unable to initialize new config from the provided credentials.")
 
-	addHost(ctx.Args().Get(0), hostConfigV9{
+	addHost(alias, hostConfigV9{
 		URL:       s3Config.HostURL,
 		AccessKey: s3Config.AccessKey,
 		SecretKey: s3Config.SecretKey,

--- a/cmd/config-host-list.go
+++ b/cmd/config-host-list.go
@@ -59,13 +59,6 @@ func checkConfigHostListSyntax(ctx *cli.Context) {
 		fatalIf(errInvalidArgument().Trace(args...),
 			"Incorrect number of arguments to list hosts.")
 	}
-
-	if args.Get(0) != "" {
-		if !isValidAlias(args.Get(0)) {
-			fatalIf(errDummy().Trace(args.Get(0)),
-				"Invalid alias `"+args.Get(0)+"`.")
-		}
-	}
 }
 
 func mainConfigHostList(ctx *cli.Context) error {
@@ -79,8 +72,9 @@ func mainConfigHostList(ctx *cli.Context) error {
 	console.SetColor("API", color.New(color.FgBlue))
 	console.SetColor("Lookup", color.New(color.FgCyan))
 
-	args := ctx.Args()
-	listHosts(args.Get(0)) // List all configured hosts.
+	alias := cleanAlias(ctx.Args().Get(0))
+
+	listHosts(alias) // List all configured hosts.
 	return nil
 }
 

--- a/cmd/config-host-remove.go
+++ b/cmd/config-host-remove.go
@@ -55,9 +55,9 @@ func checkConfigHostRemoveSyntax(ctx *cli.Context) {
 			"Incorrect number of arguments for remove host command.")
 	}
 
-	if !isValidAlias(args.Get(0)) {
-		fatalIf(errDummy().Trace(args.Get(0)),
-			"Invalid alias `"+args.Get(0)+"`.")
+	alias := cleanAlias(args.Get(0))
+	if !isValidAlias(alias) {
+		fatalIf(errDummy().Trace(alias), "Invalid alias `"+alias+"`.")
 	}
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -159,6 +159,14 @@ func isMcConfigExists() bool {
 	return true
 }
 
+// cleanAlias removes any forbidden trailing slashes or backslashes
+// before any validation to avoid annoying mc complaints.
+func cleanAlias(s string) string {
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, "\\")
+	return s
+}
+
 // isValidAlias - Check if alias valid.
 func isValidAlias(alias string) bool {
 	return regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9-_]+$").MatchString(alias)


### PR DESCRIPTION
```
mc config host list
mc config host add
mc config host remove
mc admin prometheus generate
```

The above mc commands generate an annoying error message complaining
about the leading slash in the alias argument.

Although alias does not support any slash or backslash, we allow the
user to enter it for convenience and the code will just clean it before
using it.