### PR TITLE
s3: Use list object v1 in case of GCS

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1325,7 +1325,7 @@ func (c *S3Client) listObjectWrapper(ctx context.Context, bucket, object string,
 	if isGoogle(c.targetURL.Host) {
 		// Google Cloud S3 layer doesn't implement ListObjectsV2 implementation
 		// https://github.com/minio/mc/issues/3073
-		return c.api.ListObjectsV2WithContext(ctx, bucket, object, isRecursive, doneCh)
+		return c.api.ListObjectsWithContext(ctx, bucket, object, isRecursive, doneCh)
 	}
 	if metadata {
 		return c.api.ListObjectsV2WithMetadataWithContext(ctx, bucket, object, isRecursive, doneCh)


### PR DESCRIPTION
Listing objects V2 was mistakenly used in case of GCS. Revert it.

Fixes https://github.com/minio/mc/issues/3273