### PR TITLE
cli: Load global flags in initBeforeRunningCmd

### DIFF
--- a/cmd/admin-bucket-quota.go
+++ b/cmd/admin-bucket-quota.go
@@ -77,7 +77,7 @@ var adminBucketQuotaCmd = cli.Command{
 	Name:   "quota",
 	Usage:  "Manage bucket quota",
 	Action: mainAdminBucketQuota,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(adminQuotaFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
    {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-bucket.go
+++ b/cmd/admin-bucket.go
@@ -22,7 +22,6 @@ var adminBucketCmd = cli.Command{
 	Name:   "bucket",
 	Usage:  "manage buckets defined in the MinIO server",
 	Action: mainAdminBucket,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminBucketQuotaCmd,

--- a/cmd/admin-config-export.go
+++ b/cmd/admin-config-export.go
@@ -25,7 +25,7 @@ import (
 var adminConfigExportCmd = cli.Command{
 	Name:   "export",
 	Usage:  "export all config keys to STDOUT",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigExport,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -27,7 +27,7 @@ import (
 var adminConfigGetCmd = cli.Command{
 	Name:   "get",
 	Usage:  "interactively retrieve a config key parameters",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigGet,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config-history.go
+++ b/cmd/admin-config-history.go
@@ -43,7 +43,7 @@ var historyListFlags = []cli.Flag{
 var adminConfigHistoryCmd = cli.Command{
 	Name:   "history",
 	Usage:  "show all historic configuration changes",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigHistory,
 	Flags:  append(append([]cli.Flag{}, globalFlags...), historyListFlags...),
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config-import.go
+++ b/cmd/admin-config-import.go
@@ -30,7 +30,7 @@ import (
 var adminConfigImportCmd = cli.Command{
 	Name:   "import",
 	Usage:  "import multiple config keys from STDIN",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigImport,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config-reset.go
+++ b/cmd/admin-config-reset.go
@@ -37,7 +37,7 @@ var adminConfigEnvFlags = []cli.Flag{
 var adminConfigResetCmd = cli.Command{
 	Name:   "reset",
 	Usage:  "interactively reset a config key parameters",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigReset,
 	Flags:  append(adminConfigEnvFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config-restore.go
+++ b/cmd/admin-config-restore.go
@@ -29,7 +29,7 @@ import (
 var adminConfigRestoreCmd = cli.Command{
 	Name:   "restore",
 	Usage:  "rollback back changes to a specific config history",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigRestore,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config-set.go
+++ b/cmd/admin-config-set.go
@@ -31,7 +31,7 @@ import (
 var adminConfigSetCmd = cli.Command{
 	Name:   "set",
 	Usage:  "interactively set a config key parameters",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminConfigSet,
 	Flags:  append(adminConfigEnvFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -22,7 +22,6 @@ var adminConfigCmd = cli.Command{
 	Name:   "config",
 	Usage:  "manage MinIO server configuration",
 	Action: mainAdminConfig,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminConfigGetCmd,

--- a/cmd/admin-console.go
+++ b/cmd/admin-console.go
@@ -49,7 +49,7 @@ var adminConsoleCmd = cli.Command{
 	Name:            "console",
 	Usage:           "show console logs for MinIO server",
 	Action:          mainAdminConsole,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           append(adminConsoleFlags, globalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-group-add.go
+++ b/cmd/admin-group-add.go
@@ -32,7 +32,7 @@ var adminGroupAddCmd = cli.Command{
 	Name:   "add",
 	Usage:  "add users to a new or existing group",
 	Action: mainAdminGroupAdd,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-group-disable.go
+++ b/cmd/admin-group-disable.go
@@ -24,7 +24,7 @@ var adminGroupDisableCmd = cli.Command{
 	Name:   "disable",
 	Usage:  "Disable a group",
 	Action: mainAdminGroupEnableDisable,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-group-enable.go
+++ b/cmd/admin-group-enable.go
@@ -30,7 +30,7 @@ var adminGroupEnableCmd = cli.Command{
 	Name:   "enable",
 	Usage:  "Enable a group",
 	Action: mainAdminGroupEnableDisable,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-group-info.go
+++ b/cmd/admin-group-info.go
@@ -27,7 +27,7 @@ var adminGroupInfoCmd = cli.Command{
 	Name:   "info",
 	Usage:  "display group info",
 	Action: mainAdminGroupInfo,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-group-list.go
+++ b/cmd/admin-group-list.go
@@ -27,7 +27,7 @@ var adminGroupListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "display list of groups",
 	Action: mainAdminGroupList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-group-remove.go
+++ b/cmd/admin-group-remove.go
@@ -28,7 +28,7 @@ var adminGroupRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "remove group or members from a group",
 	Action: mainAdminGroupRemove,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-group.go
+++ b/cmd/admin-group.go
@@ -22,7 +22,6 @@ var adminGroupCmd = cli.Command{
 	Name:   "group",
 	Usage:  "manage groups",
 	Action: mainAdminGroup,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminGroupAddCmd,

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -67,7 +67,7 @@ var adminHealCmd = cli.Command{
 	Name:            "heal",
 	Usage:           "heal disks, buckets and objects on MinIO server",
 	Action:          mainAdminHeal,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           append(adminHealFlags, globalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -38,7 +38,7 @@ var adminInfoCmd = cli.Command{
 	Name:   "info",
 	Usage:  "display MinIO server information",
 	Action: mainAdminInfo,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-kms-key-status.go
+++ b/cmd/admin-kms-key-status.go
@@ -28,7 +28,7 @@ var adminKMSKeyStatusCmd = cli.Command{
 	Name:   "status",
 	Usage:  "request status information for a KMS master key",
 	Action: mainAdminKMSKeyStatus,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-kms-key.go
+++ b/cmd/admin-kms-key.go
@@ -22,7 +22,6 @@ var adminKMSKeyCmd = cli.Command{
 	Name:   "key",
 	Usage:  "Manage KMS master keys: Request key status information",
 	Action: mainAdminKMSKey,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminKMSKeyStatusCmd,

--- a/cmd/admin-kms.go
+++ b/cmd/admin-kms.go
@@ -22,7 +22,6 @@ var adminKMSCmd = cli.Command{
 	Name:   "kms",
 	Usage:  "perform KMS management operations",
 	Action: mainAdminKMS,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminKMSKeyCmd,

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -34,7 +34,6 @@ var adminCmd = cli.Command{
 	Usage:           "manage MinIO servers",
 	Action:          mainAdmin,
 	HideHelpCommand: true,
-	Before:          setGlobalsFromContext,
 	Flags:           append(adminFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		adminServiceCmd,

--- a/cmd/admin-obd.go
+++ b/cmd/admin-obd.go
@@ -56,7 +56,7 @@ var adminOBDCmd = cli.Command{
 	Name:   "obd",
 	Usage:  "run on-board diagnostics",
 	Action: mainAdminOBD,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(adminOBDFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-policy-add.go
+++ b/cmd/admin-policy-add.go
@@ -33,7 +33,7 @@ var adminPolicyAddCmd = cli.Command{
 	Name:   "add",
 	Usage:  "add new policy",
 	Action: mainAdminPolicyAdd,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-policy-info.go
+++ b/cmd/admin-policy-info.go
@@ -29,7 +29,7 @@ var adminPolicyInfoCmd = cli.Command{
 	Name:   "info",
 	Usage:  "show info on a policy",
 	Action: mainAdminPolicyInfo,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-policy-list.go
+++ b/cmd/admin-policy-list.go
@@ -27,7 +27,7 @@ var adminPolicyListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "list all policies",
 	Action: mainAdminPolicyList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-policy-remove.go
+++ b/cmd/admin-policy-remove.go
@@ -27,7 +27,7 @@ var adminPolicyRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "remove policy",
 	Action: mainAdminPolicyRemove,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-policy-set.go
+++ b/cmd/admin-policy-set.go
@@ -30,7 +30,7 @@ var adminPolicySetCmd = cli.Command{
 	Name:   "set",
 	Usage:  "set IAM policy on a user or group",
 	Action: mainAdminPolicySet,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-policy.go
+++ b/cmd/admin-policy.go
@@ -22,7 +22,6 @@ var adminPolicyCmd = cli.Command{
 	Name:   "policy",
 	Usage:  "manage policies defined in the MinIO server",
 	Action: mainAdminPolicy,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminPolicyAddCmd,

--- a/cmd/admin-profile-start.go
+++ b/cmd/admin-profile-start.go
@@ -38,7 +38,7 @@ var adminProfileStartCmd = cli.Command{
 	Name:            "start",
 	Usage:           "start recording profile data",
 	Action:          mainAdminProfileStart,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           append(adminProfileStartFlags, globalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-profile-stop.go
+++ b/cmd/admin-profile-stop.go
@@ -31,7 +31,7 @@ var adminProfileStopCmd = cli.Command{
 	Name:            "stop",
 	Usage:           "stop and download profile data",
 	Action:          mainAdminProfileStop,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-profile.go
+++ b/cmd/admin-profile.go
@@ -24,7 +24,6 @@ var adminProfileCmd = cli.Command{
 	Name:   "profile",
 	Usage:  "generate profile data for debugging purposes",
 	Action: mainAdminProfile,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminProfileStartCmd,

--- a/cmd/admin-prometheus-generate.go
+++ b/cmd/admin-prometheus-generate.go
@@ -40,7 +40,7 @@ var adminPrometheusGenerateCmd = cli.Command{
 	Name:            "generate",
 	Usage:           "generates prometheus config",
 	Action:          mainAdminPrometheusGenerate,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-prometheus.go
+++ b/cmd/admin-prometheus.go
@@ -22,7 +22,6 @@ var adminPrometheusCmd = cli.Command{
 	Name:            "prometheus",
 	Usage:           "manages prometheus config",
 	Action:          mainAdminPrometheus,
-	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	Subcommands: []cli.Command{

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -30,7 +30,7 @@ var adminServiceRestartCmd = cli.Command{
 	Name:   "restart",
 	Usage:  "restart all MinIO servers",
 	Action: mainAdminServiceRestart,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-service-stop.go
+++ b/cmd/admin-service-stop.go
@@ -28,7 +28,7 @@ var adminServiceStopCmd = cli.Command{
 	Name:   "stop",
 	Usage:  "stop MinIO server",
 	Action: mainAdminServiceStop,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -22,7 +22,6 @@ var adminServiceCmd = cli.Command{
 	Name:            "service",
 	Usage:           "restart and stop all MinIO servers",
 	Action:          mainAdminService,
-	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	Subcommands: []cli.Command{

--- a/cmd/admin-top-locks.go
+++ b/cmd/admin-top-locks.go
@@ -31,7 +31,7 @@ import (
 var adminTopLocksCmd = cli.Command{
 	Name:   "locks",
 	Usage:  "Get a list of the 10 oldest locks on a MinIO cluster.",
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Action: mainAdminTopLocks,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-top.go
+++ b/cmd/admin-top.go
@@ -22,7 +22,6 @@ var adminTopCmd = cli.Command{
 	Name:   "top",
 	Usage:  "provide top like statistics for MinIO",
 	Action: mainAdminTop,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminTopLocksCmd,

--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -53,7 +53,7 @@ var adminTraceCmd = cli.Command{
 	Name:            "trace",
 	Usage:           "show http trace for MinIO server",
 	Action:          mainAdminTrace,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           append(adminTraceFlags, globalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/admin-update.go
+++ b/cmd/admin-update.go
@@ -30,7 +30,7 @@ var adminServerUpdateCmd = cli.Command{
 	Name:   "update",
 	Usage:  "update all MinIO servers",
 	Action: mainAdminServerUpdate,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user-add.go
+++ b/cmd/admin-user-add.go
@@ -34,7 +34,7 @@ var adminUserAddCmd = cli.Command{
 	Name:   "add",
 	Usage:  "add a new user",
 	Action: mainAdminUserAdd,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user-disable.go
+++ b/cmd/admin-user-disable.go
@@ -28,7 +28,7 @@ var adminUserDisableCmd = cli.Command{
 	Name:   "disable",
 	Usage:  "disable user",
 	Action: mainAdminUserDisable,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user-enable.go
+++ b/cmd/admin-user-enable.go
@@ -28,7 +28,7 @@ var adminUserEnableCmd = cli.Command{
 	Name:   "enable",
 	Usage:  "enable user",
 	Action: mainAdminUserEnable,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user-info.go
+++ b/cmd/admin-user-info.go
@@ -27,7 +27,7 @@ var adminUserInfoCmd = cli.Command{
 	Name:   "info",
 	Usage:  "display info of a user",
 	Action: mainAdminUserInfo,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user-list.go
+++ b/cmd/admin-user-list.go
@@ -27,7 +27,7 @@ var adminUserListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "list all users",
 	Action: mainAdminUserList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user-remove.go
+++ b/cmd/admin-user-remove.go
@@ -27,7 +27,7 @@ var adminUserRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "remove user",
 	Action: mainAdminUserRemove,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/admin-user.go
+++ b/cmd/admin-user.go
@@ -22,7 +22,6 @@ var adminUserCmd = cli.Command{
 	Name:   "user",
 	Usage:  "manage users",
 	Action: mainAdminUser,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		adminUserAddCmd,

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -44,7 +44,7 @@ var catCmd = cli.Command{
 	Name:   "cat",
 	Usage:  "display object contents",
 	Action: mainCat,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(catFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/config-host-add.go
+++ b/cmd/config-host-add.go
@@ -50,7 +50,7 @@ var configHostAddCmd = cli.Command{
 	ShortName:       "a",
 	Usage:           "add a new host to configuration file",
 	Action:          mainConfigHostAdd,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           append(hostAddFlags, globalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/config-host-list.go
+++ b/cmd/config-host-list.go
@@ -30,7 +30,7 @@ var configHostListCmd = cli.Command{
 	ShortName:       "ls",
 	Usage:           "list hosts in configuration file",
 	Action:          mainConfigHostList,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/config-host-remove.go
+++ b/cmd/config-host-remove.go
@@ -27,7 +27,7 @@ var configHostRemoveCmd = cli.Command{
 	ShortName:       "rm",
 	Usage:           "remove a host from configuration file",
 	Action:          mainConfigHostRemove,
-	Before:          setGlobalsFromContext,
+	Before:          initBeforeRunningCmd,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:

--- a/cmd/config-host.go
+++ b/cmd/config-host.go
@@ -27,7 +27,6 @@ var configHostCmd = cli.Command{
 	Name:   "host",
 	Usage:  "add, remove and list hosts in configuration file",
 	Action: mainConfigHost,
-	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
 		configHostAddCmd,

--- a/cmd/config-main.go
+++ b/cmd/config-main.go
@@ -37,7 +37,6 @@ var configCmd = cli.Command{
 	Name:            "config",
 	Usage:           "configure MinIO client",
 	Action:          mainConfig,
-	Before:          setGlobalsFromContext,
 	HideHelpCommand: true,
 	Flags:           append(configFlags, globalFlags...),
 	Subcommands: []cli.Command{

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -104,7 +104,7 @@ var cpCmd = cli.Command{
 	Name:   "cp",
 	Usage:  "copy objects",
 	Action: mainCopy,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(cpFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -38,7 +38,7 @@ var diffCmd = cli.Command{
 	Name:   "diff",
 	Usage:  "list differences in object name, size, and date between two buckets",
 	Action: mainDiff,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(diffFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -48,7 +48,7 @@ var duCmd = cli.Command{
 	Name:   "du",
 	Usage:  "summarize disk usage recursively",
 	Action: mainDu,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(duFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/event-add.go
+++ b/cmd/event-add.go
@@ -53,7 +53,7 @@ var eventAddCmd = cli.Command{
 	Name:   "add",
 	Usage:  "add a new bucket notification",
 	Action: mainEventAdd,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(eventAddFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/event-list.go
+++ b/cmd/event-list.go
@@ -35,7 +35,7 @@ var eventListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "list bucket notifications",
 	Action: mainEventList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(eventListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/event-main.go
+++ b/cmd/event-main.go
@@ -27,7 +27,6 @@ var eventCmd = cli.Command{
 	Usage:           "configure object notifications",
 	HideHelpCommand: true,
 	Action:          mainEvent,
-	Before:          setGlobalsFromContext,
 	Flags:           append(eventFlags, globalFlags...),
 	Subcommands: []cli.Command{
 		eventAddCmd,

--- a/cmd/event-remove.go
+++ b/cmd/event-remove.go
@@ -54,7 +54,7 @@ var eventRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "remove a bucket notification; '--force' removes all bucket notifications",
 	Action: mainEventRemove,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(eventRemoveFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -85,7 +85,7 @@ var findCmd = cli.Command{
 	Name:   "find",
 	Usage:  "search for objects",
 	Action: mainFind,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(findFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/head-main.go
+++ b/cmd/head-main.go
@@ -46,7 +46,7 @@ var headCmd = cli.Command{
 	Name:   "head",
 	Usage:  "display first 'n' lines of an object",
 	Action: mainHead,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(headFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/ilm-add.go
+++ b/cmd/ilm-add.go
@@ -30,7 +30,7 @@ var ilmAddCmd = cli.Command{
 	Name:   "add",
 	Usage:  "add a lifecycle configuration rule to existing (if any) rule(s) on a bucket",
 	Action: mainILMAdd,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(ilmAddFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/ilm-export.go
+++ b/cmd/ilm-export.go
@@ -30,7 +30,7 @@ var ilmExportCmd = cli.Command{
 	Name:   "export",
 	Usage:  "export lifecycle configuration in JSON format",
 	Action: mainILMExport,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/ilm-import.go
+++ b/cmd/ilm-import.go
@@ -31,7 +31,7 @@ var ilmImportCmd = cli.Command{
 	Name:   "import",
 	Usage:  "import lifecycle configuration in JSON format",
 	Action: mainILMImport,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/ilm-list.go
+++ b/cmd/ilm-list.go
@@ -49,7 +49,7 @@ var ilmListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "pretty print bucket lifecycle configuration",
 	Action: mainILMList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(ilmListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/ilm-main.go
+++ b/cmd/ilm-main.go
@@ -26,7 +26,6 @@ var ilmCmd = cli.Command{
 	Name:            "ilm",
 	Usage:           "configure bucket lifecycle",
 	Action:          mainILM,
-	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	Subcommands: []cli.Command{

--- a/cmd/ilm-remove.go
+++ b/cmd/ilm-remove.go
@@ -45,7 +45,7 @@ var ilmRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "remove (if any) existing lifecycle configuration rule with the id",
 	Action: mainILMRemove,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(ilmRemoveFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/legalhold-main.go
+++ b/cmd/legalhold-main.go
@@ -41,7 +41,7 @@ var legalHoldCmd = cli.Command{
 	Name:   "legalhold",
 	Usage:  "set legal hold for object(s)",
 	Action: mainLegalHold,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(lhFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/lock-main.go
+++ b/cmd/lock-main.go
@@ -43,7 +43,7 @@ var lockCmd = cli.Command{
 	Name:   "lock",
 	Usage:  "set and get object lock configuration",
 	Action: mainLock,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(lockFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -44,7 +44,7 @@ var lsCmd = cli.Command{
 	Name:   "ls",
 	Usage:  "list buckets and objects",
 	Action: mainList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(lsFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -255,25 +255,6 @@ func installAutoCompletion() {
 	}
 }
 
-func registerBefore(ctx *cli.Context) error {
-	// Set the config directory.
-	setMcConfigDir(ctx.GlobalString("config-dir"))
-
-	// Migrate any old version of config / state files to newer format.
-	migrate()
-
-	// Set global flags.
-	setGlobalsFromContext(ctx)
-
-	// Initialize default config files.
-	initMC()
-
-	// Check if config can be read.
-	checkConfig()
-
-	return nil
-}
-
 // findClosestCommands to match a given string with commands trie tree.
 func findClosestCommands(command string) []string {
 	var closestCommands []string
@@ -311,6 +292,26 @@ func checkUpdate(ctx *cli.Context) {
 			})
 		}
 	}
+}
+
+// All the routines that need to be done before running any mc command
+func initBeforeRunningCmd(ctx *cli.Context) error {
+	// Set global variables from the context
+	setGlobalsFromContext(ctx)
+
+	// Set the config directory.
+	setMcConfigDir(ctx.GlobalString("config-dir"))
+
+	// Migrate any old version of config / state files to newer format.
+	migrate()
+
+	// Initialize default config files.
+	initMC()
+
+	// Check if config can be read.
+	checkConfig()
+
+	return nil
 }
 
 var appCmds = []cli.Command{
@@ -372,7 +373,6 @@ func registerApp(name string) *cli.App {
 		return exitStatus(globalErrorExitStatus)
 	}
 
-	app.Before = registerBefore
 	app.ExtraInfo = func() map[string]string {
 		if globalDebug {
 			return getSystemData()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,50 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/minio/cli"
+)
+
+// This function checks that only leaf commands have Before
+// function configured to avoid calling it multiple times.
+func TestBeforeCommand(t *testing.T) {
+	var checkCmd func(string, cli.Command)
+
+	checkCmd = func(cmdPath string, c cli.Command) {
+		if len(c.Subcommands) != 0 {
+			if c.Before != nil {
+				t.Fatalf("Command %s does not expect to have a Before func since it is not the leaf command", cmdPath)
+			}
+		} else {
+			if c.Before == nil {
+				t.Fatalf("Command %s expects to have a Before func since it is a leaf command", cmdPath)
+			}
+		}
+
+		// Test subcommands
+		for _, subCmd := range c.Subcommands {
+			checkCmd(cmdPath+"/"+subCmd.Name, subCmd)
+		}
+	}
+
+	for _, cmd := range appCmds {
+		checkCmd("", cmd)
+	}
+}

--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -49,7 +49,7 @@ var mbCmd = cli.Command{
 	Name:   "mb",
 	Usage:  "make a bucket",
 	Action: mainMakeBucket,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(mbFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -117,7 +117,7 @@ var mirrorCmd = cli.Command{
 	Name:   "mirror",
 	Usage:  "synchronize object(s) to a remote site",
 	Action: mainMirror,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(mirrorFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -77,7 +77,7 @@ var mvCmd = cli.Command{
 	Name:   "mv",
 	Usage:  "move objects",
 	Action: mainMove,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(mvFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -42,7 +42,7 @@ var pipeCmd = cli.Command{
 	Name:   "pipe",
 	Usage:  "stream STDIN to an object",
 	Action: mainPipe,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(pipeFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -46,7 +46,7 @@ var policyCmd = cli.Command{
 	Name:   "policy",
 	Usage:  "manage anonymous access to buckets and objects",
 	Action: mainPolicy,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(policyFlags, globalFlags...),
 	CustomHelpTemplate: `Name:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -47,7 +47,7 @@ var rbCmd = cli.Command{
 	Name:   "rb",
 	Usage:  "remove a bucket",
 	Action: mainRemoveBucket,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(rbFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/retention-main.go
+++ b/cmd/retention-main.go
@@ -50,7 +50,7 @@ var retentionCmd = cli.Command{
 	Name:   "retention",
 	Usage:  "set retention for object(s)",
 	Action: mainRetention,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(rFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -78,7 +78,7 @@ var rmCmd = cli.Command{
 	Name:   "rm",
 	Usage:  "remove objects",
 	Action: mainRm,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(rmFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -40,7 +40,7 @@ var shareDownload = cli.Command{
 	Name:   "download",
 	Usage:  "generate URLs for download access",
 	Action: mainShareDownload,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(shareDownloadFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/share-list-main.go
+++ b/cmd/share-list-main.go
@@ -33,7 +33,7 @@ var shareList = cli.Command{
 	Name:   "list",
 	Usage:  "list previously shared objects",
 	Action: mainShareList,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(shareListFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} COMMAND - {{.Usage}}

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -34,7 +34,6 @@ var shareCmd = cli.Command{
 	Name:            "share",
 	Usage:           "generate URL for temporary access to an object",
 	Action:          mainShare,
-	Before:          setGlobalsFromContext,
 	Flags:           append(shareFlags, globalFlags...),
 	HideHelpCommand: true,
 	Subcommands: []cli.Command{

--- a/cmd/share-upload-main.go
+++ b/cmd/share-upload-main.go
@@ -41,7 +41,7 @@ var shareUpload = cli.Command{
 	Name:   "upload",
 	Usage:  "generate `curl` command to upload objects without requiring access/secret keys",
 	Action: mainShareUpload,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(shareUploadFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -79,7 +79,7 @@ var sqlCmd = cli.Command{
 	Name:   "sql",
 	Usage:  "run sql queries on objects",
 	Action: mainSQL,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(sqlFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -40,7 +40,7 @@ var statCmd = cli.Command{
 	Name:   "stat",
 	Usage:  "show object metadata",
 	Action: mainStat,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(append(statFlags, ioFlags...), globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -34,7 +34,7 @@ var tagListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "list tags of a bucket or an object",
 	Action: mainListTag,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/tag-main.go
+++ b/cmd/tag-main.go
@@ -24,7 +24,6 @@ var tagCmd = cli.Command{
 	Name:            "tag",
 	Usage:           "manage tags for bucket(s) and object(s)",
 	Action:          mainTag,
-	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
 	Subcommands: []cli.Command{

--- a/cmd/tag-remove.go
+++ b/cmd/tag-remove.go
@@ -30,7 +30,7 @@ var tagRemoveCmd = cli.Command{
 	Name:   "remove",
 	Usage:  "remove tags assigned to a bucket or an object",
 	Action: mainRemoveTag,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/tag-set.go
+++ b/cmd/tag-set.go
@@ -30,7 +30,7 @@ var tagSetCmd = cli.Command{
 	Name:   "set",
 	Usage:  "set tags for a bucket(s) and object(s)",
 	Action: mainSetTag,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -76,7 +76,7 @@ var treeCmd = cli.Command{
 	Name:   "tree",
 	Usage:  "list buckets and objects in a tree format",
 	Action: mainTree,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(treeFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -41,6 +41,7 @@ import (
 var updateCmd = cli.Command{
 	Name:   "update",
 	Usage:  "update mc to latest release",
+	Before: func(*cli.Context) error { return nil },
 	Action: mainUpdate,
 	Flags: []cli.Flag{
 		cli.BoolFlag{

--- a/cmd/watch-main.go
+++ b/cmd/watch-main.go
@@ -56,7 +56,7 @@ var watchCmd = cli.Command{
 	Name:   "watch",
 	Usage:  "listen for object notification events",
 	Action: mainWatch,
-	Before: setGlobalsFromContext,
+	Before: initBeforeRunningCmd,
 	Flags:  append(watchFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}


### PR DESCRIPTION
`rm -rf ~/.mc/ && mc ls --json` shows some non-json output.

cli.App.Before receives a cli.Context but without flags parsed. There is no
point calling ctx.Bool() or ctx.IsSet() at that stage.

However, flags are parsed in commands, so minio initialization and
setting global variables (globalJSON, globalQuiet, etc..) can be moved
to the Before function of all commands.

Avoid setting command.Before for non leaf commands, otherwise Before
function will be called multiples times until it reaches the leaf
command.


