### PR TITLE
ilm: Add ignores bucket lifecycle not found error

### DIFF
--- a/cmd/ilm/tabular_info.go
+++ b/cmd/ilm/tabular_info.go
@@ -227,7 +227,7 @@ func getExpiryDateVal(rule lifecycle.Rule) string {
 		expiryDate = strconv.Itoa(rule.Expiration.Date.Day()) + " " +
 			rule.Expiration.Date.Month().String()[0:3] + " " +
 			strconv.Itoa(rule.Expiration.Date.Year())
-	} else if !rule.Expiration.IsDateNull() {
+	} else if !rule.Expiration.IsDaysNull() {
 		expiryDate = strconv.Itoa(int(rule.Expiration.Days)) + " day(s)"
 	}
 	return expiryDate


### PR DESCRIPTION
mc ilm add should not error when the bucket does not have a bucket lifecycle.

Bonus fix:
Properly show expiry days field

Depends on https://github.com/minio/minio-go/pull/1351/files