### PR TITLE
find: Add support of --versions/--rewind flags

### DIFF
--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Client (C) 2017-2019 MinIO, Inc.
+ * MinIO Client (C) 2017-2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,14 @@ var (
 		cli.StringFlag{
 			Name:  "ignore",
 			Usage: "exclude objects matching the wildcard pattern",
+		},
+		cli.StringFlag{
+			Name:  "rewind",
+			Usage: "go back in time",
+		},
+		cli.BoolFlag{
+			Name:  "versions",
+			Usage: "include all objects versions",
 		},
 		cli.StringFlag{
 			Name:  "name",
@@ -112,11 +120,12 @@ FORMAT
   Support string substitutions with special interpretations for following keywords.
   Keywords supported if target is filesystem or object storage:
 
-     {}     --> Substitutes to full path.
-     {base} --> Substitutes to basename of path.
-     {dir}  --> Substitutes to dirname of the path.
-     {size} --> Substitutes to object size of the path.
-     {time} --> Substitutes to object modified time of the path.
+     {}        --> Substitutes to full path.
+     {base}    --> Substitutes to basename of path.
+     {dir}     --> Substitutes to dirname of the path.
+     {size}    --> Substitutes to object size of the path.
+     {time}    --> Substitutes to object modified time of the path.
+     {version} --> Substitutes to object version identifier.
 
   Keywords supported if target is object storage:
 
@@ -153,6 +162,9 @@ EXAMPLES:
 
   10. List all objects up to 3 levels sub-directory deep under "s3/bucket".
       {{.Prompt}} {{.HelpName}} s3/bucket --maxdepth 3
+
+  11. Copy all versions of all objects in bucket in the local machine
+      {{.Prompt}} {{.HelpName}} s3/bucket --versions --exec "mc cp --version-id {version} {} /tmp/dir/{}.{version}"
 `,
 }
 
@@ -189,18 +201,20 @@ func checkFindSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 // ease of repurposing.
 type findContext struct {
 	*cli.Context
-	execCmd       string
-	ignorePattern string
-	namePattern   string
-	pathPattern   string
-	regexPattern  string
-	maxDepth      uint
-	printFmt      string
-	olderThan     string
-	newerThan     string
-	largerSize    uint64
-	smallerSize   uint64
-	watch         bool
+	execCmd           string
+	ignorePattern     string
+	namePattern       string
+	pathPattern       string
+	regexPattern      string
+	maxDepth          uint
+	printFmt          string
+	olderThan         string
+	newerThan         string
+	largerSize        uint64
+	smallerSize       uint64
+	watch             bool
+	timeRef           time.Time
+	withOlderVersions bool
 
 	// Internal values
 	targetAlias   string
@@ -258,6 +272,11 @@ func mainFind(cliCtx *cli.Context) error {
 		fatalIf(probe.NewError(e).Trace(cliCtx.String("smaller")), "Unable to parse input bytes.")
 	}
 
+	// Parse --rewind flag
+	timeRef := parseRewindFlag(cliCtx.String("rewind"))
+	// Get --versions flag
+	withVersions := cliCtx.Bool("versions")
+
 	targetAlias, _, hostCfg, err := expandAlias(args[0])
 	fatalIf(err.Trace(args[0]), "Unable to expand alias.")
 
@@ -267,22 +286,24 @@ func mainFind(cliCtx *cli.Context) error {
 	}
 
 	return doFind(ctx, &findContext{
-		Context:       cliCtx,
-		maxDepth:      cliCtx.Uint("maxdepth"),
-		execCmd:       cliCtx.String("exec"),
-		printFmt:      cliCtx.String("print"),
-		namePattern:   cliCtx.String("name"),
-		pathPattern:   cliCtx.String("path"),
-		regexPattern:  cliCtx.String("regex"),
-		ignorePattern: cliCtx.String("ignore"),
-		olderThan:     olderThan,
-		newerThan:     newerThan,
-		largerSize:    largerSize,
-		smallerSize:   smallerSize,
-		watch:         cliCtx.Bool("watch"),
-		targetAlias:   targetAlias,
-		targetURL:     args[0],
-		targetFullURL: targetFullURL,
-		clnt:          clnt,
+		Context:           cliCtx,
+		maxDepth:          cliCtx.Uint("maxdepth"),
+		execCmd:           cliCtx.String("exec"),
+		printFmt:          cliCtx.String("print"),
+		namePattern:       cliCtx.String("name"),
+		pathPattern:       cliCtx.String("path"),
+		regexPattern:      cliCtx.String("regex"),
+		ignorePattern:     cliCtx.String("ignore"),
+		timeRef:           timeRef,
+		withOlderVersions: withVersions,
+		olderThan:         olderThan,
+		newerThan:         newerThan,
+		largerSize:        largerSize,
+		smallerSize:       smallerSize,
+		watch:             cliCtx.Bool("watch"),
+		targetAlias:       targetAlias,
+		targetURL:         args[0],
+		targetFullURL:     targetFullURL,
+		clnt:              clnt,
 	})
 }

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -43,7 +43,12 @@ type findMessage struct {
 
 // String calls tells the console what to print and how to print it.
 func (f findMessage) String() string {
-	return console.Colorize("Find", f.contentMessage.Key)
+	var msg string
+	msg += f.contentMessage.Key
+	if f.VersionID != "" {
+		msg += " (" + f.contentMessage.VersionID + ")"
+	}
+	return console.Colorize("Find", msg)
 }
 
 // JSON formats output to be JSON output.
@@ -246,10 +251,16 @@ func doFind(ctxCtx context.Context, ctx *findContext) error {
 	// following defer is a no-op.
 	defer watchFind(ctxCtx, ctx)
 
-	var prevKeyName string
+	lstOptions := ListOptions{
+		TimeRef:           ctx.timeRef,
+		WithOlderVersions: ctx.withOlderVersions,
+		WithDeleteMarkers: false,
+		Recursive:         true,
+		ShowDir:           DirFirst,
+	}
 
 	// iterate over all content which is within the given directory
-	for content := range ctx.clnt.List(globalContext, ListOptions{Recursive: true, ShowDir: DirFirst}) {
+	for content := range ctx.clnt.List(globalContext, lstOptions) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {
 			// handle this specifically for filesystem related errors.
@@ -269,23 +280,23 @@ func doFind(ctxCtx context.Context, ctx *findContext) error {
 			fatalIf(content.Err.Trace(ctx.clnt.GetURL().String()), "Unable to list folder.")
 			continue
 		}
+
 		if content.StorageClass == s3StorageClassGlacier {
 			continue
 		}
 
 		fileKeyName := getAliasedPath(ctx, content.URL.String())
 		fileContent := contentMessage{
-			Key:  fileKeyName,
-			Time: content.Time.Local(),
-			Size: content.Size,
+			Key:       fileKeyName,
+			VersionID: content.VersionID,
+			Time:      content.Time.Local(),
+			Size:      content.Size,
 		}
 
 		// Match the incoming content, didn't match return.
-		if !matchFind(ctx, fileContent) || prevKeyName == fileKeyName {
+		if !matchFind(ctx, fileContent) {
 			continue
 		} // For all matching content
-
-		prevKeyName = fileKeyName
 
 		// proceed to either exec, format the output string.
 		if ctx.execCmd != "" {
@@ -366,6 +377,16 @@ func stringsReplace(ctx context.Context, args string, fileContent contentMessage
 	// replace all instances of {"url"}
 	if strings.Contains(str, `{"url"}`) {
 		str = strings.Replace(str, `{"url"}`, strconv.Quote(getShareURL(ctx, fileContent.Key)), -1)
+	}
+
+	// replace all instances of {version}
+	if strings.Contains(str, `{version}`) {
+		str = strings.Replace(str, `{version}`, fileContent.VersionID, -1)
+	}
+
+	// replace all instances of {"version"}
+	if strings.Contains(str, `{"version"}`) {
+		str = strings.Replace(str, `{"version"}`, strconv.Quote(fileContent.VersionID), -1)
 	}
 
 	return str

--- a/go.sum
+++ b/go.sum
@@ -764,6 +764,8 @@ golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200425043458-8463f397d07c/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200929223013-bf155c11ec6f h1:7+Nz9MyPqt2qMCTvNiRy1G0zYfkB7UCa+ayT6uVvbyI=
 golang.org/x/tools v0.0.0-20200929223013-bf155c11ec6f/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201021171030-d105bfabbdbe h1:mqtBRk3aoRiR4uBrcErzjJLYCESLpI3dRwRX1g2DWks=
+golang.org/x/tools v0.0.0-20201021171030-d105bfabbdbe/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Also add a possibility to insert the version id in --exec using
{version} or {"version"} mark.
