### PR TITLE
update json flag help to indicate the correct format

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -83,8 +83,8 @@ SCAN MODES:
   normal (default): Heal objects which are missing on one or more disks.
   deep            : Heal objects which are missing or with silent data corruption on one or more disks.
 
-EXAMPLES:
-  DEPRECATED
+DEPRECATED:
+  MinIO server now supports auto-heal, this command will be removed in future.
 `,
 }
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -44,7 +44,7 @@ var globalFlags = []cli.Flag{
 	},
 	cli.BoolFlag{
 		Name:  "json",
-		Usage: "enable JSON formatted output",
+		Usage: "enable JSON lines formatted output",
 	},
 	cli.BoolFlag{
 		Name:  "debug",

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -46,7 +46,7 @@ var updateCmd = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "json",
-			Usage: "enable JSON formatted output",
+			Usage: "enable JSON lines formatted output",
 		},
 	},
 	CustomHelpTemplate: `Name:

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -265,7 +265,7 @@ mc: <DEBUG> Response Time:  1.220112837s
 ```
 
 ### Option [--json]
-JSON option enables parseable output in [JSON lines](http://jsonlines.org/) format.
+JSON option enables parseable output in [JSON lines](http://jsonlines.org/), also called as [NDJSON](http://ndjson.org/) format.
 
 *Example: List all buckets from MinIO play service.*
 


### PR DESCRIPTION
some users may get confused without reading the docs
might end up assuming that --json is a full JSON document.