### PR TITLE
policy: Recalculate permission mode after setting a new one

### DIFF
--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -437,8 +437,11 @@ func runPolicyCmd(args cli.Args) {
 	perms := accessPerms(args.Get(1))
 	targetURL := args.Get(2)
 	if perms.isValidAccessPERM() {
-		probeErr = doSetAccess(ctx, targetURL, perms)
 		operation = "set"
+		probeErr = doSetAccess(ctx, targetURL, perms)
+		if probeErr == nil {
+			perms, _, probeErr = doGetAccess(ctx, targetURL)
+		}
 	} else if perms.isValidAccessFile() {
 		probeErr = doSetAccessJSON(ctx, targetURL, perms)
 		operation = "set-json"


### PR DESCRIPTION
`mc policy set` can confuse users by showing that a bucket has 'none'
policy mode although issuing `mc policy get` will show it is 'custom'

This happens when a bucket already have other policy statements 
for some sub-resources.

For better UX, mc will issue another request to get the real policy
mode.