### PR TITLE
Stops looping when api is notImplemented

### DIFF
--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -341,7 +341,15 @@ func difference(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, t
 			if err != nil {
 				// handle this specifically for filesystem related errors.
 				switch err.ToGoError().(type) {
-				case PathNotFound, PathInsufficientPermission:
+				case PathNotFound, PathInsufficientPermission, APINotImplemented:
+					diffCh <- diffMessage{
+						Error: err,
+					}
+					return
+				}
+
+				stopAtErr := "A header or query you provided requested a function that is not implemented."
+				if strings.Contains(err.String(), stopAtErr) {
 					diffCh <- diffMessage{
 						Error: err,
 					}


### PR DESCRIPTION
Fixes #3237
mc mirror fails for GCS, since GCS is not compatible with Amazon S3. So, some apis like Stat, List etc. fails with `notImplemented` error message:
`"A header or query you provided requested a function that is not implemented."`

During `mc mirror`, we hit the same `notImplemented` issue for `Stat` api, and continue to `Compare` to check if there is a difference between source and destination. We loop for 30 seconds meaninglessly even though we hit the `notImplemented` error message. 
So, the fix is to stop trying as soon as we hit `notImplemented` condition.
