### PR TITLE
rb: Delete object versions as well

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1096,6 +1096,7 @@ func (c *S3Client) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 		for content := range contentCh {
 			// Convert content.URL.Path to objectName for objectsCh.
 			bucket, objectName := c.splitPath(content.URL.Path)
+			objectVersionID := content.VersionID
 
 			// We don't treat path when bucket is
 			// empty, just skip it when it happens.
@@ -1144,7 +1145,7 @@ func (c *S3Client) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 				sent := false
 				for !sent {
 					select {
-					case objectsCh <- minio.ObjectInfo{Key: objectName}:
+					case objectsCh <- minio.ObjectInfo{Key: objectName, VersionID: objectVersionID}:
 						sent = true
 					case removeStatus := <-statusCh:
 						errorCh <- probe.NewError(removeStatus.Err)

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -114,7 +114,7 @@ func checkRbSyntax(ctx context.Context, cliCtx *cli.Context) {
 	}
 }
 
-// Delete a bucket and all its contents, versions will be removed as well.
+// Delete a bucket and all its objects and versions will be removed as well.
 func deleteBucket(ctx context.Context, url string) *probe.Error {
 	targetAlias, targetURL, _ := mustExpandAlias(url)
 	clnt, pErr := newClientFromAlias(targetAlias, targetURL)

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -34,7 +34,7 @@ var (
 	rbFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "force",
-			Usage: "allow a recursive remove operation with all objects versions",
+			Usage: "force a recursive remove operation on all object versions",
 		},
 		cli.BoolFlag{
 			Name:  "dangerous",

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -400,15 +400,15 @@ Bucket created successfully ‘s3/mybucket’.
 ### Command `rb`
 `rb` command removes a bucket and all its contents on an object storage. On a filesystem, it behaves like `rmdir` command.
 
-Note that when a bucket is removed all policies associated with the bucket will also be removed. If you would like to just
-empty the objects in a bucket use `rm` command
+Note that when a bucket is removed all policies associated with the bucket will also be removed. All objects versions will
+be removed as well. If you would like to just empty the objects in a bucket use `rm` command.
 
 ```
 USAGE:
    mc rb [FLAGS] TARGET [TARGET...]
 
 FLAGS:
-  --force                       allow a recursive remove operation
+  --force                       allow a recursive remove operation with all objects versions
   --dangerous                   allow site-wide removal of objects
   --help, -h                    show help
 

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -408,7 +408,7 @@ USAGE:
    mc rb [FLAGS] TARGET [TARGET...]
 
 FLAGS:
-  --force                       allow a recursive remove operation with all objects versions
+  --force                       force a recursive remove operation on all object versions
   --dangerous                   allow site-wide removal of objects
   --help, -h                    show help
 

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -401,7 +401,6 @@ Bucket created successfully ‘s3/mybucket’.
 `rb` command removes a bucket and all its contents on an object storage. On a filesystem, it behaves like `rmdir` command.
 
 > NOTE:  When a bucket is removed all bucket configurations associated with the bucket will also be removed. All objects and their versions will be removed as well. If you need to preserve bucket and its configuration - only empty the objects and versions in a bucket use `mc rm` instead.
-be removed as well. If you would like to just empty the objects in a bucket use `rm` command.
 
 ```
 USAGE:

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -400,7 +400,7 @@ Bucket created successfully ‘s3/mybucket’.
 ### Command `rb`
 `rb` command removes a bucket and all its contents on an object storage. On a filesystem, it behaves like `rmdir` command.
 
-Note that when a bucket is removed all policies associated with the bucket will also be removed. All objects versions will
+> NOTE:  When a bucket is removed all bucket configurations associated with the bucket will also be removed. All objects and their versions will be removed as well. If you need to preserve bucket and its configuration - only empty the objects and versions in a bucket use `mc rm` instead.
 be removed as well. If you would like to just empty the objects in a bucket use `rm` command.
 
 ```


### PR DESCRIPTION
Ready but we need to validate this requirement.

Dangerous for users since it is removing all versions as well.

Maybe we can add a confirmation prompt here, or a flag --with-versions.