### PR TITLE
make sure active/active enables watch by default

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -381,11 +381,11 @@ func getAllMetadata(ctx context.Context, sourceAlias, sourceURLStr string, srcSS
 	}
 
 	for k, v := range st.Metadata {
-		metadata[k] = v
+		metadata[http.CanonicalHeaderKey(k)] = v
 	}
 
 	for k, v := range urls.TargetContent.UserMetadata {
-		metadata[k] = v
+		metadata[http.CanonicalHeaderKey(k)] = v
 	}
 
 	return filterMetadata(metadata), nil
@@ -462,19 +462,20 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 			}
 		}
 
+		// Get metadata from target content as well
+		for k, v := range urls.TargetContent.Metadata {
+			metadata[http.CanonicalHeaderKey(k)] = v
+		}
+
+		// Get userMetadata from target content as well
+		for k, v := range urls.TargetContent.UserMetadata {
+			metadata[http.CanonicalHeaderKey(k)] = v
+		}
+
 		sourcePath := filepath.ToSlash(sourceURL.Path)
 		if urls.SourceContent.RetentionEnabled {
 			err = putTargetRetention(ctx, targetAlias, targetURL.String(), metadata)
 			return urls.WithError(err.Trace(sourceURL.String()))
-		}
-
-		// Get metadata from target content as well
-		for k, v := range urls.TargetContent.Metadata {
-			metadata[k] = v
-		}
-		// Get userMetadata from target content as well
-		for k, v := range urls.TargetContent.UserMetadata {
-			metadata[k] = v
 		}
 
 		err = copySourceToTargetURL(ctx, targetAlias, targetURL.String(), sourcePath, mode, until,
@@ -490,9 +491,20 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 				}
 			}
 
+			// Get metadata from target content as well
+			for k, v := range urls.TargetContent.Metadata {
+				metadata[http.CanonicalHeaderKey(k)] = v
+			}
+
+			// Get userMetadata from target content as well
+			for k, v := range urls.TargetContent.UserMetadata {
+				metadata[http.CanonicalHeaderKey(k)] = v
+			}
+
 			err = putTargetRetention(ctx, targetAlias, targetURL.String(), metadata)
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}
+
 		var reader io.ReadCloser
 		// Proceed with regular stream copy.
 		reader, metadata, err = getSourceStream(ctx, sourceAlias, sourceURL.String(), true, srcSSE, preserve)
@@ -503,11 +515,12 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 
 		// Get metadata from target content as well
 		for k, v := range urls.TargetContent.Metadata {
-			metadata[k] = v
+			metadata[http.CanonicalHeaderKey(k)] = v
 		}
+
 		// Get userMetadata from target content as well
 		for k, v := range urls.TargetContent.UserMetadata {
-			metadata[k] = v
+			metadata[http.CanonicalHeaderKey(k)] = v
 		}
 
 		if isReadAt(reader) {

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -149,7 +149,7 @@ func checkDiffSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 }
 
 // doDiffMain runs the diff.
-func doDiffMain(firstURL, secondURL string) error {
+func doDiffMain(ctx context.Context, firstURL, secondURL string) error {
 	// Source and targets are always directories
 	sourceSeparator := string(newClientURL(firstURL).Separator)
 	if !strings.HasSuffix(firstURL, sourceSeparator) {
@@ -177,7 +177,7 @@ func doDiffMain(firstURL, secondURL string) error {
 	}
 
 	// Diff first and second urls.
-	for diffMsg := range objectDifference(firstClient, secondClient, firstURL, secondURL, false) {
+	for diffMsg := range objectDifference(ctx, firstClient, secondClient, firstURL, secondURL, true) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
 			// Ignore error and proceed to next object.
@@ -214,5 +214,5 @@ func mainDiff(cliCtx *cli.Context) error {
 	firstURL := URLs.Get(0)
 	secondURL := URLs.Get(1)
 
-	return doDiffMain(firstURL, secondURL)
+	return doDiffMain(ctx, firstURL, secondURL)
 }


### PR DESCRIPTION
- effectively use context everywhere
- effectively look for source-mtime in all
  variations
- `mc diff` should do metadata diff as well