### PR TITLE
fix attr argument parsing - support quoted keys and values

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -604,14 +604,108 @@ loop:
 // validate the passed metadataString and populate the map
 func getMetaDataEntry(metadataString string) (map[string]string, *probe.Error) {
 	metaDataMap := make(map[string]string)
-	for _, metaData := range strings.Split(metadataString, ";") {
-		metaDataEntry := strings.SplitN(metaData, "=", 2)
-		if len(metaDataEntry) != 2 {
-			return nil, probe.NewError(ErrInvalidMetadata)
+	r := strings.NewReader(metadataString)
+
+	type pToken int
+	const (
+		KEY pToken = iota
+		VALUE
+	)
+
+	type pState int
+	const (
+		NORMAL pState = iota
+		QSTRING
+		DQSTRING
+	)
+
+	var key, value strings.Builder
+
+	writeRune := func(ch rune, pt pToken) {
+		if pt == KEY {
+			key.WriteRune(ch)
+		} else if pt == VALUE {
+			value.WriteRune(ch)
+		} else {
+			panic("Invalid parser token type")
 		}
-		metaDataMap[http.CanonicalHeaderKey(metaDataEntry[0])] = metaDataEntry[1]
 	}
-	return metaDataMap, nil
+
+	ps := NORMAL
+	pt := KEY
+	p := 0
+
+	for ;;p++ {
+		ch, _, err := r.ReadRune()
+		if err != nil {
+			//eof
+			if ps == QSTRING || ps == DQSTRING || pt == KEY {
+				return nil, probe.NewError(ErrInvalidMetadata)
+			}
+			metaDataMap[http.CanonicalHeaderKey(key.String())] = value.String()
+			return metaDataMap, nil
+		}
+
+		if ch == '"' {
+			if ps == DQSTRING {
+				ps = NORMAL
+			} else if ps == QSTRING {
+				writeRune(ch, pt)
+			} else if ps == NORMAL {
+				ps = DQSTRING
+			} else {
+				break
+			}
+			continue
+		}
+
+		if ch == '\'' {
+			if ps == QSTRING {
+				ps = NORMAL
+			} else if ps == DQSTRING {
+				writeRune(ch, pt)
+			} else if ps == NORMAL {
+				ps = QSTRING
+			} else {
+				break
+			}
+			continue
+		}
+
+		if ch == '=' {
+			if ps == QSTRING || ps == DQSTRING {
+				writeRune(ch, pt)
+			} else if pt == KEY {
+				pt = VALUE
+			} else if pt == VALUE {
+				writeRune(ch, pt)
+			} else {
+				break
+			}
+			continue
+		}
+
+		if ch == ';' {
+			if ps == QSTRING || ps == DQSTRING {
+				writeRune(ch, pt)
+			} else if pt == KEY {
+				return nil, probe.NewError(ErrInvalidMetadata)
+			} else if pt == VALUE {
+				metaDataMap[http.CanonicalHeaderKey(key.String())] = value.String()
+				key.Reset()
+				value.Reset()
+				pt = KEY
+			} else {
+				break
+			}
+			continue
+		}
+
+		writeRune(ch, pt)
+	}
+
+	fatalErr := fmt.Sprintf("Invalid parser state at index: %d", p)
+	panic(fatalErr)
 }
 
 // mainCopy is the entry point for cp command.

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -635,7 +635,7 @@ func getMetaDataEntry(metadataString string) (map[string]string, *probe.Error) {
 	pt := KEY
 	p := 0
 
-	for ;;p++ {
+	for ; ; p++ {
 		ch, _, err := r.ReadRune()
 		if err != nil {
 			//eof

--- a/cmd/cp-main_test.go
+++ b/cmd/cp-main_test.go
@@ -38,6 +38,19 @@ func TestParseMetaData(t *testing.T) {
 		{"key1:value1;key2:value2", nil, ErrInvalidMetadata, false},
 		// using no delimiter
 		{"key1:value1:key2:value2", nil, ErrInvalidMetadata, false},
+
+		//success: use value in quotes
+		{"Content-Disposition='form-data; name=\"description\"'", map[string]string{"Content-Disposition" : "form-data; name=\"description\""}, nil, true},
+		//success: use value in double quotes
+		{"Content-Disposition=\"form-data; name='description'\"", map[string]string{"Content-Disposition" : "form-data; name='description'"}, nil, true},
+		//fail: unterminated quote
+		{"Content-Disposition='form-data; name=\"description\"", nil, ErrInvalidMetadata, false},
+		//fail: unterminated double quote
+		{"Content-Disposition=\"form-data; name='description'", nil, ErrInvalidMetadata, false},
+		//success: use value and key in quotes
+		{"\"Content-Disposition\"='form-data; name=\"description\"'", map[string]string{"Content-Disposition" : "form-data; name=\"description\""}, nil, true},
+		//success: use value and key in quotes
+		{"\"Content=Disposition;Other key part=this is also key data\"='form-data; name=\"description\"'", map[string]string{"Content=Disposition;Other key part=this is also key data" : "form-data; name=\"description\""}, nil, true},
 	}
 
 	for idx, testCase := range metaDataCases {

--- a/cmd/cp-main_test.go
+++ b/cmd/cp-main_test.go
@@ -38,19 +38,18 @@ func TestParseMetaData(t *testing.T) {
 		{"key1:value1;key2:value2", nil, ErrInvalidMetadata, false},
 		// using no delimiter
 		{"key1:value1:key2:value2", nil, ErrInvalidMetadata, false},
-
 		//success: use value in quotes
-		{"Content-Disposition='form-data; name=\"description\"'", map[string]string{"Content-Disposition" : "form-data; name=\"description\""}, nil, true},
+		{"Content-Disposition='form-data; name=\"description\"'", map[string]string{"Content-Disposition": "form-data; name=\"description\""}, nil, true},
 		//success: use value in double quotes
-		{"Content-Disposition=\"form-data; name='description'\"", map[string]string{"Content-Disposition" : "form-data; name='description'"}, nil, true},
+		{"Content-Disposition=\"form-data; name='description'\"", map[string]string{"Content-Disposition": "form-data; name='description'"}, nil, true},
 		//fail: unterminated quote
 		{"Content-Disposition='form-data; name=\"description\"", nil, ErrInvalidMetadata, false},
 		//fail: unterminated double quote
 		{"Content-Disposition=\"form-data; name='description'", nil, ErrInvalidMetadata, false},
 		//success: use value and key in quotes
-		{"\"Content-Disposition\"='form-data; name=\"description\"'", map[string]string{"Content-Disposition" : "form-data; name=\"description\""}, nil, true},
+		{"\"Content-Disposition\"='form-data; name=\"description\"'", map[string]string{"Content-Disposition": "form-data; name=\"description\""}, nil, true},
 		//success: use value and key in quotes
-		{"\"Content=Disposition;Other key part=this is also key data\"='form-data; name=\"description\"'", map[string]string{"Content=Disposition;Other key part=this is also key data" : "form-data; name=\"description\""}, nil, true},
+		{"\"Content=Disposition;Other key part=this is also key data\"='form-data; name=\"description\"'", map[string]string{"Content=Disposition;Other key part=this is also key data": "form-data; name=\"description\""}, nil, true},
 	}
 
 	for idx, testCase := range metaDataCases {


### PR DESCRIPTION
Minio cli unable to parse `--attr` arg with value like `Content-Disposition='attachment; filename="README.md"'`.
This PR fix that issue.

howto check (example):
```sh
echo 'test-test-test' > README.md
$MINIO_CLI cp --attr "Content-Disposition='attachment; filename="README.md"'" $PWD/README.md minio/0123456789-README.md
```