### PR TITLE
Fix policy command flags order online help and partially doc

### DIFF
--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -51,11 +51,11 @@ var policyCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} set [FLAGS] PERMISSION TARGET
-  {{.HelpName}} set-json [FLAGS] FILE TARGET
-  {{.HelpName}} get [FLAGS] TARGET
-  {{.HelpName}} get-json [FLAGS] TARGET
-  {{.HelpName}} list [FLAGS] TARGET
+  {{.HelpName}} [FLAGS] set PERMISSION TARGET
+  {{.HelpName}} [FLAGS] set-json FILE TARGET
+  {{.HelpName}} [FLAGS] get TARGET
+  {{.HelpName}} [FLAGS] get-json TARGET
+  {{.HelpName}} [FLAGS] list TARGET
 {{if .VisibleFlags}}
 FLAGS:
   {{range .VisibleFlags}}{{.}}

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -1226,7 +1226,7 @@ USAGE:
   mc policy [FLAGS] set-json FILE TARGET
   mc policy [FLAGS] get TARGET
   mc policy [FLAGS] get-json TARGET
-  mc policy list [FLAGS] TARGET
+  mc policy [FLAGS] list TARGET
 
 PERMISSION:
   Allowed policies are: [none, download, upload, public].


### PR DESCRIPTION
The online help (and partially, just for one command, also the documentation) states that the `FLAGS` passed to the policy command should be passed after the subcommand, but that actually fails, ie.:

> ./mc policy list --no-color minio/foobar
> Name:
>   mc policy - manage anonymous access to buckets and objects
> 
> USAGE:
>   mc policy set [FLAGS] PERMISSION TARGET
>   mc policy set-json [FLAGS] FILE TARGET
>   mc policy get [FLAGS] TARGET
>   mc policy get-json [FLAGS] TARGET
>   mc policy list [FLAGS] TARGET

While passing the flags before the subcommand works correctly:

> ./mc policy --no-color list minio/foobar
> foobar/* => readwrite

This PR fixes the help message and documentation (just for list, for the others was already correct) to indicate the correct syntax.