### PR TITLE
Apply global context for all apis

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -221,7 +221,7 @@ func mainAdminHeal(ctx *cli.Context) error {
 		fatalIf(err.Trace(clnt.GetURL().String()), "Unable to create client for URL ", aliasedURL)
 		return nil
 	}
-	for content := range clnt.List(false, false, false, DirNone) {
+	for content := range clnt.List(globalContext, false, false, false, DirNone) {
 		if content.Err != nil {
 			fatalIf(content.Err.Trace(clnt.GetURL().String()), "Unable to heal bucket `"+bucket+"`.")
 			return nil

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -96,7 +96,7 @@ func completeS3Path(s3Path string) (prediction []string) {
 
 	// List dirPath content and only pick elements that corresponds
 	// to the path that we want to complete
-	for content := range clnt.List(false, false, false, DirFirst) {
+	for content := range clnt.List(globalContext, false, false, false, DirFirst) {
 		cmplS3Path := alias + getKey(content)
 		if content.Type.IsDir() {
 			if !strings.HasSuffix(cmplS3Path, "/") {

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -156,7 +157,7 @@ func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error 
 		if err == nil && client.GetURL().Type == objectStorage {
 			size = content.Size
 		}
-		if reader, err = getSourceStreamFromURL(sourceURL, encKeyDB); err != nil {
+		if reader, err = getSourceStreamFromURL(context.Background(), sourceURL, encKeyDB); err != nil {
 			return err.Trace(sourceURL)
 		}
 		defer reader.Close()

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -140,7 +140,7 @@ func checkCatSyntax(ctx *cli.Context) {
 }
 
 // catURL displays contents of a URL to stdout.
-func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error {
+func catURL(ctx context.Context, sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error {
 	var reader io.ReadCloser
 	size := int64(-1)
 	switch sourceURL {
@@ -153,11 +153,11 @@ func catURL(sourceURL string, encKeyDB map[string][]prefixSSEPair) *probe.Error 
 		// downloaded object is equal to the original one. FS files
 		// are ignored since some of them have zero size though they
 		// have contents like files under /proc.
-		client, content, err := url2Stat(sourceURL, false, encKeyDB)
+		client, content, err := url2Stat(ctx, sourceURL, false, encKeyDB)
 		if err == nil && client.GetURL().Type == objectStorage {
 			size = content.Size
 		}
-		if reader, err = getSourceStreamFromURL(context.Background(), sourceURL, encKeyDB); err != nil {
+		if reader, err = getSourceStreamFromURL(ctx, sourceURL, encKeyDB); err != nil {
 			return err.Trace(sourceURL)
 		}
 		defer reader.Close()
@@ -211,17 +211,20 @@ func catOut(r io.Reader, size int64) *probe.Error {
 }
 
 // mainCat is the main entry point for cat command.
-func mainCat(ctx *cli.Context) error {
+func mainCat(cliCtx *cli.Context) error {
+	ctx, cancelCat := context.WithCancel(globalContext)
+	defer cancelCat()
+
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check 'cat' cli arguments.
-	checkCatSyntax(ctx)
+	checkCatSyntax(cliCtx)
 
 	// Set command flags from context.
 	stdinMode := false
-	if !ctx.Args().Present() {
+	if !cliCtx.Args().Present() {
 		stdinMode = true
 	}
 
@@ -232,11 +235,11 @@ func mainCat(ctx *cli.Context) error {
 	}
 
 	// if Args contain `-`, we need to preserve its order specially.
-	args := []string(ctx.Args())
-	if ctx.Args().First() == "-" {
+	args := []string(cliCtx.Args())
+	if cliCtx.Args().First() == "-" {
 		for i, arg := range os.Args {
 			if arg == "cat" {
-				// Overwrite ctx.Args with os.Args.
+				// Overwrite cliCtx.Args with os.Args.
 				args = os.Args[i+1:]
 				break
 			}
@@ -245,7 +248,7 @@ func mainCat(ctx *cli.Context) error {
 
 	// Convert arguments to URLs: expand alias, fix format.
 	for _, url := range args {
-		fatalIf(catURL(url, encKeyDB).Trace(url), "Unable to read from `"+url+"`.")
+		fatalIf(catURL(ctx, url, encKeyDB).Trace(url), "Unable to read from `"+url+"`.")
 	}
 
 	return nil

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -119,7 +119,7 @@ func (f *fsClient) GetURL() ClientURL {
 }
 
 // Select replies a stream of query results.
-func (f *fsClient) Select(expression string, sse encrypt.ServerSide, opts SelectObjectOpts) (io.ReadCloser, *probe.Error) {
+func (f *fsClient) Select(ctx context.Context, expression string, sse encrypt.ServerSide, opts SelectObjectOpts) (io.ReadCloser, *probe.Error) {
 	return nil, probe.NewError(APINotImplemented{
 		API:     "Select",
 		APIType: "filesystem",
@@ -127,7 +127,7 @@ func (f *fsClient) Select(expression string, sse encrypt.ServerSide, opts Select
 }
 
 // Watches for all fs events on an input path.
-func (f *fsClient) Watch(options WatchOptions) (*WatchObject, *probe.Error) {
+func (f *fsClient) Watch(ctx context.Context, options WatchOptions) (*WatchObject, *probe.Error) {
 	eventChan := make(chan []EventInfo)
 	errorChan := make(chan *probe.Error)
 	doneChan := make(chan struct{})
@@ -253,7 +253,7 @@ func preserveAttributes(fd *os.File, attr map[string]string) *probe.Error {
 
 /// Object operations.
 
-func (f *fsClient) put(reader io.Reader, size int64, metadata map[string][]string, progress io.Reader) (int64, *probe.Error) {
+func (f *fsClient) put(ctx context.Context, reader io.Reader, size int64, metadata map[string][]string, progress io.Reader) (int64, *probe.Error) {
 	// ContentType is not handled on purpose.
 	// For filesystem this is a redundant information.
 
@@ -372,13 +372,13 @@ func (f *fsClient) Put(ctx context.Context, reader io.Reader, size int64, metada
 	if metadata[metaDataKey] != "" {
 		meta := make(map[string][]string)
 		meta[metaDataKey] = append(meta[metaDataKey], metadata[metaDataKey])
-		return f.put(reader, size, meta, progress)
+		return f.put(ctx, reader, size, meta, progress)
 	}
-	return f.put(reader, size, nil, progress)
+	return f.put(ctx, reader, size, nil, progress)
 }
 
 // ShareDownload - share download not implemented for filesystem.
-func (f *fsClient) ShareDownload(expires time.Duration) (string, *probe.Error) {
+func (f *fsClient) ShareDownload(ctx context.Context, expires time.Duration) (string, *probe.Error) {
 	return "", probe.NewError(APINotImplemented{
 		API:     "ShareDownload",
 		APIType: "filesystem",
@@ -394,7 +394,7 @@ func (f *fsClient) ShareUpload(startsWith bool, expires time.Duration, contentTy
 }
 
 // Copy - copy data from source to destination
-func (f *fsClient) Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
+func (f *fsClient) Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
 	rc, e := os.Open(source)
 	if e != nil {
 		err := f.toClientError(e, source)
@@ -403,14 +403,14 @@ func (f *fsClient) Copy(source string, size int64, progress io.Reader, srcSSE, t
 	defer rc.Close()
 
 	destination := f.PathURL.Path
-	if _, err := f.put(rc, size, map[string][]string{}, progress); err != nil {
+	if _, err := f.put(ctx, rc, size, map[string][]string{}, progress); err != nil {
 		return err.Trace(destination, source)
 	}
 	return nil
 }
 
 // Get returns reader and any additional metadata.
-func (f *fsClient) Get(sse encrypt.ServerSide) (io.ReadCloser, *probe.Error) {
+func (f *fsClient) Get(ctx context.Context, sse encrypt.ServerSide) (io.ReadCloser, *probe.Error) {
 	fileData, e := os.Open(f.PathURL.Path)
 	if e != nil {
 		err := f.toClientError(e, f.PathURL.Path)
@@ -464,7 +464,7 @@ func deleteFile(deletePath string) error {
 }
 
 // Remove - remove entry read from clientContent channel.
-func (f *fsClient) Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *ClientContent) <-chan *probe.Error {
+func (f *fsClient) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *ClientContent) <-chan *probe.Error {
 	errorCh := make(chan *probe.Error)
 
 	// Goroutine reads from contentCh and removes the entry in content.
@@ -503,7 +503,7 @@ func (f *fsClient) Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh
 }
 
 // List - list files and folders.
-func (f *fsClient) List(isRecursive, isIncomplete, isMetadata bool, showDir DirOpt) <-chan *ClientContent {
+func (f *fsClient) List(ctx context.Context, isRecursive, isIncomplete, isMetadata bool, showDir DirOpt) <-chan *ClientContent {
 	contentCh := make(chan *ClientContent)
 	filteredCh := make(chan *ClientContent)
 
@@ -511,7 +511,7 @@ func (f *fsClient) List(isRecursive, isIncomplete, isMetadata bool, showDir DirO
 		if showDir == DirNone {
 			go f.listRecursiveInRoutine(contentCh, isMetadata)
 		} else {
-			go f.listDirOpt(contentCh, isIncomplete, isMetadata, showDir)
+			go f.listDirOpt(ctx, contentCh, isIncomplete, isMetadata, showDir)
 		}
 	} else {
 		go f.listInRoutine(contentCh, isMetadata)
@@ -702,7 +702,7 @@ func (f *fsClient) listInRoutine(contentCh chan<- *ClientContent, isMetadata boo
 }
 
 // List files recursively using non-recursive mode.
-func (f *fsClient) listDirOpt(contentCh chan *ClientContent, isIncomplete bool, isMetadata bool, dirOpt DirOpt) {
+func (f *fsClient) listDirOpt(ctx context.Context, contentCh chan *ClientContent, isIncomplete bool, isMetadata bool, dirOpt DirOpt) {
 	defer close(contentCh)
 
 	// Trim trailing / or \.
@@ -877,7 +877,7 @@ func (f *fsClient) listRecursiveInRoutine(contentCh chan *ClientContent, isMetad
 }
 
 // MakeBucket - create a new bucket.
-func (f *fsClient) MakeBucket(region string, ignoreExisting, withLock bool) *probe.Error {
+func (f *fsClient) MakeBucket(ctx context.Context, region string, ignoreExisting, withLock bool) *probe.Error {
 	// TODO: ignoreExisting has no effect currently. In the future, we want
 	// to call os.Mkdir() when ignoredExisting is disabled and os.MkdirAll()
 	// otherwise.
@@ -890,7 +890,7 @@ func (f *fsClient) MakeBucket(region string, ignoreExisting, withLock bool) *pro
 }
 
 // Set object lock configuration of bucket.
-func (f *fsClient) SetObjectLockConfig(mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error {
+func (f *fsClient) SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error {
 	return probe.NewError(APINotImplemented{
 		API:     "SetObjectLockConfig",
 		APIType: "filesystem",
@@ -898,7 +898,7 @@ func (f *fsClient) SetObjectLockConfig(mode minio.RetentionMode, validity uint64
 }
 
 // Get object lock configuration of bucket.
-func (f *fsClient) GetObjectLockConfig() (mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit, err *probe.Error) {
+func (f *fsClient) GetObjectLockConfig(ctx context.Context) (mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit, err *probe.Error) {
 	return "", 0, "", probe.NewError(APINotImplemented{
 		API:     "GetObjectLockConfig",
 		APIType: "filesystem",
@@ -906,7 +906,7 @@ func (f *fsClient) GetObjectLockConfig() (mode minio.RetentionMode, validity uin
 }
 
 // GetAccessRules - unsupported API
-func (f *fsClient) GetAccessRules() (map[string]string, *probe.Error) {
+func (f *fsClient) GetAccessRules(ctx context.Context) (map[string]string, *probe.Error) {
 	return map[string]string{}, probe.NewError(APINotImplemented{
 		API:     "GetBucketPolicy",
 		APIType: "filesystem",
@@ -914,7 +914,7 @@ func (f *fsClient) GetAccessRules() (map[string]string, *probe.Error) {
 }
 
 // Set object retention for a given object.
-func (f *fsClient) PutObjectRetention(mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error {
+func (f *fsClient) PutObjectRetention(ctx context.Context, mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error {
 	return probe.NewError(APINotImplemented{
 		API:     "PutObjectRetention",
 		APIType: "filesystem",
@@ -922,7 +922,7 @@ func (f *fsClient) PutObjectRetention(mode minio.RetentionMode, retainUntilDate 
 }
 
 // Set object legal hold for a given object.
-func (f *fsClient) PutObjectLegalHold(lhold minio.LegalHoldStatus) *probe.Error {
+func (f *fsClient) PutObjectLegalHold(ctx context.Context, lhold minio.LegalHoldStatus) *probe.Error {
 	return probe.NewError(APINotImplemented{
 		API:     "PutObjectLegalHold",
 		APIType: "filesystem",
@@ -930,7 +930,7 @@ func (f *fsClient) PutObjectLegalHold(lhold minio.LegalHoldStatus) *probe.Error 
 }
 
 // GetAccess - get access policy permissions.
-func (f *fsClient) GetAccess() (access string, policyJSON string, err *probe.Error) {
+func (f *fsClient) GetAccess(ctx context.Context) (access string, policyJSON string, err *probe.Error) {
 	// For windows this feature is not implemented.
 	if runtime.GOOS == "windows" {
 		return "", "", probe.NewError(APINotImplemented{API: "GetAccess", APIType: "filesystem"})
@@ -955,7 +955,7 @@ func (f *fsClient) GetAccess() (access string, policyJSON string, err *probe.Err
 }
 
 // SetAccess - set access policy permissions.
-func (f *fsClient) SetAccess(access string, isJSON bool) *probe.Error {
+func (f *fsClient) SetAccess(ctx context.Context, access string, isJSON bool) *probe.Error {
 	// For windows this feature is not implemented.
 	// JSON policy for fs is not yet implemented.
 	if runtime.GOOS == "windows" || isJSON {
@@ -987,7 +987,7 @@ func (f *fsClient) SetAccess(access string, isJSON bool) *probe.Error {
 }
 
 // Stat - get metadata from path.
-func (f *fsClient) Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (content *ClientContent, err *probe.Error) {
+func (f *fsClient) Stat(ctx context.Context, isIncomplete, isPreserve bool, sse encrypt.ServerSide) (content *ClientContent, err *probe.Error) {
 	st, err := f.fsStat(isIncomplete)
 	if err != nil {
 		return nil, err.Trace(f.PathURL.String())
@@ -1059,11 +1059,11 @@ func (f *fsClient) fsStat(isIncomplete bool) (os.FileInfo, *probe.Error) {
 	return st, nil
 }
 
-func (f *fsClient) AddUserAgent(_, _ string) {
+func (f *fsClient) AddUserAgent(ctx context.Context, _, _ string) {
 }
 
 // Get Object Tags
-func (f *fsClient) GetTags() (*tags.Tags, *probe.Error) {
+func (f *fsClient) GetTags(ctx context.Context) (*tags.Tags, *probe.Error) {
 	return nil, probe.NewError(APINotImplemented{
 		API:     "GetObjectTagging",
 		APIType: "filesystem",
@@ -1071,7 +1071,7 @@ func (f *fsClient) GetTags() (*tags.Tags, *probe.Error) {
 }
 
 // Set Object tags
-func (f *fsClient) SetTags(tags string) *probe.Error {
+func (f *fsClient) SetTags(ctx context.Context, tags string) *probe.Error {
 	return probe.NewError(APINotImplemented{
 		API:     "SetObjectTagging",
 		APIType: "filesystem",
@@ -1079,7 +1079,7 @@ func (f *fsClient) SetTags(tags string) *probe.Error {
 }
 
 // Delete object tags
-func (f *fsClient) DeleteTags() *probe.Error {
+func (f *fsClient) DeleteTags(ctx context.Context) *probe.Error {
 	return probe.NewError(APINotImplemented{
 		API:     "DeleteObjectTagging",
 		APIType: "filesystem",
@@ -1087,7 +1087,7 @@ func (f *fsClient) DeleteTags() *probe.Error {
 }
 
 // Get lifecycle configuration for a given bucket, not implemented.
-func (f *fsClient) GetLifecycle() (ilm.LifecycleConfiguration, *probe.Error) {
+func (f *fsClient) GetLifecycle(ctx context.Context) (ilm.LifecycleConfiguration, *probe.Error) {
 	return ilm.LifecycleConfiguration{}, probe.NewError(APINotImplemented{
 		API:     "GetLifecycle",
 		APIType: "filesystem",
@@ -1095,7 +1095,7 @@ func (f *fsClient) GetLifecycle() (ilm.LifecycleConfiguration, *probe.Error) {
 }
 
 // Set lifecycle configuration for a given bucket, not implemented.
-func (f *fsClient) SetLifecycle(_ ilm.LifecycleConfiguration) *probe.Error {
+func (f *fsClient) SetLifecycle(ctx context.Context, _ ilm.LifecycleConfiguration) *probe.Error {
 	return probe.NewError(APINotImplemented{
 		API:     "SetLifecycle",
 		APIType: "filesystem",

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -511,7 +511,7 @@ func (f *fsClient) List(ctx context.Context, isRecursive, isIncomplete, isMetada
 		if showDir == DirNone {
 			go f.listRecursiveInRoutine(contentCh, isMetadata)
 		} else {
-			go f.listDirOpt(ctx, contentCh, isIncomplete, isMetadata, showDir)
+			go f.listDirOpt(contentCh, isIncomplete, isMetadata, showDir)
 		}
 	} else {
 		go f.listInRoutine(contentCh, isMetadata)
@@ -702,7 +702,7 @@ func (f *fsClient) listInRoutine(contentCh chan<- *ClientContent, isMetadata boo
 }
 
 // List files recursively using non-recursive mode.
-func (f *fsClient) listDirOpt(ctx context.Context, contentCh chan *ClientContent, isIncomplete bool, isMetadata bool, dirOpt DirOpt) {
+func (f *fsClient) listDirOpt(contentCh chan *ClientContent, isIncomplete bool, isMetadata bool, dirOpt DirOpt) {
 	defer close(contentCh)
 
 	// Trim trailing / or \.
@@ -1059,7 +1059,7 @@ func (f *fsClient) fsStat(isIncomplete bool) (os.FileInfo, *probe.Error) {
 	return st, nil
 }
 
-func (f *fsClient) AddUserAgent(ctx context.Context, _, _ string) {
+func (f *fsClient) AddUserAgent(_, _ string) {
 }
 
 // Get Object Tags

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -65,7 +65,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	// Verify previously create files and list them.
 	var contents []*ClientContent
-	for content := range fsClient.List(false, false, false, DirNone) {
+	for content := range fsClient.List(globalContext, false, false, false, DirNone) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -93,7 +93,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List non recursive to list only top level files.
-	for content := range fsClient.List(false, false, false, DirNone) {
+	for content := range fsClient.List(globalContext, false, false, false, DirNone) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -109,7 +109,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List recursively all files and verify.
-	for content := range fsClient.List(true, false, false, DirNone) {
+	for content := range fsClient.List(globalContext, true, false, false, DirNone) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -153,7 +153,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List recursively all files and verify.
-	for content := range fsClient.List(true, false, false, DirNone) {
+	for content := range fsClient.List(globalContext, true, false, false, DirNone) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -194,7 +194,7 @@ func (s *TestSuite) TestPutBucket(c *C) {
 	bucketPath := filepath.Join(root, "bucket")
 	fsClient, err := fsNew(bucketPath)
 	c.Assert(err, IsNil)
-	err = fsClient.MakeBucket("us-east-1", true, false)
+	err = fsClient.MakeBucket(context.Background(), "us-east-1", true, false)
 	c.Assert(err, IsNil)
 }
 
@@ -208,9 +208,9 @@ func (s *TestSuite) TestStatBucket(c *C) {
 
 	fsClient, err := fsNew(bucketPath)
 	c.Assert(err, IsNil)
-	err = fsClient.MakeBucket("us-east-1", true, false)
+	err = fsClient.MakeBucket(context.Background(), "us-east-1", true, false)
 	c.Assert(err, IsNil)
-	_, err = fsClient.Stat(false, false, nil)
+	_, err = fsClient.Stat(context.Background(), false, false, nil)
 	c.Assert(err, IsNil)
 }
 
@@ -223,15 +223,15 @@ func (s *TestSuite) TestBucketACLFails(c *C) {
 	bucketPath := filepath.Join(root, "bucket")
 	fsClient, err := fsNew(bucketPath)
 	c.Assert(err, IsNil)
-	err = fsClient.MakeBucket("us-east-1", true, false)
+	err = fsClient.MakeBucket(context.Background(), "us-east-1", true, false)
 	c.Assert(err, IsNil)
 
 	// On windows setting permissions is not supported.
 	if runtime.GOOS != "windows" {
-		err = fsClient.SetAccess("readonly", false)
+		err = fsClient.SetAccess(context.Background(), "readonly", false)
 		c.Assert(err, IsNil)
 
-		_, _, err = fsClient.GetAccess()
+		_, _, err = fsClient.GetAccess(context.Background())
 		c.Assert(err, IsNil)
 	}
 }
@@ -275,7 +275,7 @@ func (s *TestSuite) TestGet(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, err = fsClient.Get(nil)
+	reader, err = fsClient.Get(context.Background(), nil)
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	_, e = io.Copy(&results, reader)
@@ -303,7 +303,7 @@ func (s *TestSuite) TestGetRange(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	reader, err = fsClient.Get(nil)
+	reader, err = fsClient.Get(context.Background(), nil)
 	c.Assert(err, IsNil)
 	var results bytes.Buffer
 	buf := make([]byte, 5)
@@ -334,7 +334,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	content, err := fsClient.Stat(false, false, nil)
+	content, err := fsClient.Stat(context.Background(), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(content.Size, Equals, int64(dataLen))
 }
@@ -359,6 +359,6 @@ func (s *TestSuite) TestCopy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	err = fsClientTarget.Copy(sourcePath, int64(len(data)), nil, nil, nil, nil, false)
+	err = fsClientTarget.Copy(context.Background(), sourcePath, int64(len(data)), nil, nil, nil, nil, false)
 	c.Assert(err, IsNil)
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -87,6 +87,9 @@ var timeSentinel = time.Unix(0, 0).UTC()
 
 // newFactory encloses New function with client cache.
 func newFactory() func(config *Config) (Client, *probe.Error) {
+	ctx, cancelNewFactory := context.WithCancel(globalContext)
+	defer cancelNewFactory()
+
 	clientCache := make(map[uint32]*minio.Client)
 	var mutex sync.Mutex
 
@@ -209,7 +212,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			}
 
 			// Set app info.
-			api.SetAppInfo(config.AppName, config.AppVersion)
+			api.SetAppInfo(ctx, config.AppName, config.AppVersion)
 
 			// Cache the new MinIO Client with hash of config as key.
 			clientCache[confSum] = api
@@ -232,7 +235,7 @@ func (c *S3Client) GetURL() ClientURL {
 }
 
 // AddNotificationConfig - Add bucket notification
-func (c *S3Client) AddNotificationConfig(arn string, events []string, prefix, suffix string, ignoreExisting bool) *probe.Error {
+func (c *S3Client) AddNotificationConfig(ctx context.Context, arn string, events []string, prefix, suffix string, ignoreExisting bool) *probe.Error {
 	bucket, _ := c.url2BucketAndObject()
 	// Validate total fields in ARN.
 	fields := strings.Split(arn, ":")
@@ -241,7 +244,7 @@ func (c *S3Client) AddNotificationConfig(arn string, events []string, prefix, su
 	}
 
 	// Get any enabled notification.
-	mb, e := c.api.GetBucketNotification(bucket)
+	mb, e := c.api.GetBucketNotification(ctx, bucket)
 	if e != nil {
 		return probe.NewError(e)
 	}
@@ -297,17 +300,17 @@ func (c *S3Client) AddNotificationConfig(arn string, events []string, prefix, su
 }
 
 // RemoveNotificationConfig - Remove bucket notification
-func (c *S3Client) RemoveNotificationConfig(arn string, event string, prefix string, suffix string) *probe.Error {
+func (c *S3Client) RemoveNotificationConfig(ctx context.Context, arn string, event string, prefix string, suffix string) *probe.Error {
 	bucket, _ := c.url2BucketAndObject()
 	// Remove all notification configs if arn is empty
 	if arn == "" {
-		if err := c.api.RemoveAllBucketNotification(bucket); err != nil {
+		if err := c.api.RemoveAllBucketNotification(ctx, bucket); err != nil {
 			return probe.NewError(err)
 		}
 		return nil
 	}
 
-	mb, e := c.api.GetBucketNotification(bucket)
+	mb, e := c.api.GetBucketNotification(ctx, bucket)
 	if e != nil {
 		return probe.NewError(e)
 	}
@@ -383,10 +386,10 @@ type NotificationConfig struct {
 }
 
 // ListNotificationConfigs - List notification configs
-func (c *S3Client) ListNotificationConfigs(arn string) ([]NotificationConfig, *probe.Error) {
+func (c *S3Client) ListNotificationConfigs(ctx context.Context, arn string) ([]NotificationConfig, *probe.Error) {
 	var configs []NotificationConfig
 	bucket, _ := c.url2BucketAndObject()
-	mb, e := c.api.GetBucketNotification(bucket)
+	mb, e := c.api.GetBucketNotification(ctx, bucket)
 	if e != nil {
 		return nil, probe.NewError(e)
 	}
@@ -607,7 +610,7 @@ func selectCompressionType(selOpts SelectObjectOpts, object string) minio.Select
 }
 
 // Select - select object content wrapper.
-func (c *S3Client) Select(expression string, sse encrypt.ServerSide, selOpts SelectObjectOpts) (io.ReadCloser, *probe.Error) {
+func (c *S3Client) Select(ctx context.Context, expression string, sse encrypt.ServerSide, selOpts SelectObjectOpts) (io.ReadCloser, *probe.Error) {
 	opts := minio.SelectObjectOptions{
 		Expression:     expression,
 		ExpressionType: minio.QueryExpressionTypeSQL,
@@ -619,7 +622,7 @@ func (c *S3Client) Select(expression string, sse encrypt.ServerSide, selOpts Sel
 
 	opts.InputSerialization = selectObjectInputOpts(selOpts, object)
 	opts.OutputSerialization = selectObjectOutputOpts(selOpts, opts.InputSerialization)
-	reader, e := c.api.SelectObjectContent(context.Background(), bucket, object, opts)
+	reader, e := c.api.SelectObjectContent(ctx, bucket, object, opts)
 	if e != nil {
 		return nil, probe.NewError(e)
 	}
@@ -728,7 +731,7 @@ func (c *S3Client) notificationToEventsInfo(ninfo minio.NotificationInfo) []Even
 }
 
 // Watch - Start watching on all bucket events for a given account ID.
-func (c *S3Client) Watch(options WatchOptions) (*WatchObject, *probe.Error) {
+func (c *S3Client) Watch(ctx context.Context, options WatchOptions) (*WatchObject, *probe.Error) {
 	// Extract bucket and object.
 	bucket, object := c.url2BucketAndObject()
 
@@ -756,7 +759,7 @@ func (c *S3Client) Watch(options WatchOptions) (*WatchObject, *probe.Error) {
 	// The list of buckets to watch
 	var buckets []string
 	if bucket == "" {
-		bkts, err := c.api.ListBuckets()
+		bkts, err := c.api.ListBuckets(ctx)
 		if err != nil {
 			return nil, probe.NewError(err)
 		}
@@ -780,7 +783,7 @@ func (c *S3Client) Watch(options WatchOptions) (*WatchObject, *probe.Error) {
 		go func() {
 			defer wg.Done()
 			// Start listening on all bucket events.
-			eventsCh := c.api.ListenBucketNotification(bucket, options.Prefix, options.Suffix, events, wo.DoneChan)
+			eventsCh := c.api.ListenBucketNotification(ctx, bucket, options.Prefix, options.Suffix, events, wo.DoneChan)
 			for notificationInfo := range eventsCh {
 				if notificationInfo.Err != nil {
 					var perr *probe.Error
@@ -811,11 +814,11 @@ func (c *S3Client) Watch(options WatchOptions) (*WatchObject, *probe.Error) {
 }
 
 // Get - get object with metadata.
-func (c *S3Client) Get(sse encrypt.ServerSide) (io.ReadCloser, *probe.Error) {
+func (c *S3Client) Get(ctx context.Context, sse encrypt.ServerSide) (io.ReadCloser, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	opts := minio.GetObjectOptions{}
 	opts.ServerSideEncryption = sse
-	reader, e := c.api.GetObject(bucket, object, opts)
+	reader, e := c.api.GetObject(ctx, bucket, object, opts)
 	if e != nil {
 		errResponse := minio.ToErrorResponse(e)
 		if errResponse.Code == "NoSuchBucket" {
@@ -839,7 +842,7 @@ func (c *S3Client) Get(sse encrypt.ServerSide) (io.ReadCloser, *probe.Error) {
 // Copy - copy object, uses server side copy API. Also uses an abstracted API
 // such that large file sizes will be copied in multipart manner on server
 // side.
-func (c *S3Client) Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
+func (c *S3Client) Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
 	dstBucket, dstObject := c.url2BucketAndObject()
 	if dstBucket == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -881,9 +884,9 @@ func (c *S3Client) Copy(source string, size int64, progress io.Reader, srcSSE, t
 	}
 
 	if disableMultipart {
-		e = c.api.CopyObjectWithProgress(dst, src, progress)
+		e = c.api.CopyObjectWithProgress(ctx, dst, src, progress)
 	} else {
-		e = c.api.ComposeObjectWithProgress(dst, []minio.SourceInfo{src}, progress)
+		e = c.api.ComposeObjectWithProgress(ctx, dst, []minio.SourceInfo{src}, progress)
 	}
 
 	if e != nil {
@@ -1061,12 +1064,12 @@ func (c *S3Client) removeIncompleteObjects(bucket string, objectsCh <-chan strin
 }
 
 // AddUserAgent - add custom user agent.
-func (c *S3Client) AddUserAgent(app string, version string) {
-	c.api.SetAppInfo(app, version)
+func (c *S3Client) AddUserAgent(ctx context.Context, app string, version string) {
+	c.api.SetAppInfo(ctx, app, version)
 }
 
 // Remove - remove object or bucket(s).
-func (c *S3Client) Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *ClientContent) <-chan *probe.Error {
+func (c *S3Client) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *ClientContent) <-chan *probe.Error {
 	errorCh := make(chan *probe.Error)
 
 	prevBucket := ""
@@ -1115,7 +1118,7 @@ func (c *S3Client) Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh
 				}
 				// Remove bucket if it qualifies.
 				if isRemoveBucket && !isIncomplete {
-					if err := c.api.RemoveBucket(prevBucket); err != nil {
+					if err := c.api.RemoveBucket(ctx, prevBucket); err != nil {
 						errorCh <- probe.NewError(err)
 					}
 				}
@@ -1162,7 +1165,7 @@ func (c *S3Client) Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh
 		}
 		// Remove last bucket if it qualifies.
 		if isRemoveBucket && prevBucket != "" && !isIncomplete {
-			if err := c.api.RemoveBucket(prevBucket); err != nil {
+			if err := c.api.RemoveBucket(ctx, prevBucket); err != nil {
 				errorCh <- probe.NewError(err)
 			}
 		}
@@ -1171,7 +1174,7 @@ func (c *S3Client) Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh
 }
 
 // MakeBucket - make a new bucket.
-func (c *S3Client) MakeBucket(region string, ignoreExisting, withLock bool) *probe.Error {
+func (c *S3Client) MakeBucket(ctx context.Context, region string, ignoreExisting, withLock bool) *probe.Error {
 	bucket, object := c.url2BucketAndObject()
 	if bucket == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -1185,7 +1188,7 @@ func (c *S3Client) MakeBucket(region string, ignoreExisting, withLock bool) *pro
 		}
 		var retried bool
 		for {
-			_, e := c.api.PutObject(bucket, object,
+			_, e := c.api.PutObject(ctx, bucket, object,
 				bytes.NewReader([]byte("")), 0, minio.PutObjectOptions{})
 			if e == nil {
 				return nil
@@ -1196,9 +1199,9 @@ func (c *S3Client) MakeBucket(region string, ignoreExisting, withLock bool) *pro
 			switch minio.ToErrorResponse(e).Code {
 			case "NoSuchBucket":
 				if withLock {
-					e = c.api.MakeBucketWithObjectLock(bucket, region)
+					e = c.api.MakeBucketWithObjectLock(ctx, bucket, region)
 				} else {
-					e = c.api.MakeBucket(bucket, region)
+					e = c.api.MakeBucket(ctx, bucket, region)
 				}
 				if e != nil {
 					return probe.NewError(e)
@@ -1212,9 +1215,9 @@ func (c *S3Client) MakeBucket(region string, ignoreExisting, withLock bool) *pro
 
 	var e error
 	if withLock {
-		e = c.api.MakeBucketWithObjectLock(bucket, region)
+		e = c.api.MakeBucketWithObjectLock(ctx, bucket, region)
 	} else {
-		e = c.api.MakeBucket(bucket, region)
+		e = c.api.MakeBucket(ctx, bucket, region)
 	}
 	if e != nil {
 		// Ignore bucket already existing error when ignoreExisting flag is enabled
@@ -1232,13 +1235,13 @@ func (c *S3Client) MakeBucket(region string, ignoreExisting, withLock bool) *pro
 }
 
 // GetAccessRules - get configured policies from the server
-func (c *S3Client) GetAccessRules() (map[string]string, *probe.Error) {
+func (c *S3Client) GetAccessRules(ctx context.Context) (map[string]string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	if bucket == "" {
 		return map[string]string{}, probe.NewError(BucketNameEmpty{})
 	}
 	policies := map[string]string{}
-	policyStr, e := c.api.GetBucketPolicy(bucket)
+	policyStr, e := c.api.GetBucketPolicy(ctx, bucket)
 	if e != nil {
 		return nil, probe.NewError(e)
 	}
@@ -1258,12 +1261,12 @@ func (c *S3Client) GetAccessRules() (map[string]string, *probe.Error) {
 }
 
 // GetAccess get access policy permissions.
-func (c *S3Client) GetAccess() (string, string, *probe.Error) {
+func (c *S3Client) GetAccess(ctx context.Context) (string, string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	if bucket == "" {
 		return "", "", probe.NewError(BucketNameEmpty{})
 	}
-	policyStr, e := c.api.GetBucketPolicy(bucket)
+	policyStr, e := c.api.GetBucketPolicy(ctx, bucket)
 	if e != nil {
 		return "", "", probe.NewError(e)
 	}
@@ -1282,18 +1285,18 @@ func (c *S3Client) GetAccess() (string, string, *probe.Error) {
 }
 
 // SetAccess set access policy permissions.
-func (c *S3Client) SetAccess(bucketPolicy string, isJSON bool) *probe.Error {
+func (c *S3Client) SetAccess(ctx context.Context, bucketPolicy string, isJSON bool) *probe.Error {
 	bucket, object := c.url2BucketAndObject()
 	if bucket == "" {
 		return probe.NewError(BucketNameEmpty{})
 	}
 	if isJSON {
-		if e := c.api.SetBucketPolicy(bucket, bucketPolicy); e != nil {
+		if e := c.api.SetBucketPolicy(ctx, bucket, bucketPolicy); e != nil {
 			return probe.NewError(e)
 		}
 		return nil
 	}
-	policyStr, e := c.api.GetBucketPolicy(bucket)
+	policyStr, e := c.api.GetBucketPolicy(ctx, bucket)
 	if e != nil {
 		return probe.NewError(e)
 	}
@@ -1305,7 +1308,7 @@ func (c *S3Client) SetAccess(bucketPolicy string, isJSON bool) *probe.Error {
 	}
 	p.Statements = policy.SetPolicy(p.Statements, policy.BucketPolicy(bucketPolicy), bucket, object)
 	if len(p.Statements) == 0 {
-		if e = c.api.SetBucketPolicy(bucket, ""); e != nil {
+		if e = c.api.SetBucketPolicy(ctx, bucket, ""); e != nil {
 			return probe.NewError(e)
 		}
 		return nil
@@ -1314,32 +1317,32 @@ func (c *S3Client) SetAccess(bucketPolicy string, isJSON bool) *probe.Error {
 	if e != nil {
 		return probe.NewError(e)
 	}
-	if e = c.api.SetBucketPolicy(bucket, string(policyB)); e != nil {
+	if e = c.api.SetBucketPolicy(ctx, bucket, string(policyB)); e != nil {
 		return probe.NewError(e)
 	}
 	return nil
 }
 
 // listObjectWrapper - select ObjectList version depending on the target hostname
-func (c *S3Client) listObjectWrapper(bucket, object string, isRecursive bool, doneCh chan struct{}, metadata bool) <-chan minio.ObjectInfo {
+func (c *S3Client) listObjectWrapper(ctx context.Context, bucket, object string, isRecursive bool, doneCh chan struct{}, metadata bool) <-chan minio.ObjectInfo {
 	if isGoogle(c.targetURL.Host) {
 		// Google Cloud S3 layer doesn't implement ListObjectsV2 implementation
 		// https://github.com/minio/mc/issues/3073
-		return c.api.ListObjects(bucket, object, isRecursive, doneCh)
+		return c.api.ListObjects(ctx, bucket, object, isRecursive, doneCh)
 	}
 	if metadata {
-		return c.api.ListObjectsV2WithMetadata(bucket, object, isRecursive, doneCh)
+		return c.api.ListObjectsV2WithMetadata(ctx, bucket, object, isRecursive, doneCh)
 	}
-	return c.api.ListObjectsV2(bucket, object, isRecursive, doneCh)
+	return c.api.ListObjectsV2(ctx, bucket, object, isRecursive, doneCh)
 }
 
-func (c *S3Client) statIncompleteUpload(bucket, object string) (*ClientContent, *probe.Error) {
+func (c *S3Client) statIncompleteUpload(ctx context.Context, bucket, object string) (*ClientContent, *probe.Error) {
 	nonRecursive := false
 	objectMetadata := &ClientContent{}
 	// Prefix to pass to minio-go listing in order to fetch a given object/directory
 	prefix := strings.TrimRight(object, string(c.targetURL.Separator))
 
-	for objectMultipartInfo := range c.api.ListIncompleteUploads(bucket, prefix, nonRecursive, nil) {
+	for objectMultipartInfo := range c.api.ListIncompleteUploads(ctx, bucket, prefix, nonRecursive, nil) {
 		if objectMultipartInfo.Err != nil {
 			return nil, probe.NewError(objectMultipartInfo.Err)
 		}
@@ -1365,7 +1368,7 @@ func (c *S3Client) statIncompleteUpload(bucket, object string) (*ClientContent, 
 
 // Stat - send a 'HEAD' on a bucket or object to fetch its metadata. It also returns
 // a DIR type content if a prefix does exist in the server.
-func (c *S3Client) Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (*ClientContent, *probe.Error) {
+func (c *S3Client) Stat(ctx context.Context, isIncomplete, isPreserve bool, sse encrypt.ServerSide) (*ClientContent, *probe.Error) {
 	c.Lock()
 	defer c.Unlock()
 	bucket, object := c.url2BucketAndObject()
@@ -1376,7 +1379,7 @@ func (c *S3Client) Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (
 	}
 
 	if object == "" {
-		content, err := c.bucketStat(bucket)
+		content, err := c.bucketStat(ctx, bucket)
 		if err != nil {
 			return nil, err.Trace(bucket)
 		}
@@ -1385,7 +1388,7 @@ func (c *S3Client) Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (
 
 	// If the request is for incomplete upload stat, handle it here.
 	if isIncomplete {
-		return c.statIncompleteUpload(bucket, object)
+		return c.statIncompleteUpload(ctx, bucket, object)
 	}
 
 	// The following code tries to calculate if a given prefix/object does really exist
@@ -1418,7 +1421,7 @@ func (c *S3Client) Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (
 	// Prefix to pass to minio-go listing in order to fetch if a prefix exists
 	prefix := strings.TrimRight(object, string(c.targetURL.Separator))
 
-	for objectStat := range c.listObjectWrapper(bucket, prefix, nonRecursive, nil, false) {
+	for objectStat := range c.listObjectWrapper(ctx, bucket, prefix, nonRecursive, nil, false) {
 		if objectStat.Err != nil {
 			return nil, probe.NewError(objectStat.Err)
 		}
@@ -1548,7 +1551,7 @@ func (c *S3Client) splitPath(path string) (bucketName, objectName string) {
 /// Bucket API operations.
 
 // List - list at delimited path, if not recursive.
-func (c *S3Client) List(isRecursive, isIncomplete, isMetadata bool, showDir DirOpt) <-chan *ClientContent {
+func (c *S3Client) List(ctx context.Context, isRecursive, isIncomplete, isMetadata bool, showDir DirOpt) <-chan *ClientContent {
 	c.Lock()
 	defer c.Unlock()
 
@@ -1556,35 +1559,35 @@ func (c *S3Client) List(isRecursive, isIncomplete, isMetadata bool, showDir DirO
 	if isIncomplete {
 		if isRecursive {
 			if showDir == DirNone {
-				go c.listIncompleteRecursiveInRoutine(contentCh)
+				go c.listIncompleteRecursiveInRoutine(ctx, contentCh)
 			} else {
-				go c.listIncompleteRecursiveInRoutineDirOpt(contentCh, showDir)
+				go c.listIncompleteRecursiveInRoutineDirOpt(ctx, contentCh, showDir)
 			}
 		} else {
-			go c.listIncompleteInRoutine(contentCh)
+			go c.listIncompleteInRoutine(ctx, contentCh)
 		}
 	} else {
 		if isRecursive {
 			if showDir == DirNone {
-				go c.listRecursiveInRoutine(contentCh, isMetadata)
+				go c.listRecursiveInRoutine(ctx, contentCh, isMetadata)
 			} else {
-				go c.listRecursiveInRoutineDirOpt(contentCh, showDir, isMetadata)
+				go c.listRecursiveInRoutineDirOpt(ctx, contentCh, showDir, isMetadata)
 			}
 		} else {
-			go c.listInRoutine(contentCh, isMetadata)
+			go c.listInRoutine(ctx, contentCh, isMetadata)
 		}
 	}
 
 	return contentCh
 }
 
-func (c *S3Client) listIncompleteInRoutine(contentCh chan *ClientContent) {
+func (c *S3Client) listIncompleteInRoutine(ctx context.Context, contentCh chan *ClientContent) {
 	defer close(contentCh)
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
 	switch {
 	case b == "" && o == "":
-		buckets, err := c.api.ListBuckets()
+		buckets, err := c.api.ListBuckets(ctx)
 		if err != nil {
 			contentCh <- &ClientContent{
 				Err: probe.NewError(err),
@@ -1593,7 +1596,7 @@ func (c *S3Client) listIncompleteInRoutine(contentCh chan *ClientContent) {
 		}
 		isRecursive := false
 		for _, bucket := range buckets {
-			for object := range c.api.ListIncompleteUploads(bucket.Name, o, isRecursive, nil) {
+			for object := range c.api.ListIncompleteUploads(ctx, bucket.Name, o, isRecursive, nil) {
 				if object.Err != nil {
 					contentCh <- &ClientContent{
 						Err: probe.NewError(object.Err),
@@ -1621,7 +1624,7 @@ func (c *S3Client) listIncompleteInRoutine(contentCh chan *ClientContent) {
 		}
 	default:
 		isRecursive := false
-		for object := range c.api.ListIncompleteUploads(b, o, isRecursive, nil) {
+		for object := range c.api.ListIncompleteUploads(ctx, b, o, isRecursive, nil) {
 			if object.Err != nil {
 				contentCh <- &ClientContent{
 					Err: probe.NewError(object.Err),
@@ -1649,13 +1652,13 @@ func (c *S3Client) listIncompleteInRoutine(contentCh chan *ClientContent) {
 	}
 }
 
-func (c *S3Client) listIncompleteRecursiveInRoutine(contentCh chan *ClientContent) {
+func (c *S3Client) listIncompleteRecursiveInRoutine(ctx context.Context, contentCh chan *ClientContent) {
 	defer close(contentCh)
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
 	switch {
 	case b == "" && o == "":
-		buckets, err := c.api.ListBuckets()
+		buckets, err := c.api.ListBuckets(ctx)
 		if err != nil {
 			contentCh <- &ClientContent{
 				Err: probe.NewError(err),
@@ -1664,7 +1667,7 @@ func (c *S3Client) listIncompleteRecursiveInRoutine(contentCh chan *ClientConten
 		}
 		isRecursive := true
 		for _, bucket := range buckets {
-			for object := range c.api.ListIncompleteUploads(bucket.Name, o, isRecursive, nil) {
+			for object := range c.api.ListIncompleteUploads(ctx, bucket.Name, o, isRecursive, nil) {
 				if object.Err != nil {
 					contentCh <- &ClientContent{
 						Err: probe.NewError(object.Err),
@@ -1683,7 +1686,7 @@ func (c *S3Client) listIncompleteRecursiveInRoutine(contentCh chan *ClientConten
 		}
 	default:
 		isRecursive := true
-		for object := range c.api.ListIncompleteUploads(b, o, isRecursive, nil) {
+		for object := range c.api.ListIncompleteUploads(ctx, b, o, isRecursive, nil) {
 			if object.Err != nil {
 				contentCh <- &ClientContent{
 					Err: probe.NewError(object.Err),
@@ -1724,7 +1727,7 @@ func (c *S3Client) objectMultipartInfo2ClientContent(bucket string, entry minio.
 }
 
 // Recursively lists incomplete uploads.
-func (c *S3Client) listIncompleteRecursiveInRoutineDirOpt(contentCh chan *ClientContent, dirOpt DirOpt) {
+func (c *S3Client) listIncompleteRecursiveInRoutineDirOpt(ctx context.Context, contentCh chan *ClientContent, dirOpt DirOpt) {
 	defer close(contentCh)
 
 	// Closure function reads list of incomplete uploads and sends to contentCh. If a directory is found, it lists
@@ -1732,7 +1735,7 @@ func (c *S3Client) listIncompleteRecursiveInRoutineDirOpt(contentCh chan *Client
 	var listDir func(bucket, object string) bool
 	listDir = func(bucket, object string) (isStop bool) {
 		isRecursive := false
-		for entry := range c.api.ListIncompleteUploads(bucket, object, isRecursive, nil) {
+		for entry := range c.api.ListIncompleteUploads(ctx, bucket, object, isRecursive, nil) {
 			if entry.Err != nil {
 				url := c.targetURL.Clone()
 				url.Path = c.joinPath(bucket, object)
@@ -1775,14 +1778,14 @@ func (c *S3Client) listIncompleteRecursiveInRoutineDirOpt(contentCh chan *Client
 	if bucket == "" && object == "" {
 		var e error
 		allBuckets = true
-		buckets, e = c.api.ListBuckets()
+		buckets, e = c.api.ListBuckets(ctx)
 		if e != nil {
 			contentCh <- &ClientContent{Err: probe.NewError(e)}
 			return
 		}
 	} else if object == "" {
 		// Get bucket stat if object is empty.
-		content, err := c.bucketStat(bucket)
+		content, err := c.bucketStat(ctx, bucket)
 		if err != nil {
 			contentCh <- &ClientContent{Err: err.Trace(bucket)}
 			return
@@ -1791,7 +1794,7 @@ func (c *S3Client) listIncompleteRecursiveInRoutineDirOpt(contentCh chan *Client
 	} else if strings.HasSuffix(object, string(c.targetURL.Separator)) {
 		// Get stat of given object is a directory.
 		isIncomplete := true
-		content, perr := c.Stat(isIncomplete, false, nil)
+		content, perr := c.Stat(ctx, isIncomplete, false, nil)
 		cContent = content
 		if perr != nil {
 			contentCh <- &ClientContent{Err: perr.Trace(bucket)}
@@ -1872,8 +1875,8 @@ func (c *S3Client) objectInfo2ClientContent(bucket string, entry minio.ObjectInf
 }
 
 // Returns bucket stat info of current bucket.
-func (c *S3Client) bucketStat(bucket string) (*ClientContent, *probe.Error) {
-	exists, e := c.api.BucketExists(bucket)
+func (c *S3Client) bucketStat(ctx context.Context, bucket string) (*ClientContent, *probe.Error) {
+	exists, e := c.api.BucketExists(ctx, bucket)
 	if e != nil {
 		return nil, probe.NewError(e)
 	}
@@ -1884,14 +1887,14 @@ func (c *S3Client) bucketStat(bucket string) (*ClientContent, *probe.Error) {
 }
 
 // Recursively lists objects.
-func (c *S3Client) listRecursiveInRoutineDirOpt(contentCh chan *ClientContent, dirOpt DirOpt, metadata bool) {
+func (c *S3Client) listRecursiveInRoutineDirOpt(ctx context.Context, contentCh chan *ClientContent, dirOpt DirOpt, metadata bool) {
 	defer close(contentCh)
 	// Closure function reads list objects and sends to contentCh. If a directory is found, it lists
 	// objects of the directory content recursively.
 	var listDir func(bucket, object string) bool
 	listDir = func(bucket, object string) (isStop bool) {
 		isRecursive := false
-		for entry := range c.listObjectWrapper(bucket, object, isRecursive, nil, metadata) {
+		for entry := range c.listObjectWrapper(ctx, bucket, object, isRecursive, nil, metadata) {
 			if entry.Err != nil {
 				url := c.targetURL.Clone()
 				url.Path = c.joinPath(bucket, object)
@@ -1933,14 +1936,14 @@ func (c *S3Client) listRecursiveInRoutineDirOpt(contentCh chan *ClientContent, d
 	if bucket == "" && object == "" {
 		var e error
 		allBuckets = true
-		buckets, e = c.api.ListBuckets()
+		buckets, e = c.api.ListBuckets(ctx)
 		if e != nil {
 			contentCh <- &ClientContent{Err: probe.NewError(e)}
 			return
 		}
 	} else if object == "" {
 		// Get bucket stat if object is empty.
-		content, err := c.bucketStat(bucket)
+		content, err := c.bucketStat(ctx, bucket)
 		if err != nil {
 			contentCh <- &ClientContent{Err: err.Trace(bucket)}
 			return
@@ -1949,7 +1952,7 @@ func (c *S3Client) listRecursiveInRoutineDirOpt(contentCh chan *ClientContent, d
 	} else {
 		// Get stat of given object is a directory.
 		isIncomplete := false
-		content, perr := c.Stat(isIncomplete, false, nil)
+		content, perr := c.Stat(ctx, isIncomplete, false, nil)
 		cContent = content
 		if perr != nil {
 			contentCh <- &ClientContent{Err: perr.Trace(bucket)}
@@ -1974,13 +1977,13 @@ func (c *S3Client) listRecursiveInRoutineDirOpt(contentCh chan *ClientContent, d
 	}
 }
 
-func (c *S3Client) listInRoutine(contentCh chan *ClientContent, metadata bool) {
+func (c *S3Client) listInRoutine(ctx context.Context, contentCh chan *ClientContent, metadata bool) {
 	defer close(contentCh)
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
 	switch {
 	case b == "" && o == "":
-		buckets, e := c.api.ListBuckets()
+		buckets, e := c.api.ListBuckets(ctx)
 		if e != nil {
 			contentCh <- &ClientContent{
 				Err: probe.NewError(e),
@@ -1991,7 +1994,7 @@ func (c *S3Client) listInRoutine(contentCh chan *ClientContent, metadata bool) {
 			contentCh <- c.bucketInfo2ClientContent(bucket)
 		}
 	case b != "" && !strings.HasSuffix(c.targetURL.Path, string(c.targetURL.Separator)) && o == "":
-		content, err := c.bucketStat(b)
+		content, err := c.bucketStat(ctx, b)
 		if err != nil {
 			contentCh <- &ClientContent{Err: err.Trace(b)}
 			return
@@ -1999,7 +2002,7 @@ func (c *S3Client) listInRoutine(contentCh chan *ClientContent, metadata bool) {
 		contentCh <- content
 	default:
 		isRecursive := false
-		for object := range c.listObjectWrapper(b, o, isRecursive, nil, metadata) {
+		for object := range c.listObjectWrapper(ctx, b, o, isRecursive, nil, metadata) {
 			if object.Err != nil {
 				contentCh <- &ClientContent{
 					Err: probe.NewError(object.Err),
@@ -2030,13 +2033,13 @@ const (
 	s3StorageClassGlacier = "GLACIER"
 )
 
-func (c *S3Client) listRecursiveInRoutine(contentCh chan *ClientContent, metadata bool) {
+func (c *S3Client) listRecursiveInRoutine(ctx context.Context, contentCh chan *ClientContent, metadata bool) {
 	defer close(contentCh)
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
 	switch {
 	case b == "" && o == "":
-		buckets, err := c.api.ListBuckets()
+		buckets, err := c.api.ListBuckets(ctx)
 		if err != nil {
 			contentCh <- &ClientContent{
 				Err: probe.NewError(err),
@@ -2045,7 +2048,7 @@ func (c *S3Client) listRecursiveInRoutine(contentCh chan *ClientContent, metadat
 		}
 		for _, bucket := range buckets {
 			isRecursive := true
-			for object := range c.listObjectWrapper(bucket.Name, o, isRecursive, nil, metadata) {
+			for object := range c.listObjectWrapper(ctx, bucket.Name, o, isRecursive, nil, metadata) {
 				if object.Err != nil {
 					contentCh <- &ClientContent{
 						Err: probe.NewError(object.Err),
@@ -2057,7 +2060,7 @@ func (c *S3Client) listRecursiveInRoutine(contentCh chan *ClientContent, metadat
 		}
 	default:
 		isRecursive := true
-		for object := range c.listObjectWrapper(b, o, isRecursive, nil, metadata) {
+		for object := range c.listObjectWrapper(ctx, b, o, isRecursive, nil, metadata) {
 			if object.Err != nil {
 				contentCh <- &ClientContent{
 					Err: probe.NewError(object.Err),
@@ -2070,11 +2073,11 @@ func (c *S3Client) listRecursiveInRoutine(contentCh chan *ClientContent, metadat
 }
 
 // ShareDownload - get a usable presigned object url to share.
-func (c *S3Client) ShareDownload(expires time.Duration) (string, *probe.Error) {
+func (c *S3Client) ShareDownload(ctx context.Context, expires time.Duration) (string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	// No additional request parameters are set for the time being.
 	reqParams := make(url.Values)
-	presignedURL, e := c.api.PresignedGetObject(bucket, object, expires, reqParams)
+	presignedURL, e := c.api.PresignedGetObject(ctx, bucket, object, expires, reqParams)
 	if e != nil {
 		return "", probe.NewError(e)
 	}
@@ -2112,20 +2115,20 @@ func (c *S3Client) ShareUpload(isRecursive bool, expires time.Duration, contentT
 }
 
 // SetObjectLockConfig - Set object lock configurataion of bucket.
-func (c *S3Client) SetObjectLockConfig(mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error {
+func (c *S3Client) SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error {
 	bucket, _ := c.url2BucketAndObject()
 
 	// FIXME: This is too ugly, fix minio-go
 	vuint := (uint)(validity)
 	if mode != "" && vuint > 0 && unit != "" {
-		e := c.api.SetBucketObjectLockConfig(bucket, &mode, &vuint, &unit)
+		e := c.api.SetBucketObjectLockConfig(ctx, bucket, &mode, &vuint, &unit)
 		if e != nil {
 			return probe.NewError(e).Trace(c.GetURL().String())
 		}
 		return nil
 	}
 	if mode == "" && vuint == 0 && unit == "" {
-		e := c.api.SetBucketObjectLockConfig(bucket, nil, nil, nil)
+		e := c.api.SetBucketObjectLockConfig(ctx, bucket, nil, nil, nil)
 		if e != nil {
 			return probe.NewError(e).Trace(c.GetURL().String())
 		}
@@ -2135,7 +2138,7 @@ func (c *S3Client) SetObjectLockConfig(mode minio.RetentionMode, validity uint64
 }
 
 // PutObjectRetention - Set object retention for a given object.
-func (c *S3Client) PutObjectRetention(mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error {
+func (c *S3Client) PutObjectRetention(ctx context.Context, mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error {
 	bucket, object := c.url2BucketAndObject()
 
 	if mode != "" && !retainUntilDate.IsZero() {
@@ -2144,7 +2147,7 @@ func (c *S3Client) PutObjectRetention(mode minio.RetentionMode, retainUntilDate 
 			Mode:             &mode,
 			GovernanceBypass: bypassGovernance,
 		}
-		e := c.api.PutObjectRetention(bucket, object, opts)
+		e := c.api.PutObjectRetention(ctx, bucket, object, opts)
 		if e != nil {
 			return probe.NewError(e).Trace(c.GetURL().String())
 		}
@@ -2155,13 +2158,13 @@ func (c *S3Client) PutObjectRetention(mode minio.RetentionMode, retainUntilDate 
 }
 
 // PutObjectLegalHold - Set object legal hold for a given object.
-func (c *S3Client) PutObjectLegalHold(lhold minio.LegalHoldStatus) *probe.Error {
+func (c *S3Client) PutObjectLegalHold(ctx context.Context, lhold minio.LegalHoldStatus) *probe.Error {
 	bucket, object := c.url2BucketAndObject()
 	if lhold.IsValid() {
 		opts := minio.PutObjectLegalHoldOptions{
 			Status: &lhold,
 		}
-		e := c.api.PutObjectLegalHold(bucket, object, opts)
+		e := c.api.PutObjectLegalHold(ctx, bucket, object, opts)
 		if e != nil {
 			return probe.NewError(e).Trace(c.GetURL().String())
 		}
@@ -2171,10 +2174,10 @@ func (c *S3Client) PutObjectLegalHold(lhold minio.LegalHoldStatus) *probe.Error 
 }
 
 // GetObjectLockConfig - Get object lock configuration of bucket.
-func (c *S3Client) GetObjectLockConfig() (minio.RetentionMode, uint64, minio.ValidityUnit, *probe.Error) {
+func (c *S3Client) GetObjectLockConfig(ctx context.Context) (minio.RetentionMode, uint64, minio.ValidityUnit, *probe.Error) {
 	bucket, _ := c.url2BucketAndObject()
 
-	mode, validity, unit, e := c.api.GetBucketObjectLockConfig(bucket)
+	mode, validity, unit, e := c.api.GetBucketObjectLockConfig(ctx, bucket)
 	if e != nil {
 		return "", 0, "", probe.NewError(e).Trace(c.GetURL().String())
 	}
@@ -2189,14 +2192,14 @@ func (c *S3Client) GetObjectLockConfig() (minio.RetentionMode, uint64, minio.Val
 }
 
 // GetTags - Get tags of bucket or object.
-func (c *S3Client) GetTags() (*tags.Tags, *probe.Error) {
+func (c *S3Client) GetTags(ctx context.Context) (*tags.Tags, *probe.Error) {
 	bucketName, objectName := c.url2BucketAndObject()
 	if bucketName == "" {
 		return nil, probe.NewError(BucketNameEmpty{})
 	}
 
 	if objectName == "" {
-		tags, err := c.api.GetBucketTagging(bucketName)
+		tags, err := c.api.GetBucketTagging(ctx, bucketName)
 		if err != nil {
 			return nil, probe.NewError(err)
 		}
@@ -2204,7 +2207,7 @@ func (c *S3Client) GetTags() (*tags.Tags, *probe.Error) {
 		return tags, nil
 	}
 
-	s, err := c.api.GetObjectTagging(bucketName, objectName)
+	s, err := c.api.GetObjectTagging(ctx, bucketName, objectName)
 	if err != nil {
 		return nil, probe.NewError(err)
 	}
@@ -2218,7 +2221,7 @@ func (c *S3Client) GetTags() (*tags.Tags, *probe.Error) {
 }
 
 // SetTags - Set tags of bucket or object.
-func (c *S3Client) SetTags(tagString string) *probe.Error {
+func (c *S3Client) SetTags(ctx context.Context, tagString string) *probe.Error {
 	bucketName, objectName := c.url2BucketAndObject()
 	if bucketName == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -2230,9 +2233,9 @@ func (c *S3Client) SetTags(tagString string) *probe.Error {
 	}
 
 	if objectName == "" {
-		err = c.api.SetBucketTagging(bucketName, tags)
+		err = c.api.SetBucketTagging(ctx, bucketName, tags)
 	} else {
-		err = c.api.PutObjectTagging(bucketName, objectName, tags.ToMap())
+		err = c.api.PutObjectTagging(ctx, bucketName, objectName, tags.ToMap())
 	}
 
 	if err != nil {
@@ -2243,7 +2246,7 @@ func (c *S3Client) SetTags(tagString string) *probe.Error {
 }
 
 // DeleteTags - Delete tags of bucket or object
-func (c *S3Client) DeleteTags() *probe.Error {
+func (c *S3Client) DeleteTags(ctx context.Context) *probe.Error {
 	bucketName, objectName := c.url2BucketAndObject()
 	if bucketName == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -2251,9 +2254,9 @@ func (c *S3Client) DeleteTags() *probe.Error {
 
 	var err error
 	if objectName == "" {
-		err = c.api.DeleteBucketTagging(bucketName)
+		err = c.api.DeleteBucketTagging(ctx, bucketName)
 	} else {
-		err = c.api.RemoveObjectTagging(bucketName, objectName)
+		err = c.api.RemoveObjectTagging(ctx, bucketName, objectName)
 	}
 
 	if err != nil {
@@ -2264,13 +2267,13 @@ func (c *S3Client) DeleteTags() *probe.Error {
 }
 
 // GetLifecycle - Get current lifecycle configuration.
-func (c *S3Client) GetLifecycle() (ilm.LifecycleConfiguration, *probe.Error) {
+func (c *S3Client) GetLifecycle(ctx context.Context) (ilm.LifecycleConfiguration, *probe.Error) {
 	bucket, _ := c.url2BucketAndObject()
 	if bucket == "" {
 		return ilm.LifecycleConfiguration{}, probe.NewError(BucketNameEmpty{})
 	}
 
-	lifecycleXML, e := c.api.GetBucketLifecycle(bucket)
+	lifecycleXML, e := c.api.GetBucketLifecycle(ctx, bucket)
 	if e != nil {
 		return ilm.LifecycleConfiguration{}, probe.NewError(e)
 	}
@@ -2284,7 +2287,7 @@ func (c *S3Client) GetLifecycle() (ilm.LifecycleConfiguration, *probe.Error) {
 }
 
 // SetLifecycle - Set lifecycle configuration on a bucket
-func (c *S3Client) SetLifecycle(ilmCfg ilm.LifecycleConfiguration) *probe.Error {
+func (c *S3Client) SetLifecycle(ctx context.Context, ilmCfg ilm.LifecycleConfiguration) *probe.Error {
 	bucket, _ := c.url2BucketAndObject()
 	if bucket == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -2299,7 +2302,7 @@ func (c *S3Client) SetLifecycle(ilmCfg ilm.LifecycleConfiguration) *probe.Error 
 		}
 	}
 
-	if e := c.api.SetBucketLifecycle(bucket, string(lifecycleXML)); e != nil {
+	if e := c.api.SetBucketLifecycle(ctx, bucket, string(lifecycleXML)); e != nil {
 		return probe.NewError(e)
 	}
 

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1434,7 +1434,6 @@ func (c *S3Client) Stat(ctx context.Context, isIncomplete, isPreserve bool, sse 
 
 // getObjectStat returns the metadata of an object from a HEAD call.
 func (c *S3Client) getObjectStat(ctx context.Context, bucket, object string, opts minio.StatObjectOptions) (*ClientContent, *probe.Error) {
-	objectMetadata := &ClientContent{}
 	objectStat, e := c.api.StatObjectWithContext(ctx, bucket, object, opts)
 	if e != nil {
 		errResponse := minio.ToErrorResponse(e)
@@ -1456,7 +1455,7 @@ func (c *S3Client) getObjectStat(ctx context.Context, bucket, object string, opt
 		}
 		return nil, probe.NewError(e)
 	}
-	objectMetadata = c.objectInfo2ClientContent(bucket, objectStat)
+	objectMetadata := c.objectInfo2ClientContent(bucket, objectStat)
 	return objectMetadata, nil
 }
 

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -171,14 +171,14 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err := S3New(conf)
 	c.Assert(err, IsNil)
 
-	err = s3c.MakeBucket("us-east-1", true, false)
+	err = s3c.MakeBucket(context.Background(), "us-east-1", true, false)
 	c.Assert(err, IsNil)
 
 	conf.HostURL = server.URL + string(s3c.GetURL().Separator)
 	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
-	for content := range s3c.List(false, false, false, DirNone) {
+	for content := range s3c.List(globalContext, false, false, false, DirNone) {
 		c.Assert(content.Err, IsNil)
 		c.Assert(content.Type.IsDir(), Equals, true)
 	}
@@ -187,7 +187,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
-	for content := range s3c.List(false, false, false, DirNone) {
+	for content := range s3c.List(globalContext, false, false, false, DirNone) {
 		c.Assert(content.Err, IsNil)
 		c.Assert(content.Type.IsDir(), Equals, true)
 	}
@@ -196,7 +196,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
-	for content := range s3c.List(false, false, false, DirNone) {
+	for content := range s3c.List(globalContext, false, false, false, DirNone) {
 		c.Assert(content.Err, IsNil)
 		c.Assert(content.Type.IsRegular(), Equals, true)
 	}
@@ -227,7 +227,7 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(object.data)))
 
-	reader, err = s3c.Get(nil)
+	reader, err = s3c.Get(context.Background(), nil)
 	c.Assert(err, IsNil)
 	var buffer bytes.Buffer
 	{

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -184,7 +184,7 @@ func urlJoinPath(url1, url2 string) string {
 }
 
 // url2Stat returns stat info for URL.
-func url2Stat(urlStr string, fileAttr bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *ClientContent, err *probe.Error) {
+func url2Stat(ctx context.Context, urlStr string, fileAttr bool, encKeyDB map[string][]prefixSSEPair) (client Client, content *ClientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
@@ -192,7 +192,7 @@ func url2Stat(urlStr string, fileAttr bool, encKeyDB map[string][]prefixSSEPair)
 	alias, _ := url2Alias(urlStr)
 	sse := getSSE(urlStr, encKeyDB[alias])
 
-	content, err = client.Stat(context.Background(), false, fileAttr, sse)
+	content, err = client.Stat(ctx, false, fileAttr, sse)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -191,7 +192,7 @@ func url2Stat(urlStr string, fileAttr bool, encKeyDB map[string][]prefixSSEPair)
 	alias, _ := url2Alias(urlStr)
 	sse := getSSE(urlStr, encKeyDB[alias])
 
-	content, err = client.Stat(false, fileAttr, sse)
+	content, err = client.Stat(context.Background(), false, fileAttr, sse)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}
@@ -231,7 +232,7 @@ func isURLPrefixExists(urlPrefix string, incomplete bool) bool {
 	isRecursive := false
 	isIncomplete := incomplete
 	isFetchMeta := false
-	for entry := range clnt.List(isRecursive, isIncomplete, isFetchMeta, DirNone) {
+	for entry := range clnt.List(globalContext, isRecursive, isIncomplete, isFetchMeta, DirNone) {
 		return entry.Err == nil
 	}
 	return false

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -47,56 +47,56 @@ const defaultMultipartThreadsNum = 4
 // Client - client interface
 type Client interface {
 	// Common operations
-	Stat(isIncomplete, isPreserve bool, sse encrypt.ServerSide) (content *ClientContent, err *probe.Error)
-	List(isRecursive, isIncomplete, isFetchMeta bool, showDir DirOpt) <-chan *ClientContent
+	Stat(ctx context.Context, isIncomplete, isPreserve bool, sse encrypt.ServerSide) (content *ClientContent, err *probe.Error)
+	List(ctx context.Context, isRecursive, isIncomplete, isFetchMeta bool, showDir DirOpt) <-chan *ClientContent
 
 	// Bucket operations
-	MakeBucket(region string, ignoreExisting, withLock bool) *probe.Error
+	MakeBucket(ctx context.Context, region string, ignoreExisting, withLock bool) *probe.Error
 	// Object lock config
-	SetObjectLockConfig(mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error
-	GetObjectLockConfig() (mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit, perr *probe.Error)
+	SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error
+	GetObjectLockConfig(ctx context.Context) (mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit, perr *probe.Error)
 
 	// Access policy operations.
-	GetAccess() (access string, policyJSON string, error *probe.Error)
-	GetAccessRules() (policyRules map[string]string, error *probe.Error)
-	SetAccess(access string, isJSON bool) *probe.Error
+	GetAccess(ctx context.Context) (access string, policyJSON string, error *probe.Error)
+	GetAccessRules(ctx context.Context) (policyRules map[string]string, error *probe.Error)
+	SetAccess(ctx context.Context, access string, isJSON bool) *probe.Error
 
 	// I/O operations
-	Copy(source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error
+	Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error
 
 	// Runs select expression on object storage on specific files.
-	Select(expression string, sse encrypt.ServerSide, opts SelectObjectOpts) (io.ReadCloser, *probe.Error)
+	Select(ctx context.Context, expression string, sse encrypt.ServerSide, opts SelectObjectOpts) (io.ReadCloser, *probe.Error)
 
 	// I/O operations with metadata.
-	Get(sse encrypt.ServerSide) (reader io.ReadCloser, err *probe.Error)
+	Get(ctx context.Context, sse encrypt.ServerSide) (reader io.ReadCloser, err *probe.Error)
 	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sse encrypt.ServerSide, md5, disableMultipart bool) (n int64, err *probe.Error)
 
 	// Object Locking related API
-	PutObjectRetention(mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error
-	PutObjectLegalHold(hold minio.LegalHoldStatus) *probe.Error
+	PutObjectRetention(ctx context.Context, mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error
+	PutObjectLegalHold(ctx context.Context, hold minio.LegalHoldStatus) *probe.Error
 
 	// I/O operations with expiration
-	ShareDownload(expires time.Duration) (string, *probe.Error)
+	ShareDownload(ctx context.Context, expires time.Duration) (string, *probe.Error)
 	ShareUpload(bool, time.Duration, string) (string, map[string]string, *probe.Error)
 
 	// Watch events
-	Watch(options WatchOptions) (*WatchObject, *probe.Error)
+	Watch(ctx context.Context, options WatchOptions) (*WatchObject, *probe.Error)
 
 	// Delete operations
-	Remove(isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *ClientContent) (errorCh <-chan *probe.Error)
+	Remove(ctx context.Context, isIncomplete, isRemoveBucket, isBypass bool, contentCh <-chan *ClientContent) (errorCh <-chan *probe.Error)
 	// GetURL returns back internal url
 	GetURL() ClientURL
 
-	AddUserAgent(app, version string)
+	AddUserAgent(ctx context.Context, app, version string)
 
 	// Tagging operations
-	GetTags() (*tags.Tags, *probe.Error)
-	SetTags(tags string) *probe.Error
-	DeleteTags() *probe.Error
+	GetTags(ctx context.Context) (*tags.Tags, *probe.Error)
+	SetTags(ctx context.Context, tags string) *probe.Error
+	DeleteTags(ctx context.Context) *probe.Error
 
 	// Lifecycle operations
-	GetLifecycle() (ilm.LifecycleConfiguration, *probe.Error)
-	SetLifecycle(lfcCfg ilm.LifecycleConfiguration) *probe.Error
+	GetLifecycle(ctx context.Context) (ilm.LifecycleConfiguration, *probe.Error)
+	SetLifecycle(ctx context.Context, lfcCfg ilm.LifecycleConfiguration) *probe.Error
 }
 
 // ClientContent - Content container for content metadata

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -87,7 +87,7 @@ type Client interface {
 	// GetURL returns back internal url
 	GetURL() ClientURL
 
-	AddUserAgent(ctx context.Context, app, version string)
+	AddUserAgent(app, version string)
 
 	// Tagging operations
 	GetTags(ctx context.Context) (*tags.Tags, *probe.Error)

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -141,24 +141,24 @@ func isAliasURLDir(aliasURL string, keys map[string][]prefixSSEPair) bool {
 }
 
 // getSourceStreamMetadataFromURL gets a reader from URL.
-func getSourceStreamMetadataFromURL(urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.ReadCloser,
+func getSourceStreamMetadataFromURL(ctx context.Context, urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.ReadCloser,
 	metadata map[string]string, err *probe.Error) {
 	alias, urlStrFull, _, err := expandAlias(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}
 	sseKey := getSSE(urlStr, encKeyDB[alias])
-	return getSourceStream(alias, urlStrFull, true, sseKey, false)
+	return getSourceStream(ctx, alias, urlStrFull, true, sseKey, false)
 }
 
 // getSourceStreamFromURL gets a reader from URL.
-func getSourceStreamFromURL(urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.ReadCloser, err *probe.Error) {
+func getSourceStreamFromURL(ctx context.Context, urlStr string, encKeyDB map[string][]prefixSSEPair) (reader io.ReadCloser, err *probe.Error) {
 	alias, urlStrFull, _, err := expandAlias(urlStr)
 	if err != nil {
 		return nil, err.Trace(urlStr)
 	}
 	sse := getSSE(urlStr, encKeyDB[alias])
-	reader, _, err = getSourceStream(alias, urlStrFull, false, sse, false)
+	reader, _, err = getSourceStream(ctx, alias, urlStrFull, false, sse, false)
 	return reader, err
 }
 
@@ -210,12 +210,12 @@ func isReadAt(reader io.Reader) (ok bool) {
 }
 
 // getSourceStream gets a reader from URL.
-func getSourceStream(alias string, urlStr string, fetchStat bool, sse encrypt.ServerSide, preserve bool) (reader io.ReadCloser, metadata map[string]string, err *probe.Error) {
+func getSourceStream(ctx context.Context, alias string, urlStr string, fetchStat bool, sse encrypt.ServerSide, preserve bool) (reader io.ReadCloser, metadata map[string]string, err *probe.Error) {
 	sourceClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
-	reader, err = sourceClnt.Get(sse)
+	reader, err = sourceClnt.Get(ctx, sse)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
@@ -241,7 +241,7 @@ func getSourceStream(alias string, urlStr string, fetchStat bool, sse encrypt.Se
 			}
 			st.ETag = oinfo.ETag
 		} else {
-			st, err = sourceClnt.Stat(false, preserve, sse)
+			st, err = sourceClnt.Stat(ctx, false, preserve, sse)
 			if err != nil {
 				return nil, nil, err.Trace(alias, urlStr)
 			}
@@ -290,7 +290,7 @@ func putTargetRetention(ctx context.Context, alias string, urlStr string, metada
 			retainUntilDate = t.UTC()
 		}
 	}
-	if err := targetClnt.PutObjectRetention(lockMode, retainUntilDate, false); err != nil {
+	if err := targetClnt.PutObjectRetention(ctx, lockMode, retainUntilDate, false); err != nil {
 		return err.Trace(alias, urlStr)
 	}
 	return nil
@@ -334,7 +334,7 @@ func putTargetStreamWithURL(urlStr string, reader io.Reader, size int64, sse enc
 }
 
 // copySourceToTargetURL copies to targetURL from source.
-func copySourceToTargetURL(alias, urlStr, source, mode, until, legalHold string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
+func copySourceToTargetURL(ctx context.Context, alias, urlStr, source, mode, until, legalHold string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
 
 	targetClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
@@ -344,7 +344,7 @@ func copySourceToTargetURL(alias, urlStr, source, mode, until, legalHold string,
 	metadata[AmzObjectLockMode] = mode
 	metadata[AmzObjectLockRetainUntilDate] = until
 	metadata[AmzObjectLockLegalHold] = legalHold
-	err = targetClnt.Copy(source, size, progress, srcSSE, tgtSSE, metadata, disableMultipart)
+	err = targetClnt.Copy(ctx, source, size, progress, srcSSE, tgtSSE, metadata, disableMultipart)
 
 	if err != nil {
 		return err.Trace(alias, urlStr)
@@ -369,13 +369,13 @@ func filterMetadata(metadata map[string]string) map[string]string {
 
 // getAllMetadata - returns a map of user defined function
 // by combining the usermetadata of object and values passed by attr keyword
-func getAllMetadata(sourceAlias, sourceURLStr string, srcSSE encrypt.ServerSide, urls URLs, preserve bool) (map[string]string, *probe.Error) {
+func getAllMetadata(ctx context.Context, sourceAlias, sourceURLStr string, srcSSE encrypt.ServerSide, urls URLs, preserve bool) (map[string]string, *probe.Error) {
 	metadata := make(map[string]string)
 	sourceClnt, err := newClientFromAlias(sourceAlias, sourceURLStr)
 	if err != nil {
 		return nil, err.Trace(sourceAlias, sourceURLStr)
 	}
-	st, err := sourceClnt.Stat(false, preserve, srcSSE)
+	st, err := sourceClnt.Stat(ctx, false, preserve, srcSSE)
 	if err != nil {
 		return nil, err.Trace(sourceAlias, sourceURLStr)
 	}
@@ -456,7 +456,7 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 		// If no metadata populated already by the caller
 		// just do a Stat() to obtain the metadata.
 		if len(metadata) == 0 {
-			metadata, err = getAllMetadata(sourceAlias, sourceURL.String(), srcSSE, urls, preserve)
+			metadata, err = getAllMetadata(ctx, sourceAlias, sourceURL.String(), srcSSE, urls, preserve)
 			if err != nil {
 				return urls.WithError(err.Trace(sourceURL.String()))
 			}
@@ -477,14 +477,14 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 			metadata[k] = v
 		}
 
-		err = copySourceToTargetURL(targetAlias, targetURL.String(), sourcePath, mode, until,
+		err = copySourceToTargetURL(ctx, targetAlias, targetURL.String(), sourcePath, mode, until,
 			legalHold, length, progress, srcSSE, tgtSSE, filterMetadata(metadata), urls.DisableMultipart)
 	} else {
 		if urls.SourceContent.RetentionEnabled {
 			// If no metadata populated already by the caller
 			// just do a Stat() to obtain the metadata.
 			if len(metadata) == 0 {
-				metadata, err = getAllMetadata(sourceAlias, sourceURL.String(), srcSSE, urls, preserve)
+				metadata, err = getAllMetadata(ctx, sourceAlias, sourceURL.String(), srcSSE, urls, preserve)
 				if err != nil {
 					return urls.WithError(err.Trace(sourceURL.String()))
 				}
@@ -495,7 +495,7 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 		}
 		var reader io.ReadCloser
 		// Proceed with regular stream copy.
-		reader, metadata, err = getSourceStream(sourceAlias, sourceURL.String(), true, srcSSE, preserve)
+		reader, metadata, err = getSourceStream(ctx, sourceAlias, sourceURL.String(), true, srcSSE, preserve)
 		if err != nil {
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -104,10 +104,10 @@ func getEncKeys(ctx *cli.Context) (map[string][]prefixSSEPair, *probe.Error) {
 // Check if the passed URL represents a folder. It may or may not exist yet.
 // If it exists, we can easily check if it is a folder, if it doesn't exist,
 // we can guess if the url is a folder from how it looks.
-func isAliasURLDir(aliasURL string, keys map[string][]prefixSSEPair) bool {
+func isAliasURLDir(ctx context.Context, aliasURL string, keys map[string][]prefixSSEPair) bool {
 	// If the target url exists, check if it is a directory
 	// and return immediately.
-	_, targetContent, err := url2Stat(aliasURL, false, keys)
+	_, targetContent, err := url2Stat(ctx, aliasURL, false, keys)
 	if err == nil {
 		return targetContent.Type.IsDir()
 	}

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -631,7 +631,7 @@ func mainCopy(cliCtx *cli.Context) error {
 	}
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(cliCtx, encKeyDB, false)
+	checkCopySyntax(ctx, cliCtx, encKeyDB, false)
 
 	// Additional command specific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -244,28 +244,28 @@ func doCopy(ctx context.Context, cpURLs URLs, pg ProgressReader, encKeyDB map[st
 
 	urls := uploadSourceToTargetURL(ctx, cpURLs, pg, encKeyDB, preserve)
 	if isMvCmd && urls.Error == nil {
-		bgRemove(sourcePath)
+		bgRemove(ctx, sourcePath)
 	}
 
 	return urls
 }
 
 // doCopyFake - Perform a fake copy to update the progress bar appropriately.
-func doCopyFake(cpURLs URLs, pg Progress, isMvCmd bool) URLs {
+func doCopyFake(ctx context.Context, cpURLs URLs, pg Progress, isMvCmd bool) URLs {
 	if progressReader, ok := pg.(*progressBar); ok {
 		progressReader.ProgressBar.Add64(cpURLs.SourceContent.Size)
 	}
 
 	if isMvCmd {
 		sourcePath := filepath.ToSlash(filepath.Join(cpURLs.SourceAlias, cpURLs.SourceContent.URL.Path))
-		bgRemove(sourcePath)
+		bgRemove(ctx, sourcePath)
 	}
 
 	return cpURLs
 }
 
 // doPrepareCopyURLs scans the source URL and prepares a list of objects for copying.
-func doPrepareCopyURLs(session *sessionV8, cancelCopy context.CancelFunc) (totalBytes, totalObjects int64) {
+func doPrepareCopyURLs(ctx context.Context, session *sessionV8, cancelCopy context.CancelFunc) (totalBytes, totalObjects int64) {
 	// Separate source and target. 'cp' can take only one target,
 	// but any number of sources.
 	sourceURLs := session.Header.CommandArgs[:len(session.Header.CommandArgs)-1]
@@ -289,7 +289,7 @@ func doPrepareCopyURLs(session *sessionV8, cancelCopy context.CancelFunc) (total
 		scanBar = scanBarFactory()
 	}
 
-	URLsCh := prepareCopyURLs(sourceURLs, targetURL, isRecursive, encKeyDB, olderThan, newerThan)
+	URLsCh := prepareCopyURLs(ctx, sourceURLs, targetURL, isRecursive, encKeyDB, olderThan, newerThan)
 	done := false
 	for !done {
 		select {
@@ -341,10 +341,7 @@ func doPrepareCopyURLs(session *sessionV8, cancelCopy context.CancelFunc) (total
 	return
 }
 
-func doCopySession(cli *cli.Context, session *sessionV8, encKeyDB map[string][]prefixSSEPair, isMvCmd bool) error {
-	ctx, cancelCopy := context.WithCancel(globalContext)
-	defer cancelCopy()
-
+func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.Context, session *sessionV8, encKeyDB map[string][]prefixSSEPair, isMvCmd bool) error {
 	var isCopied func(string) bool
 	var totalObjects, totalBytes int64
 
@@ -366,7 +363,7 @@ func doCopySession(cli *cli.Context, session *sessionV8, encKeyDB map[string][]p
 		isCopied = isLastFactory(session.Header.LastCopied)
 
 		if !session.HasData() {
-			totalBytes, totalObjects = doPrepareCopyURLs(session, cancelCopy)
+			totalBytes, totalObjects = doPrepareCopyURLs(ctx, session, cancelCopy)
 		} else {
 			totalBytes, totalObjects = session.Header.TotalBytes, session.Header.TotalObjects
 		}
@@ -403,7 +400,7 @@ func doCopySession(cli *cli.Context, session *sessionV8, encKeyDB map[string][]p
 
 		go func() {
 			totalBytes := int64(0)
-			for cpURLs := range prepareCopyURLs(sourceURLs, targetURL, isRecursive,
+			for cpURLs := range prepareCopyURLs(ctx, sourceURLs, targetURL, isRecursive,
 				encKeyDB, olderThan, newerThan) {
 				if cpURLs.Error != nil {
 					// Print in new line and adjust to top so that we
@@ -509,7 +506,7 @@ func doCopySession(cli *cli.Context, session *sessionV8, encKeyDB map[string][]p
 				// Verify if previously copied, notify progress bar.
 				if isCopied != nil && isCopied(cpURLs.SourceContent.URL.String()) {
 					queueCh <- func() URLs {
-						return doCopyFake(cpURLs, pg, isMvCmd)
+						return doCopyFake(ctx, cpURLs, pg, isMvCmd)
 					}
 				} else {
 					queueCh <- func() URLs {
@@ -618,33 +615,36 @@ func getMetaDataEntry(metadataString string) (map[string]string, *probe.Error) {
 }
 
 // mainCopy is the entry point for cp command.
-func mainCopy(ctx *cli.Context) error {
+func mainCopy(cliCtx *cli.Context) error {
+	ctx, cancelCopy := context.WithCancel(globalContext)
+	defer cancelCopy()
+
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// Parse metadata.
 	userMetaMap := make(map[string]string)
-	if ctx.String("attr") != "" {
-		userMetaMap, err = getMetaDataEntry(ctx.String("attr"))
-		fatalIf(err, "Unable to parse attribute %v", ctx.String("attr"))
+	if cliCtx.String("attr") != "" {
+		userMetaMap, err = getMetaDataEntry(cliCtx.String("attr"))
+		fatalIf(err, "Unable to parse attribute %v", cliCtx.String("attr"))
 	}
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(ctx, encKeyDB, false)
+	checkCopySyntax(cliCtx, encKeyDB, false)
 
 	// Additional command specific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))
 
-	recursive := ctx.Bool("recursive")
-	olderThan := ctx.String("older-than")
-	newerThan := ctx.String("newer-than")
-	storageClass := ctx.String("storage-class")
-	retentionMode := ctx.String(rmFlag)
-	retentionDuration := ctx.String(rdFlag)
-	legalHold := strings.ToUpper(ctx.String(lhFlag))
+	recursive := cliCtx.Bool("recursive")
+	olderThan := cliCtx.String("older-than")
+	newerThan := cliCtx.String("newer-than")
+	storageClass := cliCtx.String("storage-class")
+	retentionMode := cliCtx.String(rmFlag)
+	retentionDuration := cliCtx.String(rdFlag)
+	legalHold := strings.ToUpper(cliCtx.String(lhFlag))
 	sseKeys := os.Getenv("MC_ENCRYPT_KEY")
-	if key := ctx.String("encrypt-key"); key != "" {
+	if key := cliCtx.String("encrypt-key"); key != "" {
 		sseKeys = key
 	}
 
@@ -652,12 +652,12 @@ func mainCopy(ctx *cli.Context) error {
 		sseKeys, err = getDecodedKey(sseKeys)
 		fatalIf(err, "Unable to parse encryption keys.")
 	}
-	sse := ctx.String("encrypt")
+	sse := cliCtx.String("encrypt")
 
 	var session *sessionV8
 
-	if ctx.Bool("continue") {
-		sessionID := getHash("cp", ctx.Args())
+	if cliCtx.Bool("continue") {
+		sessionID := getHash("cp", cliCtx.Args())
 		if isSessionExists(sessionID) {
 			session, err = loadSessionV8(sessionID)
 			fatalIf(err.Trace(sessionID), "Unable to load session.")
@@ -673,14 +673,14 @@ func mainCopy(ctx *cli.Context) error {
 			session.Header.CommandStringFlags[lhFlag] = legalHold
 			session.Header.CommandStringFlags["encrypt-key"] = sseKeys
 			session.Header.CommandStringFlags["encrypt"] = sse
-			session.Header.CommandBoolFlags["session"] = ctx.Bool("continue")
+			session.Header.CommandBoolFlags["session"] = cliCtx.Bool("continue")
 
-			if ctx.Bool("preserve") {
-				session.Header.CommandBoolFlags["preserve"] = ctx.Bool("preserve")
+			if cliCtx.Bool("preserve") {
+				session.Header.CommandBoolFlags["preserve"] = cliCtx.Bool("preserve")
 			}
 			session.Header.UserMetaData = userMetaMap
-			session.Header.CommandBoolFlags["md5"] = ctx.Bool("md5")
-			session.Header.CommandBoolFlags["disable-multipart"] = ctx.Bool("disable-multipart")
+			session.Header.CommandBoolFlags["md5"] = cliCtx.Bool("md5")
+			session.Header.CommandBoolFlags["disable-multipart"] = cliCtx.Bool("disable-multipart")
 
 			var e error
 			if session.Header.RootPath, e = os.Getwd(); e != nil {
@@ -689,11 +689,11 @@ func mainCopy(ctx *cli.Context) error {
 			}
 
 			// extract URLs.
-			session.Header.CommandArgs = ctx.Args()
+			session.Header.CommandArgs = cliCtx.Args()
 		}
 	}
 
-	e := doCopySession(ctx, session, encKeyDB, false)
+	e := doCopySession(ctx, cancelCopy, cliCtx, session, encKeyDB, false)
 	if session != nil {
 		session.Delete()
 	}

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -138,8 +138,8 @@ func dirDifference(sourceClnt, targetClnt Client, sourceURL, targetURL string) (
 func differenceInternal(sourceClnt, targetClnt Client, sourceURL, targetURL string, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt, diffCh chan<- diffMessage) *probe.Error {
 	// Set default values for listing.
 	isIncomplete := false // we will not compare any incomplete objects.
-	srcCh := sourceClnt.List(isRecursive, isIncomplete, isMetadata, dirOpt)
-	tgtCh := targetClnt.List(isRecursive, isIncomplete, isMetadata, dirOpt)
+	srcCh := sourceClnt.List(globalContext, isRecursive, isIncomplete, isMetadata, dirOpt)
+	tgtCh := targetClnt.List(globalContext, isRecursive, isIncomplete, isMetadata, dirOpt)
 
 	srcCtnt, srcOk := <-srcCh
 	tgtCtnt, tgtOk := <-tgtCh

--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -107,7 +107,7 @@ func du(urlStr string, depth int, encKeyDB map[string][]prefixSSEPair) (int64, e
 
 	isRecursive := false
 	isIncomplete := false
-	contentCh := clnt.List(isRecursive, isIncomplete, false, DirFirst)
+	contentCh := clnt.List(globalContext, isRecursive, isIncomplete, false, DirFirst)
 	size := int64(0)
 	for content := range contentCh {
 		if content.Err != nil {

--- a/cmd/event-list.go
+++ b/cmd/event-list.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/fatih/color"
@@ -96,14 +97,17 @@ func (u eventListMessage) String() string {
 	return msg
 }
 
-func mainEventList(ctx *cli.Context) error {
+func mainEventList(cliCtx *cli.Context) error {
+	ctx, cancelEventList := context.WithCancel(globalContext)
+	defer cancelEventList()
+
 	console.SetColor("ARN", color.New(color.FgGreen, color.Bold))
 	console.SetColor("Event", color.New(color.FgCyan, color.Bold))
 	console.SetColor("Filter", color.New(color.Bold))
 
-	checkEventListSyntax(ctx)
+	checkEventListSyntax(cliCtx)
 
-	args := ctx.Args()
+	args := cliCtx.Args()
 	path := args[0]
 	arn := ""
 	if len(args) > 1 {
@@ -120,7 +124,7 @@ func mainEventList(ctx *cli.Context) error {
 		fatalIf(errDummy().Trace(), "The provided url doesn't point to a S3 server.")
 	}
 
-	configs, err := s3Client.ListNotificationConfigs(arn)
+	configs, err := s3Client.ListNotificationConfigs(ctx, arn)
 	fatalIf(err, "Cannot list notifications on the specified bucket.")
 
 	for _, config := range configs {

--- a/cmd/event-remove.go
+++ b/cmd/event-remove.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 
 	"github.com/minio/minio-go/v6"
@@ -102,12 +103,15 @@ func (u eventRemoveMessage) String() string {
 	return msg
 }
 
-func mainEventRemove(ctx *cli.Context) error {
+func mainEventRemove(cliCtx *cli.Context) error {
+	ctx, cancelEventRemove := context.WithCancel(globalContext)
+	defer cancelEventRemove()
+
 	console.SetColor("Event", color.New(color.FgGreen, color.Bold))
 
-	checkEventRemoveSyntax(ctx)
+	checkEventRemoveSyntax(cliCtx)
 
-	args := ctx.Args()
+	args := cliCtx.Args()
 	path := args.Get(0)
 
 	arn := ""
@@ -126,11 +130,11 @@ func mainEventRemove(ctx *cli.Context) error {
 	}
 
 	// flags for the attributes of the even
-	event := ctx.String("event")
-	prefix := ctx.String("prefix")
-	suffix := ctx.String("suffix")
+	event := cliCtx.String("event")
+	prefix := cliCtx.String("prefix")
+	suffix := cliCtx.String("suffix")
 
-	err = s3Client.RemoveNotificationConfig(arn, event, prefix, suffix)
+	err = s3Client.RemoveNotificationConfig(ctx, arn, event, prefix, suffix)
 	if err != nil {
 		if err.Cause == minio.ErrNoNotificationConfigMatch {
 			fatalIf(err, "Remove event failed.")

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -155,8 +155,8 @@ EXAMPLES:
 }
 
 // checkFindSyntax - validate the passed arguments
-func checkFindSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
-	args := ctx.Args()
+func checkFindSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
+	args := cliCtx.Args()
 	if !args.Present() {
 		args = []string{"./"} // No args just default to present directory.
 	} else if args.Get(0) == "." {
@@ -171,10 +171,10 @@ func checkFindSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 
 	// Extract input URLs and validate.
 	for _, url := range args {
-		_, _, err := url2Stat(url, false, encKeyDB)
+		_, _, err := url2Stat(ctx, url, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, false) {
 			// Bucket name empty is a valid error for 'find myminio' unless we are using watch, treat it as such.
-			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !ctx.Bool("watch") {
+			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !cliCtx.Bool("watch") {
 				continue
 			}
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
@@ -208,18 +208,21 @@ type findContext struct {
 }
 
 // mainFind - handler for mc find commands
-func mainFind(ctxCtx context.Context, ctx *cli.Context) error {
+func mainFind(cliCtx *cli.Context) error {
+	ctx, cancelFind := context.WithCancel(globalContext)
+	defer cancelFind()
+
 	// Additional command specific theme customization.
 	console.SetColor("Find", color.New(color.FgGreen, color.Bold))
 	console.SetColor("FindExecErr", color.New(color.FgRed, color.Italic, color.Bold))
 
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
-	checkFindSyntax(ctx, encKeyDB)
+	checkFindSyntax(ctx, cliCtx, encKeyDB)
 
-	args := ctx.Args()
+	args := cliCtx.Args()
 	if !args.Present() {
 		args = []string{"./"} // Not args present default to present directory.
 	} else if args.Get(0) == "." {
@@ -231,11 +234,11 @@ func mainFind(ctxCtx context.Context, ctx *cli.Context) error {
 
 	var olderThan, newerThan string
 
-	if ctx.String("older-than") != "" {
-		olderThan = ctx.String("older-than")
+	if cliCtx.String("older-than") != "" {
+		olderThan = cliCtx.String("older-than")
 	}
-	if ctx.String("newer-than") != "" {
-		newerThan = ctx.String("newer-than")
+	if cliCtx.String("newer-than") != "" {
+		newerThan = cliCtx.String("newer-than")
 	}
 
 	// Use 'e' to indicate Go error, this is a convention followed in `mc`. For probe.Error we call it
@@ -243,14 +246,14 @@ func mainFind(ctxCtx context.Context, ctx *cli.Context) error {
 	var e error
 	var largerSize, smallerSize uint64
 
-	if ctx.String("larger") != "" {
-		largerSize, e = humanize.ParseBytes(ctx.String("larger"))
-		fatalIf(probe.NewError(e).Trace(ctx.String("larger")), "Unable to parse input bytes.")
+	if cliCtx.String("larger") != "" {
+		largerSize, e = humanize.ParseBytes(cliCtx.String("larger"))
+		fatalIf(probe.NewError(e).Trace(cliCtx.String("larger")), "Unable to parse input bytes.")
 	}
 
-	if ctx.String("smaller") != "" {
-		smallerSize, e = humanize.ParseBytes(ctx.String("smaller"))
-		fatalIf(probe.NewError(e).Trace(ctx.String("smaller")), "Unable to parse input bytes.")
+	if cliCtx.String("smaller") != "" {
+		smallerSize, e = humanize.ParseBytes(cliCtx.String("smaller"))
+		fatalIf(probe.NewError(e).Trace(cliCtx.String("smaller")), "Unable to parse input bytes.")
 	}
 
 	targetAlias, _, hostCfg, err := expandAlias(args[0])
@@ -261,20 +264,20 @@ func mainFind(ctxCtx context.Context, ctx *cli.Context) error {
 		targetFullURL = hostCfg.URL
 	}
 
-	return doFind(ctxCtx, &findContext{
-		Context:       ctx,
-		maxDepth:      ctx.Uint("maxdepth"),
-		execCmd:       ctx.String("exec"),
-		printFmt:      ctx.String("print"),
-		namePattern:   ctx.String("name"),
-		pathPattern:   ctx.String("path"),
-		regexPattern:  ctx.String("regex"),
-		ignorePattern: ctx.String("ignore"),
+	return doFind(ctx, &findContext{
+		Context:       cliCtx,
+		maxDepth:      cliCtx.Uint("maxdepth"),
+		execCmd:       cliCtx.String("exec"),
+		printFmt:      cliCtx.String("print"),
+		namePattern:   cliCtx.String("name"),
+		pathPattern:   cliCtx.String("path"),
+		regexPattern:  cliCtx.String("regex"),
+		ignorePattern: cliCtx.String("ignore"),
 		olderThan:     olderThan,
 		newerThan:     newerThan,
 		largerSize:    largerSize,
 		smallerSize:   smallerSize,
-		watch:         ctx.Bool("watch"),
+		watch:         cliCtx.Bool("watch"),
 		targetAlias:   targetAlias,
 		targetURL:     args[0],
 		targetFullURL: targetFullURL,

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 
 	humanize "github.com/dustin/go-humanize"
@@ -207,7 +208,7 @@ type findContext struct {
 }
 
 // mainFind - handler for mc find commands
-func mainFind(ctx *cli.Context) error {
+func mainFind(ctxCtx context.Context, ctx *cli.Context) error {
 	// Additional command specific theme customization.
 	console.SetColor("Find", color.New(color.FgGreen, color.Bold))
 	console.SetColor("FindExecErr", color.New(color.FgRed, color.Italic, color.Bold))
@@ -260,7 +261,7 @@ func mainFind(ctx *cli.Context) error {
 		targetFullURL = hostCfg.URL
 	}
 
-	return doFind(&findContext{
+	return doFind(ctxCtx, &findContext{
 		Context:       ctx,
 		maxDepth:      ctx.Uint("maxdepth"),
 		execCmd:       ctx.String("exec"),

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 	"testing"
@@ -410,7 +411,7 @@ func TestStringReplace(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
-		gotStr := stringsReplace(testCase.str, testCase.content)
+		gotStr := stringsReplace(context.Background(), testCase.str, testCase.content)
 		if gotStr != testCase.expectedStr {
 			t.Errorf("Test %d: Expected %s, got %s", i+1, testCase.expectedStr, gotStr)
 		}

--- a/cmd/head-main.go
+++ b/cmd/head-main.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"compress/bzip2"
 	"compress/gzip"
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -84,7 +85,7 @@ func headURL(sourceURL string, encKeyDB map[string][]prefixSSEPair, nlines int64
 	default:
 		var err *probe.Error
 		var metadata map[string]string
-		if reader, metadata, err = getSourceStreamMetadataFromURL(sourceURL, encKeyDB); err != nil {
+		if reader, metadata, err = getSourceStreamMetadataFromURL(context.Background(), sourceURL, encKeyDB); err != nil {
 			return err.Trace(sourceURL)
 		}
 		ctype := metadata["Content-Type"]

--- a/cmd/legalhold-main.go
+++ b/cmd/legalhold-main.go
@@ -111,7 +111,7 @@ func setLegalHold(urlStr string, lhold minio.LegalHoldStatus, isRecursive bool) 
 	alias, _, _ := mustExpandAlias(urlStr)
 	var cErr error
 	errorsFound := false
-	for content := range clnt.List(globalContext, isRecursive, false, false, DirNone) {
+	for content := range clnt.List(ctx, isRecursive, false, false, DirNone) {
 		if content.Err != nil {
 			errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
 			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.

--- a/cmd/legalhold-main.go
+++ b/cmd/legalhold-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -86,12 +87,15 @@ func (l legalHoldCmdMessage) JSON() string {
 
 // setRetention - Set Retention for all objects within a given prefix.
 func setLegalHold(urlStr string, lhold minio.LegalHoldStatus, isRecursive bool) error {
+	ctx, cancelLegalHold := context.WithCancel(globalContext)
+	defer cancelLegalHold()
+
 	clnt, err := newClient(urlStr)
 	if err != nil {
 		fatalIf(err.Trace(), "Cannot parse the provided url.")
 	}
 	if !isRecursive {
-		err = clnt.PutObjectLegalHold(lhold)
+		err = clnt.PutObjectLegalHold(ctx, lhold)
 		if err != nil {
 			errorIf(err.Trace(urlStr), "Failed to set legal hold on `"+urlStr+"` successfully")
 		} else {
@@ -107,7 +111,7 @@ func setLegalHold(urlStr string, lhold minio.LegalHoldStatus, isRecursive bool) 
 	alias, _, _ := mustExpandAlias(urlStr)
 	var cErr error
 	errorsFound := false
-	for content := range clnt.List(isRecursive, false, false, DirNone) {
+	for content := range clnt.List(globalContext, isRecursive, false, false, DirNone) {
 		if content.Err != nil {
 			errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
 			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
@@ -119,7 +123,7 @@ func setLegalHold(urlStr string, lhold minio.LegalHoldStatus, isRecursive bool) 
 			errorIf(content.Err.Trace(clnt.GetURL().String()), "Invalid URL")
 			continue
 		}
-		probeErr := newClnt.PutObjectLegalHold(lhold)
+		probeErr := newClnt.PutObjectLegalHold(ctx, lhold)
 		if probeErr != nil {
 			errorsFound = true
 			errorIf(probeErr.Trace(content.URL.Path), "Failed to set legal hold on `"+content.URL.Path+"` successfully")

--- a/cmd/lock-main.go
+++ b/cmd/lock-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -99,11 +100,14 @@ func lock(urlStr string, mode minio.RetentionMode, validity uint64, unit minio.V
 		fatalIf(err.Trace(), "Cannot parse the provided url.")
 	}
 
+	ctx, cancelLock := context.WithCancel(globalContext)
+	defer cancelLock()
+
 	if clearLock || mode != "" {
-		err = client.SetObjectLockConfig(mode, validity, unit)
+		err = client.SetObjectLockConfig(ctx, mode, validity, unit)
 		fatalIf(err, "Cannot enable object lock configuration on the specified bucket.")
 	} else {
-		mode, validity, unit, err = client.GetObjectLockConfig()
+		mode, validity, unit, err = client.GetObjectLockConfig(ctx)
 		fatalIf(err, "Cannot get object lock configuration on the specified bucket.")
 	}
 

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 
 	"github.com/fatih/color"
@@ -106,7 +107,7 @@ func checkListSyntax(ctx *cli.Context) {
 }
 
 // mainList - is a handler for mc ls command
-func mainList(ctx *cli.Context) error {
+func mainList(cli *cli.Context) error {
 	// Additional command specific theme customization.
 	console.SetColor("File", color.New(color.Bold))
 	console.SetColor("Dir", color.New(color.FgCyan, color.Bold))
@@ -114,26 +115,28 @@ func mainList(ctx *cli.Context) error {
 	console.SetColor("Time", color.New(color.FgGreen))
 
 	// check 'ls' cli arguments.
-	checkListSyntax(ctx)
+	checkListSyntax(cli)
 
 	// Set command flags from context.
-	isRecursive := ctx.Bool("recursive")
-	isIncomplete := ctx.Bool("incomplete")
+	isRecursive := cli.Bool("recursive")
+	isIncomplete := cli.Bool("incomplete")
 
-	args := ctx.Args()
+	args := cli.Args()
 	// mimic operating system tool behavior.
-	if !ctx.Args().Present() {
+	if !cli.Args().Present() {
 		args = []string{"."}
 	}
+
+	ctx, cancelList := context.WithCancel(globalContext)
+	defer cancelList()
 
 	var cErr error
 	for _, targetURL := range args {
 		clnt, err := newClient(targetURL)
 		fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
-
 		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 			var st *ClientContent
-			st, err = clnt.Stat(isIncomplete, false, nil)
+			st, err = clnt.Stat(ctx, isIncomplete, false, nil)
 			if st != nil && err == nil && st.Type.IsDir() {
 				targetURL = targetURL + string(clnt.GetURL().Separator)
 				clnt, err = newClient(targetURL)
@@ -141,7 +144,7 @@ func mainList(ctx *cli.Context) error {
 			}
 		}
 
-		if e := doList(clnt, isRecursive, isIncomplete); e != nil {
+		if e := doList(ctx, clnt, isRecursive, isIncomplete); e != nil {
 			cErr = e
 		}
 	}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -106,14 +107,15 @@ func getKey(c *ClientContent) string {
 }
 
 // doList - list all entities inside a folder.
-func doList(clnt Client, isRecursive, isIncomplete bool) error {
+func doList(ctx context.Context, clnt Client, isRecursive, isIncomplete bool) error {
 	prefixPath := clnt.GetURL().Path
 	separator := string(clnt.GetURL().Separator)
 	if !strings.HasSuffix(prefixPath, separator) {
 		prefixPath = prefixPath[:strings.LastIndex(prefixPath, separator)+1]
 	}
+
 	var cErr error
-	for content := range clnt.List(isRecursive, isIncomplete, false, DirNone) {
+	for content := range clnt.List(ctx, isRecursive, isIncomplete, false, DirNone) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {
 			// handle this specifically for filesystem related errors.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,6 +73,7 @@ VERSION:
 
 // Main starts mc application
 func Main(args []string) {
+
 	if len(args) > 1 {
 		switch args[1] {
 		case "mc", filepath.Base(args[0]):

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -251,7 +251,7 @@ func (m mirrorMessage) JSON() string {
 }
 
 // doRemove - removes files on target.
-func (mj *mirrorJob) doRemove(sURLs URLs) URLs {
+func (mj *mirrorJob) doRemove(ctx context.Context, sURLs URLs) URLs {
 	if mj.isFake {
 		return sURLs.WithError(nil)
 	}
@@ -262,12 +262,12 @@ func (mj *mirrorJob) doRemove(sURLs URLs) URLs {
 	if pErr != nil {
 		return sURLs.WithError(pErr)
 	}
-	clnt.AddUserAgent(uaMirrorAppName, Version)
+	clnt.AddUserAgent(ctx, uaMirrorAppName, Version)
 	contentCh := make(chan *ClientContent, 1)
 	contentCh <- &ClientContent{URL: *newClientURL(sURLs.TargetContent.URL.Path)}
 	close(contentCh)
 	isRemoveBucket := false
-	errorCh := clnt.Remove(false, isRemoveBucket, false, contentCh)
+	errorCh := clnt.Remove(ctx, false, isRemoveBucket, false, contentCh)
 	for pErr := range errorCh {
 		if pErr != nil {
 			switch pErr.ToGoError().(type) {
@@ -291,7 +291,7 @@ func (mj *mirrorJob) doMirrorWatch(ctx context.Context, targetPath string, tgtSS
 			// cannot create targetclient
 			return sURLs.WithError(err)
 		}
-		_, err = targetClient.Stat(false, false, tgtSSE)
+		_, err = targetClient.Stat(ctx, false, false, tgtSSE)
 		if err == nil {
 			if !sURLs.SourceContent.RetentionEnabled && !sURLs.SourceContent.LegalHoldEnabled {
 				return sURLs.WithError(probe.NewError(ObjectAlreadyExists{}))
@@ -501,7 +501,7 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 			mirrorURL.TotalSize = mj.status.Get()
 			if mirrorURL.TargetContent != nil && (mj.isRemove || mj.activeActive) {
 				mj.queueCh <- func() URLs {
-					return mj.doRemove(mirrorURL)
+					return mj.doRemove(ctx, mirrorURL)
 				}
 			}
 		}
@@ -541,8 +541,8 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, stopParallel func()) {
 	}
 }
 
-func (mj *mirrorJob) watchURL(sourceClient Client) *probe.Error {
-	return mj.watcher.Join(sourceClient, true)
+func (mj *mirrorJob) watchURL(ctx context.Context, sourceClient Client) *probe.Error {
+	return mj.watcher.Join(ctx, sourceClient, true)
 }
 
 // Fetch urls that need to be mirrored
@@ -592,7 +592,7 @@ func (mj *mirrorJob) startMirror(ctx context.Context, cancelMirror context.Cance
 				}
 			} else if sURLs.TargetContent != nil && mj.isRemove {
 				mj.queueCh <- func() URLs {
-					return mj.doRemove(sURLs)
+					return mj.doRemove(ctx, sURLs)
 				}
 			}
 		case <-globalContext.Done():
@@ -692,8 +692,8 @@ func newMirrorJob(srcURL, dstURL string, isFake, isRemove, isOverwrite, isWatch,
 }
 
 // copyBucketPolicies - copy policies from source to dest
-func copyBucketPolicies(srcClt, dstClt Client, isOverwrite bool) *probe.Error {
-	rules, err := srcClt.GetAccessRules()
+func copyBucketPolicies(ctx context.Context, srcClt, dstClt Client, isOverwrite bool) *probe.Error {
+	rules, err := srcClt.GetAccessRules(ctx)
 	if err != nil {
 		switch err.ToGoError().(type) {
 		case APINotImplemented:
@@ -703,14 +703,14 @@ func copyBucketPolicies(srcClt, dstClt Client, isOverwrite bool) *probe.Error {
 	}
 	// Set found rules to target bucket if permitted
 	for _, r := range rules {
-		originalRule, _, err := dstClt.GetAccess()
+		originalRule, _, err := dstClt.GetAccess(ctx)
 		if err != nil {
 			return err
 		}
 		// Set rule only if it doesn't exist in the target bucket
 		// or force flag is activated
 		if originalRule == "none" || isOverwrite {
-			err = dstClt.SetAccess(r, false)
+			err = dstClt.SetAccess(ctx, r, false)
 			if err != nil {
 				return err
 			}
@@ -743,20 +743,20 @@ func getEventPathURLWin(srcURL, eventPath string) string {
 }
 
 // runMirror - mirrors all buckets to another S3 server
-func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) bool {
+func runMirror(srcURL, dstURL string, cli *cli.Context, encKeyDB map[string][]prefixSSEPair) bool {
 	// This is kept for backward compatibility, `--force` means
 	// --overwrite.
-	isOverwrite := ctx.Bool("force")
+	isOverwrite := cli.Bool("force")
 	if !isOverwrite {
-		isOverwrite = ctx.Bool("overwrite")
+		isOverwrite = cli.Bool("overwrite")
 	}
 
 	// Parse metadata.
 	userMetaMap := make(map[string]string)
-	if ctx.String("attr") != "" {
+	if cli.String("attr") != "" {
 		var err *probe.Error
-		userMetaMap, err = getMetaDataEntry(ctx.String("attr"))
-		fatalIf(err, "Unable to parse attribute %v", ctx.String("attr"))
+		userMetaMap, err = getMetaDataEntry(cli.String("attr"))
+		fatalIf(err, "Unable to parse attribute %v", cli.String("attr"))
 	}
 
 	srcClt, err := newClient(srcURL)
@@ -781,8 +781,8 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 
 	// Create a new mirror job and execute it
 	mj := newMirrorJob(srcURL, dstURL,
-		ctx.Bool("fake"),
-		ctx.Bool("remove"),
+		cli.Bool("fake"),
+		cli.Bool("remove"),
 		isOverwrite,
 		ctx.Bool("watch"),
 		ctx.Bool("a"),
@@ -793,14 +793,17 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 		ctx.String("storage-class"),
 		userMetaMap,
 		encKeyDB,
-		ctx.Bool("md5"),
-		ctx.Bool("disable-multipart"),
+		cli.Bool("md5"),
+		cli.Bool("disable-multipart"),
 	)
 
 	go func() {
 		<-globalContext.Done()
 		os.Exit(globalErrorExitStatus)
 	}()
+
+	ctx, cancelMirror := context.WithCancel(context.Background())
+	defer cancelMirror()
 
 	if mirrorAllBuckets {
 		// Synchronize buckets using dirDifference function
@@ -826,28 +829,28 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 
 			if d.Diff == differInFirst {
 				withLock := false
-				mode, validity, unit, err := newSrcClt.GetObjectLockConfig()
+				mode, validity, unit, err := newSrcClt.GetObjectLockConfig(ctx)
 				if err == nil {
 					withLock = true
 				}
 				// Bucket only exists in the source, create the same bucket in the destination
-				if err := newDstClt.MakeBucket(ctx.String("region"), false, withLock); err != nil {
+				if err := newDstClt.MakeBucket(ctx, cli.String("region"), false, withLock); err != nil {
 					errorIf(err, "Unable to create bucket at `"+newTgtURL+"`.")
 					continue
 				}
 				// object lock configuration set on bucket
 				if mode != "" {
-					errorIf(newDstClt.SetObjectLockConfig(mode, validity, unit),
+					errorIf(newDstClt.SetObjectLockConfig(ctx, mode, validity, unit),
 						"Unable to set object lock config in `"+newTgtURL+"`.")
 				}
-				errorIf(copyBucketPolicies(newSrcClt, newDstClt, isOverwrite),
+				errorIf(copyBucketPolicies(ctx, newSrcClt, newDstClt, isOverwrite),
 					"Unable to copy bucket policies to `"+newDstClt.GetURL().String()+"`.")
 			}
 
 			if mj.isWatch {
 				// monitor mode will watch the source folders for changes,
 				// and queue them for copying.
-				if err := mj.watchURL(newSrcClt); err != nil {
+				if err := mj.watchURL(ctx, newSrcClt); err != nil {
 					if mj.activeActive {
 						errorIf(err, "Failed to start monitoring.")
 						return true
@@ -856,9 +859,9 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 				}
 			}
 		}
-	} else if _, err := dstClt.Stat(false, false, nil); err != nil {
+	} else if _, err := dstClt.Stat(ctx, false, false, nil); err != nil {
 		withLock := false
-		mode, validity, unit, err := srcClt.GetObjectLockConfig()
+		mode, validity, unit, err := srcClt.GetObjectLockConfig(ctx)
 		if err == nil {
 			withLock = true
 		}
@@ -866,26 +869,26 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 		// Create bucket if it doesn't exist at destination.
 		// ignore if already exists.
 		if mj.activeActive {
-			err = dstClt.MakeBucket(ctx.String("region"), true, withLock)
+			err = dstClt.MakeBucket(ctx, ctx.String("region"), true, withLock)
 			errorIf(err, "Unable to create bucket at `"+dstURL+"`.")
 			if err != nil {
 				return true
 			}
 		} else {
-			mj.status.fatalIf(dstClt.MakeBucket(ctx.String("region"), true, withLock),
+			mj.status.fatalIf(dstClt.MakeBucket(ctx, cli.String("region"), true, withLock),
 				"Unable to create bucket at `"+dstURL+"`.")
 		}
 
 		// object lock configuration set on bucket
 		if mode != "" {
-			err = dstClt.SetObjectLockConfig(mode, validity, unit)
+			err = dstClt.SetObjectLockConfig(ctx, mode, validity, unit)
 			errorIf(err, "Unable to set object lock config in `"+dstURL+"`.")
 			if err != nil && mj.activeActive {
 				return true
 			}
 		}
 
-		err = copyBucketPolicies(srcClt, dstClt, isOverwrite)
+		err = copyBucketPolicies(ctx, srcClt, dstClt, isOverwrite)
 		errorIf(err, "Unable to copy bucket policies to `"+dstClt.GetURL().String()+"`.")
 		if err != nil && mj.activeActive {
 			return true
@@ -895,7 +898,7 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 	if !mirrorAllBuckets && mj.isWatch {
 		// monitor mode will watch the source folders for changes,
 		// and queue them for copying.
-		if err := mj.watchURL(srcClt); err != nil {
+		if err := mj.watchURL(ctx, srcClt); err != nil {
 			if mj.activeActive {
 				errorIf(err, "Failed to start monitoring.")
 				return true
@@ -904,11 +907,8 @@ func runMirror(srcURL, dstURL string, ctx *cli.Context, encKeyDB map[string][]pr
 		}
 	}
 
-	ctxt, cancelMirror := context.WithCancel(context.Background())
-	defer cancelMirror()
-
 	// Start mirroring job
-	return mj.mirror(ctxt, cancelMirror)
+	return mj.mirror(ctx, cancelMirror)
 }
 
 // Main entry point for mirror command.

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -802,7 +802,7 @@ func runMirror(srcURL, dstURL string, cli *cli.Context, encKeyDB map[string][]pr
 		os.Exit(globalErrorExitStatus)
 	}()
 
-	ctx, cancelMirror := context.WithCancel(context.Background())
+	ctx, cancelMirror := context.WithCancel(globalContext)
 	defer cancelMirror()
 
 	if mirrorAllBuckets {

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -262,7 +262,7 @@ func (mj *mirrorJob) doRemove(ctx context.Context, sURLs URLs) URLs {
 	if pErr != nil {
 		return sURLs.WithError(pErr)
 	}
-	clnt.AddUserAgent(ctx, uaMirrorAppName, Version)
+	clnt.AddUserAgent(uaMirrorAppName, Version)
 	contentCh := make(chan *ClientContent, 1)
 	contentCh <- &ClientContent{URL: *newClientURL(sURLs.TargetContent.URL.Path)}
 	close(contentCh)

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -181,7 +182,7 @@ func (rm *removeManager) readErrors(errorCh <-chan *probe.Error, targetURL strin
 	}()
 }
 
-func (rm *removeManager) add(targetAlias, targetURL string) {
+func (rm *removeManager) add(ctx context.Context, targetAlias, targetURL string) {
 	if atomic.LoadInt32(&rm.isClosed) != 0 {
 		return
 	}
@@ -198,7 +199,7 @@ func (rm *removeManager) add(targetAlias, targetURL string) {
 		}
 
 		contentCh := make(chan *ClientContent)
-		errorCh := client.Remove(false, false, false, contentCh)
+		errorCh := client.Remove(ctx, false, false, false, contentCh)
 		rm.readErrors(errorCh, targetURL)
 
 		clientInfo = &removeClientInfo{
@@ -236,7 +237,7 @@ var rmManager = &removeManager{
 	doneCh:    make(chan struct{}),
 }
 
-func bgRemove(url string) {
+func bgRemove(ctx context.Context, url string) {
 	remove := func(targetAlias, targetURL string) {
 		clnt, pErr := newClientFromAlias(targetAlias, targetURL)
 		if pErr != nil {
@@ -246,7 +247,7 @@ func bgRemove(url string) {
 		contentCh := make(chan *ClientContent, 1)
 		contentCh <- &ClientContent{URL: *newClientURL(targetURL)}
 		close(contentCh)
-		errorCh := clnt.Remove(false, false, false, contentCh)
+		errorCh := clnt.Remove(ctx, false, false, false, contentCh)
 		for pErr := range errorCh {
 			if pErr != nil {
 				errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
@@ -266,27 +267,30 @@ func bgRemove(url string) {
 		return
 	}
 
-	rmManager.add(targetAlias, targetURL)
+	rmManager.add(ctx, targetAlias, targetURL)
 }
 
 // mainMove is the entry point for mv command.
-func mainMove(ctx *cli.Context) error {
+func mainMove(cliCtx *cli.Context) error {
+	ctx, cancelMove := context.WithCancel(globalContext)
+	defer cancelMove()
+
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// Parse metadata.
 	userMetaMap := make(map[string]string)
-	if ctx.String("attr") != "" {
-		userMetaMap, err = getMetaDataEntry(ctx.String("attr"))
-		fatalIf(err, "Unable to parse attribute %v", ctx.String("attr"))
+	if cliCtx.String("attr") != "" {
+		userMetaMap, err = getMetaDataEntry(cliCtx.String("attr"))
+		fatalIf(err, "Unable to parse attribute %v", cliCtx.String("attr"))
 	}
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(ctx, encKeyDB, true)
+	checkCopySyntax(cliCtx, encKeyDB, true)
 
-	if ctx.NArg() == 2 {
-		args := ctx.Args()
+	if cliCtx.NArg() == 2 {
+		args := cliCtx.Args()
 		srcURL := args.Get(0)
 		dstURL := args.Get(1)
 		if srcURL == dstURL {
@@ -294,14 +298,14 @@ func mainMove(ctx *cli.Context) error {
 		}
 	}
 
-	for _, urlStr := range ctx.Args() {
+	for _, urlStr := range cliCtx.Args() {
 		client, err := newClient(urlStr)
 		if err != nil {
 			fatalIf(err.Trace(), "Cannot parse the provided url.")
 		}
 
 		if s3Client, ok := client.(*S3Client); ok {
-			if _, _, _, err = s3Client.GetObjectLockConfig(); err == nil {
+			if _, _, _, err = s3Client.GetObjectLockConfig(ctx); err == nil {
 				fatalIf(probe.NewError(errors.New("")), fmt.Sprintf("Object lock configuration is enabled on the specified bucket in alias %v.", urlStr))
 			}
 		}
@@ -310,12 +314,12 @@ func mainMove(ctx *cli.Context) error {
 	// Additional command speific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))
 
-	recursive := ctx.Bool("recursive")
-	olderThan := ctx.String("older-than")
-	newerThan := ctx.String("newer-than")
-	storageClass := ctx.String("storage-class")
+	recursive := cliCtx.Bool("recursive")
+	olderThan := cliCtx.String("older-than")
+	newerThan := cliCtx.String("newer-than")
+	storageClass := cliCtx.String("storage-class")
 	sseKeys := os.Getenv("MC_ENCRYPT_KEY")
-	if key := ctx.String("encrypt-key"); key != "" {
+	if key := cliCtx.String("encrypt-key"); key != "" {
 		sseKeys = key
 	}
 
@@ -323,12 +327,12 @@ func mainMove(ctx *cli.Context) error {
 		sseKeys, err = getDecodedKey(sseKeys)
 		fatalIf(err, "Unable to parse encryption keys.")
 	}
-	sse := ctx.String("encrypt")
+	sse := cliCtx.String("encrypt")
 
 	var session *sessionV8
 
-	if ctx.Bool("continue") {
-		sessionID := getHash("mv", ctx.Args())
+	if cliCtx.Bool("continue") {
+		sessionID := getHash("mv", cliCtx.Args())
 		if isSessionExists(sessionID) {
 			session, err = loadSessionV8(sessionID)
 			fatalIf(err.Trace(sessionID), "Unable to load session.")
@@ -341,13 +345,13 @@ func mainMove(ctx *cli.Context) error {
 			session.Header.CommandStringFlags["storage-class"] = storageClass
 			session.Header.CommandStringFlags["encrypt-key"] = sseKeys
 			session.Header.CommandStringFlags["encrypt"] = sse
-			session.Header.CommandBoolFlags["session"] = ctx.Bool("continue")
+			session.Header.CommandBoolFlags["session"] = cliCtx.Bool("continue")
 
-			if ctx.Bool("preserve") {
-				session.Header.CommandBoolFlags["preserve"] = ctx.Bool("preserve")
+			if cliCtx.Bool("preserve") {
+				session.Header.CommandBoolFlags["preserve"] = cliCtx.Bool("preserve")
 			}
 			session.Header.UserMetaData = userMetaMap
-			session.Header.CommandBoolFlags["disable-multipart"] = ctx.Bool("disable-multipart")
+			session.Header.CommandBoolFlags["disable-multipart"] = cliCtx.Bool("disable-multipart")
 
 			var e error
 			if session.Header.RootPath, e = os.Getwd(); e != nil {
@@ -356,11 +360,11 @@ func mainMove(ctx *cli.Context) error {
 			}
 
 			// extract URLs.
-			session.Header.CommandArgs = ctx.Args()
+			session.Header.CommandArgs = cliCtx.Args()
 		}
 	}
 
-	e := doCopySession(ctx, session, encKeyDB, true)
+	e := doCopySession(ctx, cancelMove, cliCtx, session, encKeyDB, true)
 	if session != nil {
 		session.Delete()
 	}

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -287,7 +287,7 @@ func mainMove(cliCtx *cli.Context) error {
 	}
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(cliCtx, encKeyDB, true)
+	checkCopySyntax(ctx, cliCtx, encKeyDB, true)
 
 	if cliCtx.NArg() == 2 {
 		args := cliCtx.Args()

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -114,10 +114,7 @@ func checkRbSyntax(ctx *cli.Context) {
 }
 
 // deletes a bucket and all its contents
-func deleteBucket(url string) *probe.Error {
-	ctx, cancelCopy := context.WithCancel(globalContext)
-	defer cancelCopy()
-
+func deleteBucket(ctx context.Context, url string) *probe.Error {
 	targetAlias, targetURL, _ := mustExpandAlias(url)
 	clnt, pErr := newClientFromAlias(targetAlias, targetURL)
 	if pErr != nil {
@@ -126,11 +123,11 @@ func deleteBucket(url string) *probe.Error {
 	var isIncomplete bool
 	isRemoveBucket := true
 	contentCh := make(chan *ClientContent)
-	errorCh := clnt.Remove(isIncomplete, isRemoveBucket, false, contentCh)
+	errorCh := clnt.Remove(ctx, isIncomplete, isRemoveBucket, false, contentCh)
 
 	go func() {
 		defer close(contentCh)
-		for content := range clnt.List(true, false, false, DirLast) {
+		for content := range clnt.List(ctx, true, false, false, DirLast) {
 			if content.Err != nil {
 				contentCh <- content
 				continue
@@ -188,16 +185,19 @@ func isNamespaceRemoval(url string) bool {
 }
 
 // mainRemoveBucket is entry point for rb command.
-func mainRemoveBucket(ctx *cli.Context) error {
+func mainRemoveBucket(cliCtx *cli.Context) error {
+	ctx, cancelRemoveBucket := context.WithCancel(globalContext)
+	defer cancelRemoveBucket()
+
 	// check 'rb' cli arguments.
-	checkRbSyntax(ctx)
-	isForce := ctx.Bool("force")
+	checkRbSyntax(cliCtx)
+	isForce := cliCtx.Bool("force")
 
 	// Additional command specific theme customization.
 	console.SetColor("RemoveBucket", color.New(color.FgGreen, color.Bold))
 
 	var cErr error
-	for _, targetURL := range ctx.Args() {
+	for _, targetURL := range cliCtx.Args() {
 		// Instantiate client for URL.
 		clnt, err := newClient(targetURL)
 		if err != nil {
@@ -205,7 +205,7 @@ func mainRemoveBucket(ctx *cli.Context) error {
 			cErr = exitStatus(globalErrorExitStatus)
 			continue
 		}
-		_, err = clnt.Stat(false, false, nil)
+		_, err = clnt.Stat(ctx, false, false, nil)
 		if err != nil {
 			switch err.ToGoError().(type) {
 			case BucketNameEmpty:
@@ -218,7 +218,7 @@ func mainRemoveBucket(ctx *cli.Context) error {
 		}
 
 		isEmpty := true
-		for range clnt.List(true, false, false, DirNone) {
+		for range clnt.List(ctx, true, false, false, DirNone) {
 			isEmpty = false
 			break
 		}
@@ -227,7 +227,7 @@ func mainRemoveBucket(ctx *cli.Context) error {
 			fatalIf(errDummy().Trace(), "`"+targetURL+"` is not empty. Retry this command with ‘--force’ flag if you want to remove `"+targetURL+"` and all its contents")
 		}
 
-		e := deleteBucket(targetURL)
+		e := deleteBucket(ctx, targetURL)
 		fatalIf(e.Trace(targetURL), "Failed to remove `"+targetURL+"`.")
 
 		if !isNamespaceRemoval(targetURL) {

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -149,20 +149,20 @@ func (r rmMessage) JSON() string {
 }
 
 // Validate command line arguments.
-func checkRmSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
+func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 	// Set command flags from context.
-	isForce := ctx.Bool("force")
-	isRecursive := ctx.Bool("recursive")
-	isStdin := ctx.Bool("stdin")
-	isDangerous := ctx.Bool("dangerous")
+	isForce := cliCtx.Bool("force")
+	isRecursive := cliCtx.Bool("recursive")
+	isStdin := cliCtx.Bool("stdin")
+	isDangerous := cliCtx.Bool("dangerous")
 	isNamespaceRemoval := false
 
-	for _, url := range ctx.Args() {
+	for _, url := range cliCtx.Args() {
 		// clean path for aliases like s3/.
 		// Note: UNC path using / works properly in go 1.9.2 even though it breaks the UNC specification.
 		url = filepath.ToSlash(filepath.Clean(url))
 		// namespace removal applies only for non FS. So filter out if passed url represents a directory
-		dir := isAliasURLDir(url, encKeyDB)
+		dir := isAliasURLDir(ctx, url, encKeyDB)
 		if !dir {
 			_, path := url2Alias(url)
 			isNamespaceRemoval = (path == "")
@@ -177,9 +177,9 @@ func checkRmSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
 				"Removal requires --recursive flag. This operation is *IRREVERSIBLE*. Please review carefully before performing this *DANGEROUS* operation.")
 		}
 	}
-	if !ctx.Args().Present() && !isStdin {
+	if !cliCtx.Args().Present() && !isStdin {
 		exitCode := 1
-		cli.ShowCommandHelpAndExit(ctx, "rm", exitCode)
+		cli.ShowCommandHelpAndExit(cliCtx, "rm", exitCode)
 	}
 
 	// For all recursive operations make sure to check for 'force' flag.
@@ -347,23 +347,26 @@ func removeRecursive(url string, isIncomplete, isFake, isBypass bool, olderThan,
 }
 
 // main for rm command.
-func mainRm(ctx *cli.Context) error {
+func mainRm(cliCtx *cli.Context) error {
+	ctx, cancelRm := context.WithCancel(globalContext)
+	defer cancelRm()
+
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check 'rm' cli arguments.
-	checkRmSyntax(ctx, encKeyDB)
+	checkRmSyntax(ctx, cliCtx, encKeyDB)
 
 	// rm specific flags.
-	isIncomplete := ctx.Bool("incomplete")
-	isRecursive := ctx.Bool("recursive")
-	isFake := ctx.Bool("fake")
-	isStdin := ctx.Bool("stdin")
-	isBypass := ctx.Bool(bypass)
-	olderThan := ctx.String("older-than")
-	newerThan := ctx.String("newer-than")
-	isForce := ctx.Bool("force")
+	isIncomplete := cliCtx.Bool("incomplete")
+	isRecursive := cliCtx.Bool("recursive")
+	isFake := cliCtx.Bool("fake")
+	isStdin := cliCtx.Bool("stdin")
+	isBypass := cliCtx.Bool(bypass)
+	olderThan := cliCtx.String("older-than")
+	newerThan := cliCtx.String("newer-than")
+	isForce := cliCtx.Bool("force")
 
 	// Set color.
 	console.SetColor("Remove", color.New(color.FgGreen, color.Bold))
@@ -371,7 +374,7 @@ func mainRm(ctx *cli.Context) error {
 	var rerr error
 	var e error
 	// Support multiple targets.
-	for _, url := range ctx.Args() {
+	for _, url := range cliCtx.Args() {
 		if isRecursive {
 			e = removeRecursive(url, isIncomplete, isFake, isBypass, olderThan, newerThan, encKeyDB)
 		} else {

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -102,7 +103,7 @@ func checkShareDownloadSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEP
 }
 
 // doShareURL share files from target.
-func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration) *probe.Error {
+func doShareDownloadURL(ctx context.Context, targetURL string, isRecursive bool, expiry time.Duration) *probe.Error {
 	targetAlias, targetURLFull, _, err := expandAlias(targetURL)
 	if err != nil {
 		return err.Trace(targetURL)
@@ -125,7 +126,7 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 	// Channel which will receive objects whose URLs need to be shared
 	objectsCh := make(chan *ClientContent)
 
-	content, err := clnt.Stat(isIncomplete, false, nil)
+	content, err := clnt.Stat(ctx, isIncomplete, false, nil)
 	if err != nil {
 		return err.Trace(clnt.GetURL().String())
 	}
@@ -146,7 +147,7 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 		// Recursive mode: Share list of objects
 		go func() {
 			defer close(objectsCh)
-			for content := range clnt.List(isRecursive, isIncomplete, false, DirNone) {
+			for content := range clnt.List(ctx, isRecursive, isIncomplete, false, DirNone) {
 				objectsCh <- content
 			}
 		}()
@@ -168,7 +169,7 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 		}
 
 		// Generate share URL.
-		shareURL, err := newClnt.ShareDownload(expiry)
+		shareURL, err := newClnt.ShareDownload(ctx, expiry)
 		if err != nil {
 			// add objectURL and expiry as part of the trace arguments.
 			return err.Trace(objectURL, "expiry="+expiry.String())
@@ -190,13 +191,16 @@ func doShareDownloadURL(targetURL string, isRecursive bool, expiry time.Duration
 }
 
 // main for share download.
-func mainShareDownload(ctx *cli.Context) error {
+func mainShareDownload(cliCtx *cli.Context) error {
+	ctx, cancelShareDownload := context.WithCancel(globalContext)
+	defer cancelShareDownload()
+
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check input arguments.
-	checkShareDownloadSyntax(ctx, encKeyDB)
+	checkShareDownloadSyntax(cliCtx, encKeyDB)
 
 	// Initialize share config folder.
 	initShareConfig()
@@ -205,16 +209,16 @@ func mainShareDownload(ctx *cli.Context) error {
 	shareSetColor()
 
 	// Set command flags from context.
-	isRecursive := ctx.Bool("recursive")
+	isRecursive := cliCtx.Bool("recursive")
 	expiry := shareDefaultExpiry
-	if ctx.String("expire") != "" {
+	if cliCtx.String("expire") != "" {
 		var e error
-		expiry, e = time.ParseDuration(ctx.String("expire"))
-		fatalIf(probe.NewError(e), "Unable to parse expire=`"+ctx.String("expire")+"`.")
+		expiry, e = time.ParseDuration(cliCtx.String("expire"))
+		fatalIf(probe.NewError(e), "Unable to parse expire=`"+cliCtx.String("expire")+"`.")
 	}
 
-	for _, targetURL := range ctx.Args() {
-		err := doShareDownloadURL(targetURL, isRecursive, expiry)
+	for _, targetURL := range cliCtx.Args() {
+		err := doShareDownloadURL(ctx, targetURL, isRecursive, expiry)
 		if err != nil {
 			switch err.ToGoError().(type) {
 			case APINotImplemented:

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -67,15 +67,15 @@ EXAMPLES:
 }
 
 // checkShareDownloadSyntax - validate command-line args.
-func checkShareDownloadSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
-	args := ctx.Args()
+func checkShareDownloadSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
+	args := cliCtx.Args()
 	if !args.Present() {
-		cli.ShowCommandHelpAndExit(ctx, "download", 1) // last argument is exit code.
+		cli.ShowCommandHelpAndExit(cliCtx, "download", 1) // last argument is exit code.
 	}
 
 	// Parse expiry.
 	expiry := shareDefaultExpiry
-	expireArg := ctx.String("expire")
+	expireArg := cliCtx.String("expire")
 	if expireArg != "" {
 		var e error
 		expiry, e = time.ParseDuration(expireArg)
@@ -91,10 +91,10 @@ func checkShareDownloadSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEP
 	}
 
 	// Validate if object exists only if the `--recursive` flag was NOT specified
-	isRecursive := ctx.Bool("recursive")
+	isRecursive := cliCtx.Bool("recursive")
 	if !isRecursive {
-		for _, url := range ctx.Args() {
-			_, _, err := url2Stat(url, false, encKeyDB)
+		for _, url := range cliCtx.Args() {
+			_, _, err := url2Stat(ctx, url, false, encKeyDB)
 			if err != nil {
 				fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 			}
@@ -200,7 +200,7 @@ func mainShareDownload(cliCtx *cli.Context) error {
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check input arguments.
-	checkShareDownloadSyntax(cliCtx, encKeyDB)
+	checkShareDownloadSyntax(ctx, cliCtx, encKeyDB)
 
 	// Initialize share config folder.
 	initShareConfig()

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -35,8 +35,10 @@ func trapSignals(sig ...os.Signal) {
 	<-sigCh
 
 	// Once signal has been received stop signal Notify handler.
+
 	signal.Stop(sigCh)
 
 	// Cancel the global context
 	globalCancel()
+
 }

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -309,7 +309,7 @@ func getCSVHeader(sourceURL string, encKeyDB map[string][]prefixSSEPair) ([]stri
 	default:
 		var err *probe.Error
 		var metadata map[string]string
-		if r, metadata, err = getSourceStreamMetadataFromURL(context.Background(), sourceURL, encKeyDB); err != nil {
+		if r, metadata, err = getSourceStreamMetadataFromURL(globalContext, sourceURL, encKeyDB); err != nil {
 			return nil, err.Trace(sourceURL)
 		}
 		ctype := metadata["Content-Type"]
@@ -471,7 +471,7 @@ func mainSQL(cliCtx *cli.Context) error {
 			continue
 		}
 
-		for content := range clnt.List(globalContext, cliCtx.Bool("recursive"), false, false, DirNone) {
+		for content := range clnt.List(ctx, cliCtx.Bool("recursive"), false, false, DirNone) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(url), "Unable to list on target `"+url+"`.")
 				continue

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -434,28 +434,31 @@ func checkSQLSyntax(ctx *cli.Context) {
 }
 
 // mainSQL is the main entry point for sql command.
-func mainSQL(ctx *cli.Context) error {
+func mainSQL(cliCtx *cli.Context) error {
+	ctx, cancelSQL := context.WithCancel(globalContext)
+	defer cancelSQL()
+
 	var (
 		csvHdrs []string
 		selOpts SelectObjectOpts
 		query   string
 	)
 	// Parse encryption keys per command.
-	encKeyDB, err := getEncKeys(ctx)
+	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// validate sql input arguments.
-	checkSQLSyntax(ctx)
+	checkSQLSyntax(cliCtx)
 	// extract URLs.
-	URLs := ctx.Args()
+	URLs := cliCtx.Args()
 	writeHdr := true
 	for _, url := range URLs {
-		if _, targetContent, err := url2Stat(url, false, encKeyDB); err != nil {
+		if _, targetContent, err := url2Stat(ctx, url, false, encKeyDB); err != nil {
 			errorIf(err.Trace(url), "Unable to run sql for "+url+".")
 			continue
 		} else if !targetContent.Type.IsDir() {
 			if writeHdr {
-				query, csvHdrs, selOpts = getAndValidateArgs(ctx, encKeyDB, url)
+				query, csvHdrs, selOpts = getAndValidateArgs(cliCtx, encKeyDB, url)
 			}
 			errorIf(sqlSelect(url, query, encKeyDB, selOpts, csvHdrs, writeHdr).Trace(url), "Unable to run sql")
 			writeHdr = false
@@ -468,13 +471,13 @@ func mainSQL(ctx *cli.Context) error {
 			continue
 		}
 
-		for content := range clnt.List(globalContext, ctx.Bool("recursive"), false, false, DirNone) {
+		for content := range clnt.List(globalContext, cliCtx.Bool("recursive"), false, false, DirNone) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(url), "Unable to list on target `"+url+"`.")
 				continue
 			}
 			if writeHdr {
-				query, csvHdrs, selOpts = getAndValidateArgs(ctx, encKeyDB, targetAlias+content.URL.Path)
+				query, csvHdrs, selOpts = getAndValidateArgs(cliCtx, encKeyDB, targetAlias+content.URL.Path)
 			}
 			contentType := mimedb.TypeByExtension(filepath.Ext(content.URL.Path))
 			for _, cTypeSuffix := range supportedContentTypes {

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -74,23 +74,23 @@ EXAMPLES:
 }
 
 // checkStatSyntax - validate all the passed arguments
-func checkStatSyntax(ctx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
-	if !ctx.Args().Present() {
-		cli.ShowCommandHelpAndExit(ctx, "stat", 1) // last argument is exit code
+func checkStatSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string][]prefixSSEPair) {
+	if !cliCtx.Args().Present() {
+		cli.ShowCommandHelpAndExit(cliCtx, "stat", 1) // last argument is exit code
 	}
 
-	args := ctx.Args()
+	args := cliCtx.Args()
 	for _, arg := range args {
 		if strings.TrimSpace(arg) == "" {
 			fatalIf(errInvalidArgument().Trace(args...), "Unable to validate empty argument.")
 		}
 	}
 	// extract URLs.
-	URLs := ctx.Args()
+	URLs := cliCtx.Args()
 	isIncomplete := false
 
 	for _, url := range URLs {
-		_, _, err := url2Stat(url, false, encKeyDB)
+		_, _, err := url2Stat(ctx, url, false, encKeyDB)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 		}
@@ -114,7 +114,7 @@ func mainStat(cliCtx *cli.Context) error {
 	fatalIf(err, "Unable to parse encryption keys.")
 
 	// check 'stat' cli arguments.
-	checkStatSyntax(cliCtx, encKeyDB)
+	checkStatSyntax(ctx, cliCtx, encKeyDB)
 
 	// Set command flags from context.
 	isRecursive := cliCtx.Bool("recursive")

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -127,7 +128,7 @@ func getStandardizedURL(targetURL string) string {
 }
 
 // statURL - simple or recursive listing
-func statURL(targetURL string, isIncomplete, isRecursive bool, encKeyDB map[string][]prefixSSEPair) ([]*ClientContent, *probe.Error) {
+func statURL(ctx context.Context, targetURL string, isIncomplete, isRecursive bool, encKeyDB map[string][]prefixSSEPair) ([]*ClientContent, *probe.Error) {
 	var stats []*ClientContent
 	var clnt Client
 	clnt, err := newClient(targetURL)
@@ -143,7 +144,7 @@ func statURL(targetURL string, isIncomplete, isRecursive bool, encKeyDB map[stri
 		prefixPath = prefixPath[:strings.LastIndex(prefixPath, separator)+1]
 	}
 	var cErr error
-	for content := range clnt.List(isRecursive, isIncomplete, false, DirNone) {
+	for content := range clnt.List(ctx, isRecursive, isIncomplete, false, DirNone) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {
 			// handle this specifically for filesystem related errors.

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -177,7 +177,7 @@ func statURL(ctx context.Context, targetURL string, isIncomplete, isRecursive bo
 			return nil, errTargetNotFound(targetURL).Trace(url, standardizedURL)
 		}
 
-		_, stat, err := url2Stat(url, true, encKeyDB)
+		_, stat, err := url2Stat(ctx, url, true, encKeyDB)
 		if err != nil {
 			stat = content
 		}

--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -100,16 +101,19 @@ func (t tagListMessage) String() string {
 	return strings.Join(strs, "\n")
 }
 
-func mainListTag(ctx *cli.Context) error {
-	if len(ctx.Args()) != 1 {
-		cli.ShowCommandHelpAndExit(ctx, "list", globalErrorExitStatus)
+func mainListTag(cliCtx *cli.Context) error {
+	ctx, cancelListTag := context.WithCancel(globalContext)
+	defer cancelListTag()
+
+	if len(cliCtx.Args()) != 1 {
+		cli.ShowCommandHelpAndExit(cliCtx, "list", globalErrorExitStatus)
 	}
 
-	targetURL := ctx.Args().Get(0)
+	targetURL := cliCtx.Args().Get(0)
 	clnt, err := newClient(targetURL)
 	fatalIf(err, "Unable to initialize target "+targetURL)
 
-	tags, err := clnt.GetTags()
+	tags, err := clnt.GetTags(ctx)
 	fatalIf(err, "Unable to fetch tags for "+targetURL)
 
 	tagMap := tags.ToMap()

--- a/cmd/tag-remove.go
+++ b/cmd/tag-remove.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	json "github.com/minio/mc/pkg/colorjson"
@@ -74,15 +76,18 @@ func checkRemoveTagSyntax(ctx *cli.Context) {
 	}
 }
 
-func mainRemoveTag(ctx *cli.Context) error {
-	checkRemoveTagSyntax(ctx)
+func mainRemoveTag(cliCtx *cli.Context) error {
+	ctx, cancelList := context.WithCancel(globalContext)
+	defer cancelList()
+
+	checkRemoveTagSyntax(cliCtx)
 
 	console.SetColor("Remove", color.New(color.FgGreen))
 
-	targetURL := ctx.Args().Get(0)
+	targetURL := cliCtx.Args().Get(0)
 	clnt, pErr := newClient(targetURL)
 	fatalIf(pErr, "Unable to initialize target "+targetURL)
-	pErr = clnt.DeleteTags()
+	pErr = clnt.DeleteTags(ctx)
 	fatalIf(pErr, "Unable to remove tags for "+targetURL)
 
 	printMsg(tagRemoveMessage{

--- a/cmd/tag-set.go
+++ b/cmd/tag-set.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	json "github.com/minio/mc/pkg/colorjson"
@@ -75,17 +77,20 @@ func checkSetTagSyntax(ctx *cli.Context) {
 	}
 }
 
-func mainSetTag(ctx *cli.Context) error {
-	checkSetTagSyntax(ctx)
+func mainSetTag(cliCtx *cli.Context) error {
+	ctx, cancelSetTag := context.WithCancel(globalContext)
+	defer cancelSetTag()
+
+	checkSetTagSyntax(cliCtx)
 	console.SetColor("List", color.New(color.FgGreen))
 
-	targetURL := ctx.Args().Get(0)
-	tags := ctx.Args().Get(1)
+	targetURL := cliCtx.Args().Get(0)
+	tags := cliCtx.Args().Get(1)
 
 	clnt, err := newClient(targetURL)
-	fatalIf(err.Trace(ctx.Args()...), "Unable to initialize target "+targetURL)
+	fatalIf(err.Trace(cliCtx.Args()...), "Unable to initialize target "+targetURL)
 
-	fatalIf(clnt.SetTags(tags).Trace(tags), "Failed to set tags for "+targetURL)
+	fatalIf(clnt.SetTags(ctx, tags).Trace(tags), "Failed to set tags for "+targetURL)
 
 	printMsg(tagSetMessage{
 		Status: "success",

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -127,7 +127,7 @@ func checkTreeSyntax(ctx context.Context, cliCtx *cli.Context) {
 }
 
 // doTree - list all entities inside a folder in a tree format.
-func doTree(url string, level int, leaf bool, branchString string, depth int, includeFiles bool) error {
+func doTree(ctx context.Context, url string, level int, leaf bool, branchString string, depth int, includeFiles bool) error {
 
 	targetAlias, targetURL, _ := mustExpandAlias(url)
 	if !strings.HasSuffix(targetURL, "/") {
@@ -207,7 +207,7 @@ func doTree(url string, level int, leaf bool, branchString string, depth int, in
 			}
 
 			if depth == -1 || level <= depth {
-				if err := doTree(url, level+1, end, currbranchString, depth, includeFiles); err != nil {
+				if err := doTree(ctx, url, level+1, end, currbranchString, depth, includeFiles); err != nil {
 					return err
 				}
 			}
@@ -216,7 +216,7 @@ func doTree(url string, level int, leaf bool, branchString string, depth int, in
 		return nil
 	}
 
-	for content := range clnt.List(globalContext, false, false, false, DirNone) {
+	for content := range clnt.List(ctx, false, false, false, DirNone) {
 
 		if !includeFiles && !content.Type.IsDir() {
 			continue
@@ -268,7 +268,7 @@ func mainTree(cliCtx *cli.Context) error {
 	var cErr error
 	for _, targetURL := range args {
 		if !globalJSON {
-			if e := doTree(targetURL, 1, false, "", depth, includeFiles); e != nil {
+			if e := doTree(ctx, targetURL, 1, false, "", depth, includeFiles); e != nil {
 				cErr = e
 			}
 		} else {

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -157,8 +158,11 @@ func mainWatch(ctx *cli.Context) error {
 		Suffix:    suffix,
 	}
 
+	ctxt, cancelWatch := context.WithCancel(globalContext)
+	defer cancelWatch()
+
 	// Start watching on events
-	wo, err := s3Client.Watch(options)
+	wo, err := s3Client.Watch(ctxt, options)
 	fatalIf(err, "Cannot watch on the specified bucket.")
 
 	// Initialize.. waitgroup to track the go-routine.

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -130,21 +130,21 @@ func (u watchMessage) String() string {
 	return msg
 }
 
-func mainWatch(ctx *cli.Context) error {
+func mainWatch(cliCtx *cli.Context) error {
 	console.SetColor("Time", color.New(color.FgGreen))
 	console.SetColor("Size", color.New(color.FgYellow))
 	console.SetColor("EventType", color.New(color.FgCyan, color.Bold))
 	console.SetColor("ObjectName", color.New(color.Bold))
 
-	checkWatchSyntax(ctx)
+	checkWatchSyntax(cliCtx)
 
-	args := ctx.Args()
+	args := cliCtx.Args()
 	path := args[0]
 
-	prefix := ctx.String("prefix")
-	suffix := ctx.String("suffix")
-	events := strings.Split(ctx.String("events"), ",")
-	recursive := ctx.Bool("recursive")
+	prefix := cliCtx.String("prefix")
+	suffix := cliCtx.String("suffix")
+	events := strings.Split(cliCtx.String("events"), ",")
+	recursive := cliCtx.Bool("recursive")
 
 	s3Client, pErr := newClient(path)
 	if pErr != nil {
@@ -158,11 +158,11 @@ func mainWatch(ctx *cli.Context) error {
 		Suffix:    suffix,
 	}
 
-	ctxt, cancelWatch := context.WithCancel(globalContext)
+	ctx, cancelWatch := context.WithCancel(globalContext)
 	defer cancelWatch()
 
 	// Start watching on events
-	wo, err := s3Client.Watch(ctxt, options)
+	wo, err := s3Client.Watch(ctx, options)
 	fatalIf(err, "Cannot watch on the specified bucket.")
 
 	// Initialize.. waitgroup to track the go-routine.

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -140,8 +141,8 @@ func (w *Watcher) Wait() {
 }
 
 // Join the watcher with client
-func (w *Watcher) Join(client Client, recursive bool) *probe.Error {
-	wo, err := client.Watch(WatchOptions{
+func (w *Watcher) Join(ctx context.Context, client Client, recursive bool) *probe.Error {
+	wo, err := client.Watch(ctx, WatchOptions{
 		Recursive: recursive,
 		Events:    []string{"put", "delete"},
 	})

--- a/go.mod
+++ b/go.mod
@@ -32,4 +32,7 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.5
 	gopkg.in/ini.v1 v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
+
 )
+
+replace github.com/minio/minio-go/v6 => ../minio-go

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.5 // indirect
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio v0.0.0-20200527010300-cccf2de129da
-	github.com/minio/minio-go/v6 v6.0.56-0.20200522164946-44a5f2e3b76b
+	github.com/minio/minio-go/v6 v6.0.58-0.20200612001654-a57fec8037ec
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/profile v1.3.0
@@ -32,7 +32,4 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.5
 	gopkg.in/ini.v1 v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8
-
 )
-
-replace github.com/minio/minio-go/v6 => ../minio-go

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,7 @@ github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eT
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.2 h1:1xAgYebNnsb9LKCdLOvFWtAxGU/33mjJtyOVbmUa0Us=
 github.com/klauspost/cpuid v1.2.2/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.4 h1:EBfaK0SWSwk+fgk6efYFWdzl8MwRWoOO1gkmiaTXPW4=
 github.com/klauspost/cpuid v1.2.4/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM=
@@ -273,6 +274,8 @@ github.com/minio/highwayhash v1.0.0 h1:iMSDhgUILCr0TNm8LWlSjF8N0ZIj2qbO8WHp6Q/J2
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
 github.com/minio/lsync v1.0.1 h1:AVvILxA976xc27hstd1oR+X9PQG0sPSom1MNb1ImfUs=
 github.com/minio/lsync v1.0.1/go.mod h1:tCFzfo0dlvdGl70IT4IAK/5Wtgb0/BrTmo/jE8pArKA=
+github.com/minio/md5-simd v1.1.0 h1:QPfiOqlZH+Cj9teu0t9b1nTBfPbyTl16Of5MeuShdK4=
+github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/minio v0.0.0-20200421050159-282c9f790a03 h1:qEWJAXNbLp1Uovs9gzPQ8gWGFY8X+58WcttySAMgny0=
 github.com/minio/minio v0.0.0-20200421050159-282c9f790a03/go.mod h1:zBua5AiljGs1Irdl2XEyiJjvZVCVDIG8gjozzRBcVlw=
 github.com/minio/minio v0.0.0-20200506184406-a2ccba69e563 h1:1HoqFH4py7JBKeLkKtPUrL8CsrucHsUcvrvyrisPgtA=
@@ -286,6 +289,8 @@ github.com/minio/minio-go/v6 v6.0.56-0.20200502013257-a81c8c13cc3f h1:ifHrI8+exq
 github.com/minio/minio-go/v6 v6.0.56-0.20200502013257-a81c8c13cc3f/go.mod h1:KQMM+/44DSlSGSQWSfRrAZ12FVMmpWNuX37i2AX0jfI=
 github.com/minio/minio-go/v6 v6.0.56-0.20200522164946-44a5f2e3b76b h1:hY8tAl7MwUuUB9ZqVDXEnrIqCuEy3dfU1RH0cZ7gu+o=
 github.com/minio/minio-go/v6 v6.0.56-0.20200522164946-44a5f2e3b76b/go.mod h1:KQMM+/44DSlSGSQWSfRrAZ12FVMmpWNuX37i2AX0jfI=
+github.com/minio/minio-go/v6 v6.0.58-0.20200612001654-a57fec8037ec h1:my1ShPzUyV5BSteRVdm/YoEhd4ycLImlN4xDX17pd8A=
+github.com/minio/minio-go/v6 v6.0.58-0.20200612001654-a57fec8037ec/go.mod h1:5+R/nM9Pwrh0vqF+HbYYDQ84wdUFPyXHkrdT4AIkifM=
 github.com/minio/parquet-go v0.0.0-20200414234858-838cfa8aae61 h1:pUSI/WKPdd77gcuoJkSzhJ4wdS8OMDOsOu99MtpXEQA=
 github.com/minio/parquet-go v0.0.0-20200414234858-838cfa8aae61/go.mod h1:4trzEJ7N1nBTd5Tt7OCZT5SEin+WiAXpdJ/WgPkESA8=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=


### PR DESCRIPTION
This effort started with `mc ls <alias>` command issue, where user needed to hit CTRL-C twice to interrupt the command. 

The global context needed to be applied for `ls` and all other apis to have a complete solution.

There will be also a minio-go side fix that goes along with this effort. I'll also create that PR.

One manifestation of not using/having global context used by apis is the need for CTRL-C to be hit twice when the user wants the interrupt the api.

Example:
- Run `mc ls <alias>` when there is no MinIO server running. You CTRL-C once and the command will keep running until the second CTRL-C