### PR TITLE
Adds support to preserve X-Amz-Meta-Mc-Attrs when os -> fs

### DIFF
--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -45,7 +45,7 @@ func (s *TestSuite) TestList(c *C) {
 	var n int64
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -56,7 +56,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -84,7 +84,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -144,7 +144,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -251,7 +251,7 @@ func (s *TestSuite) TestPut(c *C) {
 	var n int64
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 }
@@ -271,7 +271,7 @@ func (s *TestSuite) TestGet(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -299,7 +299,7 @@ func (s *TestSuite) TestGetRange(c *C) {
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -330,7 +330,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	reader := bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(dataLen), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -355,10 +355,10 @@ func (s *TestSuite) TestCopy(c *C) {
 	reader := bytes.NewReader([]byte(data))
 	n, err := fsClientSource.Put(context.Background(), reader, int64(len(data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
-	err = fsClientTarget.Copy(context.Background(), sourcePath, int64(len(data)), nil, nil, nil, nil, false)
+	err = fsClientTarget.Copy(context.Background(), sourcePath, int64(len(data)), nil, nil, nil, nil, false, false)
 	c.Assert(err, IsNil)
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -839,7 +839,7 @@ func (c *S3Client) Get(ctx context.Context, sse encrypt.ServerSide) (io.ReadClos
 // Copy - copy object, uses server side copy API. Also uses an abstracted API
 // such that large file sizes will be copied in multipart manner on server
 // side.
-func (c *S3Client) Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error {
+func (c *S3Client) Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart, isPreserve bool) *probe.Error {
 	dstBucket, dstObject := c.url2BucketAndObject()
 	if dstBucket == "" {
 		return probe.NewError(BucketNameEmpty{})
@@ -912,7 +912,7 @@ func (c *S3Client) Copy(ctx context.Context, source string, size int64, progress
 }
 
 // Put - upload an object with custom metadata.
-func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sse encrypt.ServerSide, md5, disableMultipart bool) (int64, *probe.Error) {
+func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sse encrypt.ServerSide, md5, disableMultipart, isPreserve bool) (int64, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	if bucket == "" {
 		return 0, probe.NewError(BucketNameEmpty{})

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -223,7 +223,7 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	reader = bytes.NewReader(object.data)
 	n, err := s3c.Put(context.Background(), reader, int64(len(object.data)), map[string]string{
 		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false)
+	}, nil, nil, false, false, false)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(object.data)))
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -62,14 +62,14 @@ type Client interface {
 	SetAccess(ctx context.Context, access string, isJSON bool) *probe.Error
 
 	// I/O operations
-	Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart bool) *probe.Error
+	Copy(ctx context.Context, source string, size int64, progress io.Reader, srcSSE, tgtSSE encrypt.ServerSide, metadata map[string]string, disableMultipart, isPreserve bool) *probe.Error
 
 	// Runs select expression on object storage on specific files.
 	Select(ctx context.Context, expression string, sse encrypt.ServerSide, opts SelectObjectOpts) (io.ReadCloser, *probe.Error)
 
 	// I/O operations with metadata.
 	Get(ctx context.Context, sse encrypt.ServerSide) (reader io.ReadCloser, err *probe.Error)
-	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sse encrypt.ServerSide, md5, disableMultipart bool) (n int64, err *probe.Error)
+	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sse encrypt.ServerSide, md5, disableMultipart, isPreserve bool) (n int64, err *probe.Error)
 
 	// Object Locking related API
 	PutObjectRetention(ctx context.Context, mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -90,7 +90,7 @@ func pipe(targetURL string, encKeyDB map[string][]prefixSSEPair, storageClass st
 	if storageClass != "" {
 		metadata = map[string]string{"X-Amz-Storage-Class": storageClass}
 	}
-	_, err := putTargetStreamWithURL(targetURL, os.Stdin, -1, sseKey, false, false, metadata)
+	_, err := putTargetStreamWithURL(targetURL, os.Stdin, -1, sseKey, false, false, false, metadata)
 	// TODO: See if this check is necessary.
 	switch e := err.ToGoError().(type) {
 	case *os.PathError:


### PR DESCRIPTION
Fixes 3263

Adds missing support for preserving file attributes of an object stored in `X-Amz-Meta-Mc-Attrs` when copying from object storage to local file system.

I have tested the fix and it works as expected for all scenarios;
`fs -> fs`
`fs -> os`
`os -> os`
`os -> fs`