### PR TITLE
admin: add new command for creating KMS master keys

### DIFF
--- a/cmd/admin-kms-key-create.go
+++ b/cmd/admin-kms-key-create.go
@@ -1,0 +1,68 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio/pkg/console"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var adminKMSCreateKeyCmd = cli.Command{
+	Name:   "create",
+	Usage:  "creates a new master key at the KMS",
+	Action: mainAdminKMSCreateKey,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET [KEY_NAME]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Create a new master key named 'my-key' default master key.
+     $ {{.HelpName}} play my-key
+`,
+}
+
+// adminKMSCreateKeyCmd is the handler for the "mc admin kms key create" command.
+func mainAdminKMSCreateKey(ctx *cli.Context) error {
+	if len(ctx.Args()) != 2 {
+		cli.ShowCommandHelpAndExit(ctx, "create", 1) // last argument is exit code
+	}
+
+	client, err := newAdminClient(ctx.Args().Get(0))
+	fatalIf(err, "Cannot get a configured admin connection.")
+
+	keyID := ctx.Args().Get(1)
+	e := client.CreateKey(globalContext, keyID)
+	fatalIf(probe.NewError(e), "Failed to create master key")
+
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		console.Println(color.GreenString(fmt.Sprintf("Created master key `%s` successfully", keyID)))
+	}
+	return nil
+}

--- a/cmd/admin-kms-key.go
+++ b/cmd/admin-kms-key.go
@@ -25,6 +25,7 @@ var adminKMSKeyCmd = cli.Command{
 	Before: setGlobalsFromContext,
 	Flags:  globalFlags,
 	Subcommands: []cli.Command{
+		adminKMSCreateKeyCmd,
 		adminKMSKeyStatusCmd,
 	},
 	HideHelpCommand: true,

--- a/cmd/admin-top-locks.go
+++ b/cmd/admin-top-locks.go
@@ -72,9 +72,11 @@ func getTimeDiff(timeStamp time.Time) (string, string) {
 
 // String colorized oldest locks message.
 func (u lockMessage) String() string {
-	timeFieldMaxLen := 20
-	resourceFieldMaxLen := -1
-	typeFieldMaxLen := 6
+	const (
+		timeFieldMaxLen     = 20
+		resourceFieldMaxLen = -1
+		typeFieldMaxLen     = 6
+	)
 
 	lockState, timeDiff := getTimeDiff(u.Lock.Timestamp)
 	return console.Colorize(lockState, newPrettyTable("  ",

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -837,7 +837,6 @@ USAGE:
   mc admin kms key COMMAND [COMMAND FLAGS | -h] [ARGUMENTS...]
 ```
 
-
 *Example: Display status information for the default master key*
 
 ```sh
@@ -847,11 +846,19 @@ Key: my-minio-key
  	 • Decryption ✔
 ```
 
+*Example: Create a new master key at the KMS*
+
+```sh
+mc admin kms key create play my-key
+
+Created master key `my-key` successfully
+```
+
 *Example: Display status information for one particular master key*
 
 ```sh
-mc admin kms key status play test-key-1
-Key: test-key-1
+mc admin kms key status play my-key
+Key: my-key
  	 • Encryption ✔
  	 • Decryption ✔
 ```


### PR DESCRIPTION
This commit adds a new admin command for creating
KMS master keys:
```
mc admin kms key create <alias> <key-name>
```

This command requires a MinIO server with the
create KMS key admin API added by minio/minio#9982