### PR TITLE
cp: Fix Windows paths

### DIFF
--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -201,7 +201,7 @@ func makeCopyContentTypeC(sourceAlias string, sourceURL ClientURL, sourceContent
 				return URLs{Error: probe.NewError(err)}
 			}
 			if fileInfo.IsDir() {
-				sourcePrefix = sourceURL.Path
+				sourcePrefix = filepath.ToSlash(sourceURL.Path)
 			}
 		}
 		newSourceSuffix = strings.TrimPrefix(newSourceSuffix, sourcePrefix)


### PR DESCRIPTION
Paths without `/` separator were not trimmed correctly.

Fixes #3241

Regression originating from #3115