### PR TITLE
Add versioning support for rm cmd

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -45,7 +45,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "version-id",
-			Usage: "pick a particular version id",
+			Usage: "delete a specific version of an object",
 		},
 		cli.BoolFlag{
 			Name:  "recursive, r",

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -37,7 +37,7 @@ var (
 	rmFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "versions",
-			Usage: "remove objects versions as well",
+			Usage: "remove object(s) and all its versions",
 		},
 		cli.StringFlag{
 			Name:  "rewind",

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -184,11 +184,12 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 	isDangerous := cliCtx.Bool("dangerous")
 	isVersions := cliCtx.Bool("versions")
 	versionID := cliCtx.String("version-id")
+	rewind := cliCtx.String("rewind")
 	isNamespaceRemoval := false
 
-	if isVersions && versionID != "" {
+	if versionID != "" && (isRecursive || isVersions || rewind != "") {
 		fatalIf(errDummy().Trace(),
-			"You cannot have both --versions and --version-id specified.")
+			"You cannot specify --version-id with any of --versions, --rewind and --recursive flags.")
 	}
 
 	for _, url := range cliCtx.Args() {

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -41,7 +41,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "rewind",
-			Usage: "back in time before removal",
+			Usage: "revert to older version of object(s) in time",
 		},
 		cli.StringFlag{
 			Name:  "version-id",

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Client (C) 2014, 2015 MinIO, Inc.
+ * MinIO Client (C) 2014-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,18 @@ import (
 // rm specific flags.
 var (
 	rmFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "versions",
+			Usage: "remove objects versions as well",
+		},
+		cli.StringFlag{
+			Name:  "rewind",
+			Usage: "back in time before removal",
+		},
+		cli.StringFlag{
+			Name:  "version-id",
+			Usage: "pick a particular version id",
+		},
 		cli.BoolFlag{
 			Name:  "recursive, r",
 			Usage: "remove recursively",
@@ -126,19 +138,33 @@ EXAMPLES:
 
   11. Bypass object retention in governance mode and delete the object.
       {{.Prompt}} {{.HelpName}} --bypass s3/pop-songs/
+
+  12. Remove a particular version ID.
+      {{.Prompt}} {{.HelpName}} s3/docs/money.xls --version-id "f20f3792-4bd4-4288-8d3c-b9d05b3b62f6"
+
+  13. Remove all object versions older than one year.
+      {{.Prompt}} {{.HelpName}} s3/docs/ --recursive --versions --rewind 365d
+
 `,
 }
 
 // Structured message depending on the type of console.
 type rmMessage struct {
-	Status string `json:"status"`
-	Key    string `json:"key"`
-	Size   int64  `json:"size"`
+	Status    string    `json:"status"`
+	Key       string    `json:"key"`
+	VersionID string    `json:"versionID"`
+	ModTime   time.Time `json:"modTime"`
+	Size      int64     `json:"size"`
 }
 
 // Colorized message for console printing.
 func (r rmMessage) String() string {
-	return console.Colorize("Remove", fmt.Sprintf("Removing `%s`.", r.Key))
+	msg := console.Colorize("Remove", fmt.Sprintf("Removing `%s`", r.Key))
+	if r.VersionID != "" {
+		msg += fmt.Sprintf(" (version-id=%s, mod-time=%s)", r.VersionID, r.ModTime)
+	}
+	msg += "."
+	return msg
 }
 
 // JSON'ified message for scripting.
@@ -156,7 +182,14 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 	isRecursive := cliCtx.Bool("recursive")
 	isStdin := cliCtx.Bool("stdin")
 	isDangerous := cliCtx.Bool("dangerous")
+	isVersions := cliCtx.Bool("versions")
+	versionID := cliCtx.String("version-id")
 	isNamespaceRemoval := false
+
+	if isVersions && versionID != "" {
+		fatalIf(errDummy().Trace(),
+			"You cannot have both --versions and --version-id specified.")
+	}
 
 	for _, url := range cliCtx.Args() {
 		// clean path for aliases like s3/.
@@ -183,8 +216,8 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 		cli.ShowCommandHelpAndExit(cliCtx, "rm", exitCode)
 	}
 
-	// For all recursive operations make sure to check for 'force' flag.
-	if (isRecursive || isStdin) && !isForce {
+	// For all recursive or versions bulk deletion operations make sure to check for 'force' flag.
+	if (isVersions || isRecursive || isStdin) && !isForce {
 		if isNamespaceRemoval {
 			fatalIf(errDummy().Trace(),
 				"This operation results in site-wide removal of objects. If you are really sure, retry this command with ‘--dangerous’ and ‘--force’ flags.")
@@ -198,12 +231,13 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 	}
 }
 
-func removeSingle(url string, isIncomplete, isFake, isForce, isBypass bool, olderThan, newerThan string, encKeyDB map[string][]prefixSSEPair) error {
+// Remove a single object or a single version in a versioned bucket
+func remove(url, versionID string, isIncomplete, isFake, isForce, isBypass bool, olderThan, newerThan string, encKeyDB map[string][]prefixSSEPair) error {
 	ctx, cancelRemoveSingle := context.WithCancel(globalContext)
 	defer cancelRemoveSingle()
 
 	isRecursive := false
-	contents, pErr := statURL(ctx, url, isIncomplete, isRecursive, encKeyDB)
+	contents, pErr := statURL(ctx, url, versionID, isIncomplete, isRecursive, encKeyDB)
 	if pErr != nil {
 		errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
 		return exitStatus(globalErrorExitStatus)
@@ -215,7 +249,6 @@ func removeSingle(url string, isIncomplete, isFake, isForce, isBypass bool, olde
 		}
 		return nil
 	}
-
 	content := contents[0]
 
 	// Skip objects older than older--than parameter if specified
@@ -264,9 +297,13 @@ func removeSingle(url string, isIncomplete, isFake, isForce, isBypass bool, olde
 	return nil
 }
 
-func removeRecursive(url string, isIncomplete, isFake, isBypass bool, olderThan, newerThan string, encKeyDB map[string][]prefixSSEPair) error {
-	ctx, cancelRemoveRecursive := context.WithCancel(globalContext)
-	defer cancelRemoveRecursive()
+// listAndRemove uses listing before removal, it can list recursively or not, with versions or not.
+//   Use cases:
+//      * Remove objects recursively
+//      * Remove all versions of a single object
+func listAndRemove(url string, timeRef time.Time, withVersions, isRecursive, isIncomplete, isFake, isBypass bool, olderThan, newerThan string, encKeyDB map[string][]prefixSSEPair) error {
+	ctx, cancelRemove := context.WithCancel(globalContext)
+	defer cancelRemove()
 
 	targetAlias, targetURL, _ := mustExpandAlias(url)
 	clnt, pErr := newClientFromAlias(targetAlias, targetURL)
@@ -279,7 +316,16 @@ func removeRecursive(url string, isIncomplete, isFake, isBypass bool, olderThan,
 
 	errorCh := clnt.Remove(ctx, isIncomplete, isRemoveBucket, isBypass, contentCh)
 
-	for content := range clnt.List(ctx, ListOptions{isRecursive: true, isIncomplete: isIncomplete, showDir: DirNone}) {
+	listOpts := ListOptions{isRecursive: isRecursive, isIncomplete: isIncomplete, showDir: DirNone}
+	if !timeRef.IsZero() {
+		listOpts.withOlderVersions = withVersions
+		listOpts.withDeleteMarkers = true
+		listOpts.timeRef = timeRef
+	}
+
+	atLeastOneObjectFound := false
+
+	for content := range clnt.List(ctx, listOpts) {
 		if content.Err != nil {
 			errorIf(content.Err.Trace(url), "Failed to remove `"+url+"` recursively.")
 			switch content.Err.ToGoError().(type) {
@@ -290,7 +336,21 @@ func removeRecursive(url string, isIncomplete, isFake, isBypass bool, olderThan,
 			close(contentCh)
 			return exitStatus(globalErrorExitStatus)
 		}
+
 		urlString := content.URL.Path
+
+		if !isRecursive {
+			currentObjectURL := targetAlias + getKey(content)
+			standardizedURL := getStandardizedURL(currentObjectURL)
+			if !strings.HasPrefix(url, standardizedURL) {
+				break
+			}
+		}
+
+		// This will mark that we found at least one target object
+		// even that it could be ineligible for deletion. So we can
+		// inform the user that he was searching in an empty area
+		atLeastOneObjectFound = true
 
 		if !content.Time.IsZero() {
 			// Skip objects older than --older-than parameter, if specified
@@ -308,8 +368,10 @@ func removeRecursive(url string, isIncomplete, isFake, isBypass bool, olderThan,
 		}
 
 		printMsg(rmMessage{
-			Key:  targetAlias + urlString,
-			Size: content.Size,
+			Key:       targetAlias + urlString,
+			Size:      content.Size,
+			VersionID: content.VersionID,
+			ModTime:   content.Time,
 		})
 
 		if !isFake {
@@ -343,6 +405,11 @@ func removeRecursive(url string, isIncomplete, isFake, isBypass bool, olderThan,
 		return exitStatus(globalErrorExitStatus)
 	}
 
+	if !atLeastOneObjectFound {
+		errorIf(probe.NewError(ObjectMissing{}).Trace(url), "Failed to remove `"+url+"`.")
+		return exitStatus(globalErrorExitStatus)
+	}
+
 	return nil
 }
 
@@ -367,6 +434,13 @@ func mainRm(cliCtx *cli.Context) error {
 	olderThan := cliCtx.String("older-than")
 	newerThan := cliCtx.String("newer-than")
 	isForce := cliCtx.Bool("force")
+	withVersions := cliCtx.Bool("versions")
+	versionID := cliCtx.String("version-id")
+	rewind := parseRewindFlag(cliCtx.String("rewind"))
+
+	if withVersions && rewind.IsZero() {
+		rewind = time.Now().UTC()
+	}
 
 	// Set color.
 	console.SetColor("Remove", color.New(color.FgGreen, color.Bold))
@@ -375,12 +449,11 @@ func mainRm(cliCtx *cli.Context) error {
 	var e error
 	// Support multiple targets.
 	for _, url := range cliCtx.Args() {
-		if isRecursive {
-			e = removeRecursive(url, isIncomplete, isFake, isBypass, olderThan, newerThan, encKeyDB)
+		if isRecursive || withVersions {
+			e = listAndRemove(url, rewind, withVersions, isRecursive, isIncomplete, isFake, isBypass, olderThan, newerThan, encKeyDB)
 		} else {
-			e = removeSingle(url, isIncomplete, isFake, isForce, isBypass, olderThan, newerThan, encKeyDB)
+			e = remove(url, versionID, isIncomplete, isFake, isForce, isBypass, olderThan, newerThan, encKeyDB)
 		}
-
 		if rerr == nil {
 			rerr = e
 		}
@@ -393,12 +466,11 @@ func mainRm(cliCtx *cli.Context) error {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		url := scanner.Text()
-		if isRecursive {
-			e = removeRecursive(url, isIncomplete, isFake, isBypass, olderThan, newerThan, encKeyDB)
+		if isRecursive || withVersions {
+			e = listAndRemove(url, rewind, withVersions, isRecursive, isIncomplete, isFake, isBypass, olderThan, newerThan, encKeyDB)
 		} else {
-			e = removeSingle(url, isIncomplete, isFake, isForce, isBypass, olderThan, newerThan, encKeyDB)
+			e = remove(url, versionID, isIncomplete, isFake, isForce, isBypass, olderThan, newerThan, encKeyDB)
 		}
-
 		if rerr == nil {
 			rerr = e
 		}

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -128,7 +128,7 @@ func mainStat(cliCtx *cli.Context) error {
 
 	var cErr error
 	for _, targetURL := range args {
-		stats, err := statURL(ctx, targetURL, false, isRecursive, encKeyDB)
+		stats, err := statURL(ctx, targetURL, "", false, isRecursive, encKeyDB)
 		if err != nil {
 			fatalIf(err, "Unable to stat `"+targetURL+"`.")
 		}

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -889,6 +889,9 @@ USAGE:
    mc rm [FLAGS] TARGET [TARGET ...]
 
 FLAGS:
+  --versions                    remove object(s) and all its versions
+  --rewind value                back in time before removal
+  --version-id value            delete a specific version of an object
   --recursive, -r               remove recursively
   --force                       allow a recursive remove operation
   --dangerous                   allow site-wide removal of objects
@@ -938,6 +941,21 @@ mc rm -r --force --older-than 1d2h30m myminio/mybucket
 Removing `myminio/mybucket/dayOld1.txt`.
 Removing `myminio/mybucket/dayOld2.txt`.
 Removing `myminio/mybucket/dayOld3.txt`.
+```
+
+*Example: Remove a particular version ID.*
+
+```
+mc rm s3/docs/money.xls --version-id "f20f3792-4bd4-4288-8d3c-b9d05b3b62f6"
+Removing `s3/docs/money.xls`.
+```
+
+*Example: Remove all object versions older than one year.*
+
+```
+mc rm s3/docs/ --recursive --versions --rewind 365d
+Removing `s3/docs/foo.xls` (version-id=BgRaeIUnPgJ2gB7wj5LSB1hJ9buuHJBM, mod-time=2020-08-05 13:42:08 +0000 UTC).
+Removing `s3/docs/foo.xls` (version-id=rdHL_s7r0SKWemO.HUMCD63QbTOM9V9W, mod-time=2020-08-05 13:41:59 +0000 UTC).
 ```
 
 <a name="share"></a>

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -890,7 +890,7 @@ USAGE:
 
 FLAGS:
   --versions                    remove object(s) and all its versions
-  --rewind value                back in time before removal
+  --rewind value                revert to older version of object(s) in time
   --version-id value            delete a specific version of an object
   --recursive, -r               remove recursively
   --force                       allow a recursive remove operation


### PR DESCRIPTION
Add versioning support of rm command

--version to specify a specific version id of an object when removing
--versions includes older versions along with objects
--rewind go back in time before removing