### PR TITLE
fix build on NetBSD

### DIFF
--- a/cmd/client-fs_freebsd_netbsd.go
+++ b/cmd/client-fs_freebsd_netbsd.go
@@ -1,4 +1,4 @@
-// +build freebsd
+// +build freebsd netbsd
 
 /*
  * MinIO Client (C) 2017 MinIO, Inc.

--- a/pkg/disk/stat_freebsd_netbsd.go
+++ b/pkg/disk/stat_freebsd_netbsd.go
@@ -1,4 +1,4 @@
-// +build freebsd
+// +build freebsd netbsd
 
 /*
  * MinIO Cloud Storage, (C) 2019-2020 MinIO, Inc.


### PR DESCRIPTION
This unbreaks the build on NetBSD. NetBSD has recently imported FreeBSD's version of extended attributes so we can reuse the same implementation.