### PR TITLE
Removes already added UserMetadata during copy

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -444,9 +444,6 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 		legalHold = urls.TargetContent.LegalHold
 	}
 
-	for k, v := range urls.SourceContent.UserMetadata {
-		metadata[http.CanonicalHeaderKey(k)] = v
-	}
 	for k, v := range urls.SourceContent.Metadata {
 		metadata[http.CanonicalHeaderKey(k)] = v
 	}


### PR DESCRIPTION
Copying an object with user defined metadata on the same server fails with:
```
mc: <ERROR> Failed to copy `https://play.minio.io:9000/test/test`. Cannot add both Sss and x-amz-meta-Sss keys as custom metadata
```
That is because we try to copy the same metadata information twice, as user defined metadata raw name, `Sss`, and as already converted and added into metadata with the standard name, `x-amz-meta-Sss`.

So, the fix is to  eliminate the user defined raw metadata name from the metadata list.
This change needs to be tested and reviewed for a possible regression risk.