### PR TITLE
Fix `mc cp` regression for recursive copy

### DIFF
--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -193,18 +192,6 @@ func makeCopyContentTypeC(sourceAlias string, sourceURL ClientURL, sourceContent
 	newSourceSuffix := filepath.ToSlash(newSourceURL.Path)
 	if pathSeparatorIndex > 1 {
 		sourcePrefix := filepath.ToSlash(sourceURL.Path[:pathSeparatorIndex])
-		// do not preserve unix cp behavior when copying a filesytem dir to
-		// objectstore.
-		if sourceAlias == "" && targetAlias != "" {
-			// Check if sourceURL.Path is a directory or not
-			fileInfo, err := os.Stat(sourceURL.Path)
-			if err != nil {
-				return URLs{Error: probe.NewError(err)}
-			}
-			if fileInfo.IsDir() {
-				sourcePrefix = filepath.ToSlash(sourceURL.Path)
-			}
-		}
 		newSourceSuffix = strings.TrimPrefix(newSourceSuffix, sourcePrefix)
 	}
 	newTargetURL := urlJoinPath(targetURL, newSourceSuffix)


### PR DESCRIPTION
Fixes #3267. Revert commit dc430afe07f5ce09b06055477cc5370e50e2f45b
which attempted to preserve similar behavior across mc cp and mc
mirror, but introduces a regression for cp when wildcards are
specified.

This PR reverts back to original unix style cp behavior.