### PR TITLE
Make it possible to mirror without delete

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -57,6 +57,10 @@ var (
 			Usage: "watch and synchronize changes",
 		},
 		cli.BoolFlag{
+			Name:  "keep",
+			Usage: "When watch is set, this will prevent any deletes on target",
+		},
+		cli.BoolFlag{
 			Name:  "remove",
 			Usage: "remove extraneous object(s) on target",
 		},
@@ -535,7 +539,7 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, stopParallel func()) {
 }
 
 func (mj *mirrorJob) watchURL(ctx context.Context, sourceClient Client) *probe.Error {
-	return mj.watcher.Join(ctx, sourceClient, true)
+	return mj.watcher.Join(ctx, sourceClient, true, !mj.opts.isKeep)
 }
 
 // Fetch urls that need to be mirrored
@@ -747,6 +751,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 	}
 
 	isWatch := cli.Bool("watch") || cli.Bool("multi-master") || cli.Bool("active-active")
+	isKeep := cli.Bool("keep")
 
 	// preserve is also expected to be overwritten if necessary
 	isMetadata := cli.Bool("a") || isWatch || len(userMetadata) > 0
@@ -758,6 +763,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 		isOverwrite:      isOverwrite,
 		isWatch:          isWatch,
 		isMetadata:       isMetadata,
+		isKeep:           isKeep,
 		md5:              cli.Bool("md5"),
 		disableMultipart: cli.Bool("disable-multipart"),
 		excludeOptions:   cli.StringSlice("exclude"),

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -198,14 +198,14 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 }
 
 type mirrorOptions struct {
-	isFake, isOverwrite, activeActive bool
-	isWatch, isRemove, isMetadata     bool
-	excludeOptions                    []string
-	encKeyDB                          map[string][]prefixSSEPair
-	md5, disableMultipart             bool
-	olderThan, newerThan              string
-	storageClass                      string
-	userMetadata                      map[string]string
+	isFake, isOverwrite, activeActive     bool
+	isWatch, isRemove, isMetadata, isKeep bool
+	excludeOptions                        []string
+	encKeyDB                              map[string][]prefixSSEPair
+	md5, disableMultipart                 bool
+	olderThan, newerThan                  string
+	storageClass                          string
+	userMetadata                          map[string]string
 }
 
 // Prepares urls that need to be copied or removed based on requested options.

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -141,10 +141,14 @@ func (w *Watcher) Wait() {
 }
 
 // Join the watcher with client
-func (w *Watcher) Join(ctx context.Context, client Client, recursive bool) *probe.Error {
+func (w *Watcher) Join(ctx context.Context, client Client, recursive bool, delete bool) *probe.Error {
+	events := []string{"put"}
+	if delete {
+		events = append(events, "delete")
+	}
 	wo, err := client.Watch(ctx, WatchOptions{
 		Recursive: recursive,
-		Events:    []string{"put", "delete"},
+		Events:    events,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR introduces a proof of concept for the idea to make it possible to use `mc mirror --watch` without deleting target files by using a new flag called `--keep`