### PR TITLE
fix: make assert_failure exit properly

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -173,6 +173,10 @@ function assert()
         else
             echo "mc: $func_name: $err"
         fi
+        
+        if [ "$rv" -eq 0 ]; then
+            exit 1
+        fi
 
         exit "$rv"
     fi


### PR DESCRIPTION
assert_failure

<https://github.com/minio/mc/blob/9ff6c146b42c6f0d526aaee4053549e2c73656a2/functional-tests.sh#L187-L189>

assert

<https://github.com/minio/mc/blob/9ff6c146b42c6f0d526aaee4053549e2c73656a2/functional-tests.sh#L168-L178>

When `"$rv"` is `0`, `assert_failure` will exit with `0` and make the tests passed.

Fix: exits with `1` when `"$rv"` is `0`.