### PR TITLE
rm: Show deleted error msg when delete marker is found

### DIFF
--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -173,7 +173,7 @@ type ObjectIsDeleteMarker struct {
 }
 
 func (e ObjectIsDeleteMarker) Error() string {
-	return "Object has been deleted"
+	return "Object is marked as deleted"
 }
 
 // UnexpectedShortWrite - write wrote less bytes than expected.

--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -168,6 +168,14 @@ func (e ObjectMissing) Error() string {
 	return "Object does not exist"
 }
 
+// ObjectIsDeleteMarker - object is a delete marker as latest
+type ObjectIsDeleteMarker struct {
+}
+
+func (e ObjectIsDeleteMarker) Error() string {
+	return "Object has been deleted"
+}
+
 // UnexpectedShortWrite - write wrote less bytes than expected.
 type UnexpectedShortWrite struct {
 	InputSize int

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -241,20 +241,11 @@ func remove(url, versionID string, isIncomplete, isFake, isForce, isBypass bool,
 	ctx, cancelRemoveSingle := context.WithCancel(globalContext)
 	defer cancelRemoveSingle()
 
-	isRecursive := false
-	contents, pErr := statURL(ctx, url, versionID, time.Time{}, false, isIncomplete, isRecursive, encKeyDB)
+	_, content, pErr := url2Stat(ctx, url, versionID, false, encKeyDB, time.Time{})
 	if pErr != nil {
 		errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
 		return exitStatus(globalErrorExitStatus)
 	}
-	if len(contents) == 0 {
-		if !isForce {
-			errorIf(errDummy().Trace(url), "Failed to remove `"+url+"`. Target object is not found")
-			return exitStatus(globalErrorExitStatus)
-		}
-		return nil
-	}
-	content := contents[0]
 
 	// Skip objects older than older--than parameter if specified
 	if olderThan != "" && isOlder(content.Time, olderThan) {

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/minio/cli"
 	json "github.com/minio/mc/pkg/colorjson"
 	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio/pkg/console"
 )
 
@@ -241,25 +243,49 @@ func remove(url, versionID string, isIncomplete, isFake, isForce, isBypass bool,
 	ctx, cancelRemoveSingle := context.WithCancel(globalContext)
 	defer cancelRemoveSingle()
 
+	var (
+		// A remove request can fail with 400 Bad Request when we STAT an
+		// object which is SSE-C encrypted, but we still want to continue
+		// object deletion.
+		failedWith400 bool
+
+		isDir   bool
+		size    int64
+		modTime time.Time
+	)
+
 	_, content, pErr := url2Stat(ctx, url, versionID, false, encKeyDB, time.Time{})
 	if pErr != nil {
+		errResp := minio.ToErrorResponse(pErr.ToGoError())
+		if errResp.StatusCode != http.StatusBadRequest {
+			errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
+			return exitStatus(globalErrorExitStatus)
+		}
+		failedWith400 = true
+	} else {
+		isDir = content.Type.IsDir()
+		size = content.Size
+		modTime = content.Time
+	}
+
+	if failedWith400 && olderThan != "" || newerThan != "" {
 		errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
 		return exitStatus(globalErrorExitStatus)
 	}
 
 	// Skip objects older than older--than parameter if specified
-	if olderThan != "" && isOlder(content.Time, olderThan) {
+	if olderThan != "" && isOlder(modTime, olderThan) {
 		return nil
 	}
 
 	// Skip objects older than older--than parameter if specified
-	if newerThan != "" && isNewer(content.Time, newerThan) {
+	if newerThan != "" && isNewer(modTime, newerThan) {
 		return nil
 	}
 
 	printMsg(rmMessage{
 		Key:       url,
-		Size:      content.Size,
+		Size:      size,
 		VersionID: versionID,
 	})
 
@@ -270,7 +296,8 @@ func remove(url, versionID string, isIncomplete, isFake, isForce, isBypass bool,
 			errorIf(pErr.Trace(url), "Invalid argument `"+url+"`.")
 			return exitStatus(globalErrorExitStatus) // End of journey.
 		}
-		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) && content.Type.IsDir() {
+
+		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) && isDir {
 			targetURL = targetURL + string(clnt.GetURL().Separator)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio v0.0.0-20200917180950-00555c747ec5
-	github.com/minio/minio-go/v7 v7.0.6-0.20200901014009-5f8d15bbc5fd
+	github.com/minio/minio-go/v7 v7.0.6-0.20200918223035-9cefc0929b69
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/minio/minio v0.0.0-20200917180950-00555c747ec5/go.mod h1:dRmX9jR9niWr
 github.com/minio/minio-go/v7 v7.0.5-0.20200811211821-14ed05478889/go.mod h1:CSt2ETZNs+bIIhWTse0mcZKZWMGrFU7Er7RR0TmkDYk=
 github.com/minio/minio-go/v7 v7.0.6-0.20200901014009-5f8d15bbc5fd h1:38hrGmWnv+C+yBcKgAWipiwRDu7Exr0kKAfy1QArW0g=
 github.com/minio/minio-go/v7 v7.0.6-0.20200901014009-5f8d15bbc5fd/go.mod h1:CSt2ETZNs+bIIhWTse0mcZKZWMGrFU7Er7RR0TmkDYk=
+github.com/minio/minio-go/v7 v7.0.6-0.20200918223035-9cefc0929b69 h1:/FOBaOo5vVZrw0QRq1mYrIoQ1tiIi6PLCtYmdb68B0Q=
+github.com/minio/minio-go/v7 v7.0.6-0.20200918223035-9cefc0929b69/go.mod h1:CSt2ETZNs+bIIhWTse0mcZKZWMGrFU7Er7RR0TmkDYk=
 github.com/minio/selfupdate v0.3.1 h1:BWEFSNnrZVMUWXbXIgLDNDjbejkmpAmZvy/nCz1HlEs=
 github.com/minio/selfupdate v0.3.1/go.mod h1:b8ThJzzH7u2MkF6PcIra7KaXO9Khf6alWPvMSyTDCFM=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=


### PR DESCRIPTION
HEAD objet returns 404 with a delete-marker header when the object is a
delete-marker in a versioning bucket. This PR will show a better error
message in that case.