### PR TITLE
Fix `mc cp` when legal-hold or retention is set

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -478,7 +478,7 @@ func doCopySession(cli *cli.Context, session *sessionV8, encKeyDB map[string][]p
 						cpURLs.TargetContent.RetentionEnabled = true
 					}
 					cpURLs.TargetContent.RetentionDuration = session.Header.CommandStringFlags[rdFlag]
-					cpURLs.TargetContent.LegalHold = session.Header.CommandStringFlags[lhFlag]
+					cpURLs.TargetContent.LegalHold = strings.ToUpper(session.Header.CommandStringFlags[lhFlag])
 					if cpURLs.TargetContent.LegalHold != "" {
 						cpURLs.TargetContent.LegalHoldEnabled = true
 					}
@@ -491,7 +491,7 @@ func doCopySession(cli *cli.Context, session *sessionV8, encKeyDB map[string][]p
 						cpURLs.TargetContent.RetentionDuration = rd
 					}
 					if lh := cli.String(lhFlag); lh != "" {
-						cpURLs.TargetContent.LegalHold = lh
+						cpURLs.TargetContent.LegalHold = strings.ToUpper(lh)
 						cpURLs.TargetContent.LegalHoldEnabled = true
 					}
 				}
@@ -642,7 +642,7 @@ func mainCopy(ctx *cli.Context) error {
 	storageClass := ctx.String("storage-class")
 	retentionMode := ctx.String(rmFlag)
 	retentionDuration := ctx.String(rdFlag)
-	legalHold := ctx.String(lhFlag)
+	legalHold := strings.ToUpper(ctx.String(lhFlag))
 	sseKeys := os.Getenv("MC_ENCRYPT_KEY")
 	if key := ctx.String("encrypt-key"); key != "" {
 		sseKeys = key


### PR DESCRIPTION
- to require Content-MD5 header
- legal-hold needs to be upper cased.


Try a `mc cp` with legal-hold / retention flags or a regular `mc cp` on a bucket with object lock default configuration against s3 endpoint. You will see an error requiring Content-MD5 header.
```
mc cp /etc/issue s3/kannappan402 --legal-hold ON
mc: <ERROR> Failed to copy `/etc/issue`. Content-MD5 HTTP header is required for Put Object requests with Object Lock parameters
mc cp --legal-hold on /etc/hostname s3/kannappan402
mc: <ERROR> Failed to copy `/etc/hostname`. Invalid arguments provided, please refer `mc <command> -h` for relevant documentation.

```