### PR TITLE
Fixes mirror not checking modtime

### DIFF
--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -178,7 +178,7 @@ func doDiffMain(ctx context.Context, firstURL, secondURL string) error {
 	}
 
 	// Diff first and second urls.
-	for diffMsg := range objectDifference(ctx, firstClient, secondClient, firstURL, secondURL, true) {
+	for diffMsg := range objectDifference(ctx, firstClient, secondClient, firstURL, secondURL, true, false) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
 			// Ignore error and proceed to next object.

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -127,7 +127,7 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 	}
 
 	// List both source and target, compare and return values through channel.
-	for diffMsg := range objectDifference(ctx, sourceClnt, targetClnt, sourceURL, targetURL, opts.isMetadata) {
+	for diffMsg := range objectDifference(ctx, sourceClnt, targetClnt, sourceURL, targetURL, opts.isMetadata, opts.activeActive) {
 		if diffMsg.Error != nil {
 			// Send all errors through the channel
 			URLsCh <- URLs{Error: diffMsg.Error}


### PR DESCRIPTION
Fixes #3331 

Issue #3331(Minio fails to mirror file after changes if file's size matches) is a regression caused by the fix #3226 (diff: Disable comparing modtimes when multimaster context is not found).
The PR fixes the regression without reverting back PR#3226.