### PR TITLE
Fixes wrong destination path

### DIFF
--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -165,8 +165,7 @@ func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, bool, 
 			// Bucket name empty is a valid error for 'ls myminio',
 			// treat it as such.
 			_, buckNameEmpty := err.ToGoError().(BucketNameEmpty)
-			_, noPath := err.ToGoError().(PathNotFound)
-			if buckNameEmpty || noPath {
+			if buckNameEmpty {
 				continue
 			}
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -748,7 +748,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 	// Check if we are only trying to mirror one bucket from source.
 	if dstClt.GetURL().Type == objectStorage &&
 		dstClt.GetURL().Path == string(dstClt.GetURL().Separator) && !mirrorAllBuckets {
-		dstURL = urlJoinPath(dstURL, filepath.Base(srcClt.GetURL().Path))
+		dstURL = urlJoinPath(dstURL, srcClt.GetURL().Path+"/")
 
 		dstClt, err = newClient(dstURL)
 		fatalIf(err, "Unable to initialize `"+dstURL+"`.")

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -745,15 +745,6 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 		(srcClt.GetURL().Type == objectStorage &&
 			srcClt.GetURL().Path == string(srcClt.GetURL().Separator))
 
-	// Check if we are only trying to mirror one bucket from source.
-	if dstClt.GetURL().Type == objectStorage &&
-		dstClt.GetURL().Path == string(dstClt.GetURL().Separator) && !mirrorAllBuckets {
-		dstURL = urlJoinPath(dstURL, srcClt.GetURL().Path+"/")
-
-		dstClt, err = newClient(dstURL)
-		fatalIf(err, "Unable to initialize `"+dstURL+"`.")
-	}
-
 	// Create a new mirror job and execute it
 	mj := newMirrorJob(srcURL, dstURL, mirrorOptions{
 		isFake:           cli.Bool("fake"),
@@ -842,8 +833,31 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 				return true
 			}
 		} else {
-			mj.status.fatalIf(dstClt.MakeBucket(ctx, cli.String("region"), true, withLock),
-				"Unable to create bucket at `"+dstURL+"`.")
+			targetAlias, targetURL, _ := mustExpandAlias(srcURL)
+			if !strings.HasSuffix(targetURL, string(srcClt.GetURL().Separator)) {
+				targetURL += string(srcClt.GetURL().Separator)
+			}
+
+			srcClt, err := newClientFromAlias(targetAlias, targetURL)
+			fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
+
+			dstInitialURL := dstURL
+			for content := range srcClt.List(ctx, ListOptions{isRecursive: false, showDir: DirNone}) {
+				if content.Err != nil {
+					errorIf(content.Err.Trace(srcClt.GetURL().String()), "Unable to list folder.")
+					continue
+				}
+
+				if content.Type.IsDir() {
+					dstURL = urlJoinPath(dstInitialURL, filepath.Base(content.URL.Path)+string(srcClt.GetURL().Separator))
+
+					dstClt, err = newClient(dstURL)
+					fatalIf(err, "Unable to initialize `"+dstURL+"`.")
+					mj.status.fatalIf(dstClt.MakeBucket(ctx, cli.String("region"), true, withLock),
+						"Unable to create bucket at `"+dstURL+"`.")
+				}
+
+			}
 		}
 
 		// object lock configuration set on bucket

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -748,7 +748,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 	// Check if we are only trying to mirror one bucket from source.
 	if dstClt.GetURL().Type == objectStorage &&
 		dstClt.GetURL().Path == string(dstClt.GetURL().Separator) && !mirrorAllBuckets {
-		dstURL = urlJoinPath(dstURL, srcClt.GetURL().Path)
+		dstURL = urlJoinPath(dstURL, filepath.Base(srcClt.GetURL().Path))
 
 		dstClt, err = newClient(dstURL)
 		fatalIf(err, "Unable to initialize `"+dstURL+"`.")


### PR DESCRIPTION
Fixes #3259 

Fixes the issue with the creation of destination path where destination was created with full absolute path instead of the base file name.

I tested the fix for regression and could not find anything.
It is a pretty simple fix, but I still would like to remind and suggest the reviewers to pay attention for regression risk.