### PR TITLE
ls: New output format when versioning is enabled

### DIFF
--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -169,7 +169,10 @@ func mainList(cliCtx *cli.Context) error {
 
 	// Additional command specific theme customization.
 	console.SetColor("File", color.New(color.Bold))
-	console.SetColor("DeletedFile", color.New(color.Bold, color.FgRed))
+	console.SetColor("DEL", color.New(color.FgRed))
+	console.SetColor("PUT", color.New(color.FgGreen))
+	console.SetColor("VersionID", color.New(color.FgHiBlue))
+	console.SetColor("VersionOrd", color.New(color.FgHiMagenta))
 	console.SetColor("Dir", color.New(color.FgCyan, color.Bold))
 	console.SetColor("Size", color.New(color.FgYellow))
 	console.SetColor("Time", color.New(color.FgGreen))

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -47,23 +47,27 @@ type contentMessage struct {
 	URL      string    `json:"url,omitempty"`
 
 	VersionID      string `json:"versionId,omitempty"`
-	VersionOrd     string `json:"versionOrdinal,omitempty"`
+	VersionOrd     int    `json:"versionOrdinal,omitempty"`
 	VersionIndex   int    `json:"versionIndex,omitempty"`
 	IsDeleteMarker bool   `json:"isDeleteMarker,omitempty"`
 }
 
 // String colorized string message.
 func (c contentMessage) String() string {
-	message := console.Colorize("Time", fmt.Sprintf("[%s] ", c.Time.Format(printDate)))
-	message += console.Colorize("Size", fmt.Sprintf("%7s ", strings.Join(strings.Fields(humanize.IBytes(uint64(c.Size))), "")))
-	fileDesc := c.Key
+	message := console.Colorize("Time", fmt.Sprintf("[%s]", c.Time.Format(printDate)))
+	message += console.Colorize("Size", fmt.Sprintf("%7s", strings.Join(strings.Fields(humanize.IBytes(uint64(c.Size))), "")))
+	fileDesc := ""
+
 	if c.VersionID != "" {
-		fileDesc += fmt.Sprintf(" (%s, vid=%s", c.VersionOrd, c.VersionID)
+		fileDesc += console.Colorize("VersionID", " "+c.VersionID) + console.Colorize("VersionOrd", fmt.Sprintf(" v%d", c.VersionOrd))
 		if c.IsDeleteMarker {
-			fileDesc += ", delete-marker"
+			fileDesc += console.Colorize("DEL", " DEL")
+		} else {
+			fileDesc += console.Colorize("PUT", " PUT")
 		}
-		fileDesc += ")"
 	}
+
+	fileDesc += " " + c.Key
 
 	if c.Filetype == "folder" {
 		message += console.Colorize("Dir", fileDesc)
@@ -140,7 +144,7 @@ func generateContentMessages(clntURL ClientURL, ctnts []*ClientContent, printAll
 		contentMsg.Key = getKey(c)
 		contentMsg.VersionID = c.VersionID
 		contentMsg.IsDeleteMarker = c.IsDeleteMarker
-		contentMsg.VersionOrd = humanize.Ordinal(nrVersions - i)
+		contentMsg.VersionOrd = nrVersions - i
 		// URL is empty by default
 		// Set it to either relative dir (host) or public url (remote)
 		contentMsg.URL = clntURL.String()


### PR DESCRIPTION
Below is the new listing output:

![Screenshot from 2020-09-01 12-15-54](https://user-images.githubusercontent.com/283197/91843250-5f13ee00-ec4d-11ea-9078-14df48741e74.png)
