### PR TITLE
Change ListOptions' fields to public

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -199,7 +199,7 @@ func mainAdminHeal(ctx *cli.Context) error {
 		fatalIf(err.Trace(clnt.GetURL().String()), "Unable to create client for URL ", aliasedURL)
 		return nil
 	}
-	for content := range clnt.List(globalContext, ListOptions{isRecursive: false, showDir: DirNone}) {
+	for content := range clnt.List(globalContext, ListOptions{IsRecursive: false, ShowDir: DirNone}) {
 		if content.Err != nil {
 			fatalIf(content.Err.Trace(clnt.GetURL().String()), "Unable to heal bucket `"+bucket+"`.")
 			return nil

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -96,7 +96,7 @@ func completeS3Path(s3Path string) (prediction []string) {
 
 	// List dirPath content and only pick elements that corresponds
 	// to the path that we want to complete
-	for content := range clnt.List(globalContext, ListOptions{isRecursive: false, showDir: DirFirst}) {
+	for content := range clnt.List(globalContext, ListOptions{IsRecursive: false, ShowDir: DirFirst}) {
 		cmplS3Path := alias + getKey(content)
 		if content.Type.IsDir() {
 			if !strings.HasSuffix(cmplS3Path, "/") {

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -506,14 +506,14 @@ func (f *fsClient) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 	contentCh := make(chan *ClientContent)
 	filteredCh := make(chan *ClientContent)
 
-	if opts.isRecursive {
-		if opts.showDir == DirNone {
-			go f.listRecursiveInRoutine(contentCh, opts.isFetchMeta)
+	if opts.IsRecursive {
+		if opts.ShowDir == DirNone {
+			go f.listRecursiveInRoutine(contentCh, opts.IsFetchMeta)
 		} else {
-			go f.listDirOpt(contentCh, opts.isIncomplete, opts.isFetchMeta, opts.showDir)
+			go f.listDirOpt(contentCh, opts.IsIncomplete, opts.IsFetchMeta, opts.ShowDir)
 		}
 	} else {
-		go f.listInRoutine(contentCh, opts.isFetchMeta)
+		go f.listInRoutine(contentCh, opts.IsFetchMeta)
 	}
 
 	// This function filters entries from any  listing go routine
@@ -521,7 +521,7 @@ func (f *fsClient) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 	// only show partly uploaded files,
 	go func() {
 		for c := range contentCh {
-			if opts.isIncomplete {
+			if opts.IsIncomplete {
 				if !strings.HasSuffix(c.URL.Path, partSuffix) {
 					continue
 				}

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -65,7 +65,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	// Verify previously create files and list them.
 	var contents []*ClientContent
-	for content := range fsClient.List(globalContext, ListOptions{showDir: DirNone}) {
+	for content := range fsClient.List(globalContext, ListOptions{ShowDir: DirNone}) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -93,7 +93,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List non recursive to list only top level files.
-	for content := range fsClient.List(globalContext, ListOptions{showDir: DirNone}) {
+	for content := range fsClient.List(globalContext, ListOptions{ShowDir: DirNone}) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -109,7 +109,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List recursively all files and verify.
-	for content := range fsClient.List(globalContext, ListOptions{isRecursive: true, showDir: DirNone}) {
+	for content := range fsClient.List(globalContext, ListOptions{IsRecursive: true, ShowDir: DirNone}) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -153,7 +153,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List recursively all files and verify.
-	for content := range fsClient.List(globalContext, ListOptions{isRecursive: true, showDir: DirNone}) {
+	for content := range fsClient.List(globalContext, ListOptions{IsRecursive: true, ShowDir: DirNone}) {
 		if content.Err != nil {
 			err = content.Err
 			break

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1626,7 +1626,7 @@ func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 
 	contentCh := make(chan *ClientContent)
 
-	if !opts.timeRef.IsZero() || opts.withOlderVersions {
+	if !opts.TimeRef.IsZero() || opts.WithOlderVersions {
 		b, o := c.url2BucketAndObject()
 		go func() {
 			switch {
@@ -1641,7 +1641,7 @@ func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 				}
 				for _, bucket := range buckets {
 					for objectVersion := range c.listVersions(ctx, bucket.Name, "",
-						opts.isRecursive, opts.timeRef, opts.withOlderVersions, opts.withDeleteMarkers) {
+						opts.IsRecursive, opts.TimeRef, opts.WithOlderVersions, opts.WithDeleteMarkers) {
 						if objectVersion.Err != nil {
 							if minio.ToErrorResponse(objectVersion.Err).Code == "NotImplemented" {
 								goto noVersioning
@@ -1659,7 +1659,7 @@ func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 				return
 			default:
 				for objectVersion := range c.listVersions(ctx, b, o,
-					opts.isRecursive, opts.timeRef, opts.withOlderVersions, opts.withDeleteMarkers) {
+					opts.IsRecursive, opts.TimeRef, opts.WithOlderVersions, opts.WithDeleteMarkers) {
 					if objectVersion.Err != nil {
 						if minio.ToErrorResponse(objectVersion.Err).Code == "NotImplemented" {
 							goto noVersioning
@@ -1681,25 +1681,25 @@ func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 		return contentCh
 	}
 
-	if opts.isIncomplete {
-		if opts.isRecursive {
-			if opts.showDir == DirNone {
+	if opts.IsIncomplete {
+		if opts.IsRecursive {
+			if opts.ShowDir == DirNone {
 				go c.listIncompleteRecursiveInRoutine(ctx, contentCh)
 			} else {
-				go c.listIncompleteRecursiveInRoutineDirOpt(ctx, contentCh, opts.showDir)
+				go c.listIncompleteRecursiveInRoutineDirOpt(ctx, contentCh, opts.ShowDir)
 			}
 		} else {
 			go c.listIncompleteInRoutine(ctx, contentCh)
 		}
 	} else {
-		if opts.isRecursive {
-			if opts.showDir == DirNone {
-				go c.listRecursiveInRoutine(ctx, contentCh, opts.isFetchMeta)
+		if opts.IsRecursive {
+			if opts.ShowDir == DirNone {
+				go c.listRecursiveInRoutine(ctx, contentCh, opts.IsFetchMeta)
 			} else {
-				go c.listRecursiveInRoutineDirOpt(ctx, contentCh, opts.showDir, opts.isFetchMeta)
+				go c.listRecursiveInRoutineDirOpt(ctx, contentCh, opts.ShowDir, opts.IsFetchMeta)
 			}
 		} else {
-			go c.listInRoutine(ctx, contentCh, opts.isFetchMeta)
+			go c.listInRoutine(ctx, contentCh, opts.IsFetchMeta)
 		}
 	}
 

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -178,7 +178,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
-	for content := range s3c.List(globalContext, ListOptions{showDir: DirNone}) {
+	for content := range s3c.List(globalContext, ListOptions{ShowDir: DirNone}) {
 		c.Assert(content.Err, IsNil)
 		c.Assert(content.Type.IsDir(), Equals, true)
 	}
@@ -187,7 +187,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
-	for content := range s3c.List(globalContext, ListOptions{showDir: DirNone}) {
+	for content := range s3c.List(globalContext, ListOptions{ShowDir: DirNone}) {
 		c.Assert(content.Err, IsNil)
 		c.Assert(content.Type.IsDir(), Equals, true)
 	}
@@ -196,7 +196,7 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	s3c, err = S3New(conf)
 	c.Assert(err, IsNil)
 
-	for content := range s3c.List(globalContext, ListOptions{showDir: DirNone}) {
+	for content := range s3c.List(globalContext, ListOptions{ShowDir: DirNone}) {
 		c.Assert(content.Err, IsNil)
 		c.Assert(content.Type.IsRegular(), Equals, true)
 	}

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -230,7 +230,7 @@ func isURLPrefixExists(urlPrefix string, incomplete bool) bool {
 	if err != nil {
 		return false
 	}
-	for entry := range clnt.List(globalContext, ListOptions{isRecursive: false, isIncomplete: incomplete, isFetchMeta: false, showDir: DirNone}) {
+	for entry := range clnt.List(globalContext, ListOptions{IsRecursive: false, IsIncomplete: incomplete, IsFetchMeta: false, ShowDir: DirNone}) {
 		return entry.Err == nil
 	}
 	return false

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -61,13 +61,13 @@ type StatOptions struct {
 
 // ListOptions holds options for listing operation
 type ListOptions struct {
-	isRecursive       bool
-	isIncomplete      bool
-	isFetchMeta       bool
-	withOlderVersions bool
-	withDeleteMarkers bool
-	timeRef           time.Time
-	showDir           DirOpt
+	IsRecursive       bool
+	IsIncomplete      bool
+	IsFetchMeta       bool
+	WithOlderVersions bool
+	WithDeleteMarkers bool
+	TimeRef           time.Time
+	ShowDir           DirOpt
 }
 
 // CopyOptions holds options for copying operation

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -166,7 +166,7 @@ func prepareCopyURLsTypeC(ctx context.Context, sourceURL, targetURL string, isRe
 			return
 		}
 
-		for sourceContent := range sourceClient.List(ctx, ListOptions{isRecursive: isRecursive, timeRef: timeRef, showDir: DirNone}) {
+		for sourceContent := range sourceClient.List(ctx, ListOptions{IsRecursive: isRecursive, TimeRef: timeRef, ShowDir: DirNone}) {
 			if sourceContent.Err != nil {
 				// Listing failed.
 				copyURLsCh <- URLs{Error: sourceContent.Err.Trace(sourceClient.GetURL().String())}

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -169,8 +169,8 @@ func dirDifference(ctx context.Context, sourceClnt, targetClnt Client, sourceURL
 
 func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, targetURL string, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt, diffCh chan<- diffMessage) *probe.Error {
 	// Set default values for listing.
-	srcCh := sourceClnt.List(ctx, ListOptions{isRecursive: isRecursive, isFetchMeta: isMetadata, showDir: dirOpt})
-	tgtCh := targetClnt.List(ctx, ListOptions{isRecursive: isRecursive, isFetchMeta: isMetadata, showDir: dirOpt})
+	srcCh := sourceClnt.List(ctx, ListOptions{IsRecursive: isRecursive, IsFetchMeta: isMetadata, ShowDir: dirOpt})
+	tgtCh := targetClnt.List(ctx, ListOptions{IsRecursive: isRecursive, IsFetchMeta: isMetadata, ShowDir: dirOpt})
 
 	srcCtnt, srcOk := <-srcCh
 	tgtCtnt, tgtOk := <-tgtCh

--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -121,10 +121,10 @@ func du(urlStr string, timeRef time.Time, withVersions bool, depth int, encKeyDB
 	}
 
 	contentCh := clnt.List(globalContext, ListOptions{
-		timeRef:           timeRef,
-		withOlderVersions: withVersions,
-		isRecursive:       false,
-		showDir:           DirFirst,
+		TimeRef:           timeRef,
+		WithOlderVersions: withVersions,
+		IsRecursive:       false,
+		ShowDir:           DirFirst,
 	})
 	size := int64(0)
 	for content := range contentCh {

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -249,7 +249,7 @@ func doFind(ctxCtx context.Context, ctx *findContext) error {
 	var prevKeyName string
 
 	// iterate over all content which is within the given directory
-	for content := range ctx.clnt.List(globalContext, ListOptions{isRecursive: true, showDir: DirNone}) {
+	for content := range ctx.clnt.List(globalContext, ListOptions{IsRecursive: true, ShowDir: DirNone}) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {
 			// handle this specifically for filesystem related errors.

--- a/cmd/legalhold-info.go
+++ b/cmd/legalhold-info.go
@@ -164,10 +164,10 @@ func showLegalHoldInfo(ctx context.Context, urlStr, versionID string, timeRef ti
 	var cErr error
 	errorsFound := false
 	objectsFound := false
-	lstOptions := ListOptions{isRecursive: recursive, showDir: DirNone}
+	lstOptions := ListOptions{IsRecursive: recursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
-		lstOptions.withOlderVersions = withOlderVersions
-		lstOptions.timeRef = timeRef
+		lstOptions.WithOlderVersions = withOlderVersions
+		lstOptions.TimeRef = timeRef
 	}
 	for content := range clnt.List(ctx, lstOptions) {
 		if content.Err != nil {

--- a/cmd/legalhold-set.go
+++ b/cmd/legalhold-set.go
@@ -117,10 +117,10 @@ func setLegalHold(ctx context.Context, urlStr, versionID string, timeRef time.Ti
 	alias, _, _ := mustExpandAlias(urlStr)
 	var cErr error
 	objectsFound := false
-	lstOptions := ListOptions{isRecursive: recursive, showDir: DirNone}
+	lstOptions := ListOptions{IsRecursive: recursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
-		lstOptions.withOlderVersions = withOlderVersions
-		lstOptions.timeRef = timeRef
+		lstOptions.WithOlderVersions = withOlderVersions
+		lstOptions.TimeRef = timeRef
 	}
 	for content := range clnt.List(ctx, lstOptions) {
 		if content.Err != nil {

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -190,12 +190,12 @@ func doList(ctx context.Context, clnt Client, isRecursive, isIncomplete bool, ti
 	)
 
 	for content := range clnt.List(ctx, ListOptions{
-		isRecursive:       isRecursive,
-		isIncomplete:      isIncomplete,
-		timeRef:           timeRef,
-		withOlderVersions: withOlderVersions || !timeRef.IsZero(),
-		withDeleteMarkers: true,
-		showDir:           DirNone,
+		IsRecursive:       isRecursive,
+		IsIncomplete:      isIncomplete,
+		TimeRef:           timeRef,
+		WithOlderVersions: withOlderVersions || !timeRef.IsZero(),
+		WithDeleteMarkers: true,
+		ShowDir:           DirNone,
 	}) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -858,7 +858,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 			fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
 
 			dstInitialURL := dstURL
-			for content := range srcClt.List(ctx, ListOptions{isRecursive: false, showDir: DirNone}) {
+			for content := range srcClt.List(ctx, ListOptions{IsRecursive: false, ShowDir: DirNone}) {
 				if content.Err != nil {
 					errorIf(content.Err.Trace(srcClt.GetURL().String()), "Unable to list folder.")
 					continue

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -398,7 +398,7 @@ func runPolicyLinksCmd(args cli.Args, recursive bool) {
 		clnt, err := newClient(newURL)
 		fatalIf(err.Trace(newURL), "Unable to initialize target `"+targetURL+"`.")
 		// Search for public objects
-		for content := range clnt.List(globalContext, ListOptions{isRecursive: recursive, showDir: DirFirst}) {
+		for content := range clnt.List(globalContext, ListOptions{IsRecursive: recursive, ShowDir: DirFirst}) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
 				continue

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -129,10 +129,10 @@ func deleteBucket(ctx context.Context, url string) *probe.Error {
 	go func() {
 		defer close(contentCh)
 		opts := ListOptions{
-			isRecursive:       true,
-			withOlderVersions: true,
-			withDeleteMarkers: true,
-			showDir:           DirLast,
+			IsRecursive:       true,
+			WithOlderVersions: true,
+			WithDeleteMarkers: true,
+			ShowDir:           DirLast,
 		}
 
 		for content := range clnt.List(ctx, opts) {
@@ -222,10 +222,10 @@ func mainRemoveBucket(cliCtx *cli.Context) error {
 		// Check if the bucket contains any object, version or delete marker.
 		isEmpty := true
 		opts := ListOptions{
-			isRecursive:       true,
-			showDir:           DirNone,
-			withOlderVersions: true,
-			withDeleteMarkers: true,
+			IsRecursive:       true,
+			ShowDir:           DirNone,
+			WithOlderVersions: true,
+			WithDeleteMarkers: true,
 		}
 
 		listCtx, listCancel := context.WithCancel(ctx)

--- a/cmd/retention-common.go
+++ b/cmd/retention-common.go
@@ -210,11 +210,11 @@ func applyRetention(ctx context.Context, op, target, versionID string, timeRef t
 		return nil
 	}
 
-	lstOptions := ListOptions{isRecursive: isRecursive, showDir: DirNone}
+	lstOptions := ListOptions{IsRecursive: isRecursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
-		lstOptions.withOlderVersions = withOlderVersions
-		lstOptions.withDeleteMarkers = true
-		lstOptions.timeRef = timeRef
+		lstOptions.WithOlderVersions = withOlderVersions
+		lstOptions.WithDeleteMarkers = true
+		lstOptions.TimeRef = timeRef
 	}
 
 	var cErr error

--- a/cmd/retention-info.go
+++ b/cmd/retention-info.go
@@ -310,11 +310,11 @@ func getRetention(ctx context.Context, target, versionID string, timeRef time.Ti
 		return nil
 	}
 
-	lstOptions := ListOptions{isRecursive: isRecursive, showDir: DirNone}
+	lstOptions := ListOptions{IsRecursive: isRecursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
-		lstOptions.withOlderVersions = withOlderVersions
-		lstOptions.withDeleteMarkers = true
-		lstOptions.timeRef = timeRef
+		lstOptions.WithOlderVersions = withOlderVersions
+		lstOptions.WithDeleteMarkers = true
+		lstOptions.TimeRef = timeRef
 	}
 
 	var cErr error

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -344,11 +344,11 @@ func listAndRemove(url string, timeRef time.Time, withVersions, isRecursive, isI
 
 	errorCh := clnt.Remove(ctx, isIncomplete, isRemoveBucket, isBypass, contentCh)
 
-	listOpts := ListOptions{isRecursive: isRecursive, isIncomplete: isIncomplete, showDir: DirNone}
+	listOpts := ListOptions{IsRecursive: isRecursive, IsIncomplete: isIncomplete, ShowDir: DirNone}
 	if !timeRef.IsZero() {
-		listOpts.withOlderVersions = withVersions
-		listOpts.withDeleteMarkers = true
-		listOpts.timeRef = timeRef
+		listOpts.WithOlderVersions = withVersions
+		listOpts.WithDeleteMarkers = true
+		listOpts.TimeRef = timeRef
 	}
 
 	atLeastOneObjectFound := false

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -155,7 +155,7 @@ func doShareDownloadURL(ctx context.Context, targetURL, versionID string, isRecu
 		// Recursive mode: Share list of objects
 		go func() {
 			defer close(objectsCh)
-			for content := range clnt.List(ctx, ListOptions{isRecursive: isRecursive, showDir: DirNone}) {
+			for content := range clnt.List(ctx, ListOptions{IsRecursive: isRecursive, ShowDir: DirNone}) {
 				objectsCh <- content
 			}
 		}()

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -472,7 +472,7 @@ func mainSQL(cliCtx *cli.Context) error {
 			continue
 		}
 
-		for content := range clnt.List(ctx, ListOptions{isRecursive: cliCtx.Bool("recursive"), showDir: DirNone}) {
+		for content := range clnt.List(ctx, ListOptions{IsRecursive: cliCtx.Bool("recursive"), ShowDir: DirNone}) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(url), "Unable to list on target `"+url+"`.")
 				continue

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -175,15 +175,15 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 	if !strings.HasSuffix(prefixPath, separator) {
 		prefixPath = prefixPath[:strings.LastIndex(prefixPath, separator)+1]
 	}
-	lstOptions := ListOptions{isRecursive: isRecursive, isIncomplete: isIncomplete, showDir: DirNone}
+	lstOptions := ListOptions{IsRecursive: isRecursive, IsIncomplete: isIncomplete, ShowDir: DirNone}
 	switch {
 	case versionID != "":
-		lstOptions.withOlderVersions = true
-		lstOptions.withDeleteMarkers = true
+		lstOptions.WithOlderVersions = true
+		lstOptions.WithDeleteMarkers = true
 	case !timeRef.IsZero():
-		lstOptions.withOlderVersions = includeOlderVersions
-		lstOptions.withDeleteMarkers = true
-		lstOptions.timeRef = timeRef
+		lstOptions.WithOlderVersions = includeOlderVersions
+		lstOptions.WithDeleteMarkers = true
+		lstOptions.TimeRef = timeRef
 	}
 	var cErr error
 	for content := range clnt.List(ctx, lstOptions) {

--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -193,7 +193,7 @@ func mainListTag(cliCtx *cli.Context) error {
 	if timeRef.IsZero() && !withVersions {
 		showTags(ctx, clnt, versionID, true)
 	} else {
-		for content := range clnt.List(ctx, ListOptions{timeRef: timeRef, withOlderVersions: withVersions}) {
+		for content := range clnt.List(ctx, ListOptions{TimeRef: timeRef, WithOlderVersions: withVersions}) {
 			if content.Err != nil {
 				fatalIf(content.Err.Trace(), "Unable to list target "+targetURL)
 			}

--- a/cmd/tag-remove.go
+++ b/cmd/tag-remove.go
@@ -155,7 +155,7 @@ func mainRemoveTag(cliCtx *cli.Context) error {
 	if timeRef.IsZero() && !withVersions {
 		deleteTags(ctx, clnt, versionID, true)
 	} else {
-		for content := range clnt.List(ctx, ListOptions{timeRef: timeRef, withOlderVersions: withVersions}) {
+		for content := range clnt.List(ctx, ListOptions{TimeRef: timeRef, WithOlderVersions: withVersions}) {
 			if content.Err != nil {
 				fatalIf(content.Err.Trace(), "Unable to list target "+targetURL)
 			}

--- a/cmd/tag-set.go
+++ b/cmd/tag-set.go
@@ -154,7 +154,7 @@ func mainSetTag(cliCtx *cli.Context) error {
 	if timeRef.IsZero() && !withVersions {
 		setTags(ctx, clnt, versionID, tags, true)
 	} else {
-		for content := range clnt.List(ctx, ListOptions{timeRef: timeRef, withOlderVersions: withVersions}) {
+		for content := range clnt.List(ctx, ListOptions{TimeRef: timeRef, WithOlderVersions: withVersions}) {
 			if content.Err != nil {
 				fatalIf(content.Err.Trace(), "Unable to list target "+targetURL)
 			}

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -226,7 +226,7 @@ func doTree(ctx context.Context, url string, timeRef time.Time, level int, leaf 
 		return nil
 	}
 
-	for content := range clnt.List(ctx, ListOptions{isRecursive: false, timeRef: timeRef, showDir: DirNone}) {
+	for content := range clnt.List(ctx, ListOptions{IsRecursive: false, TimeRef: timeRef, ShowDir: DirNone}) {
 		if content.Err != nil {
 			errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to tree.")
 			continue

--- a/cmd/undo-main.go
+++ b/cmd/undo-main.go
@@ -198,10 +198,10 @@ func undoURL(ctx context.Context, aliasedURL string, last int, recursive, dryRun
 	)
 
 	for content := range clnt.List(ctx, ListOptions{
-		isRecursive:       recursive,
-		withOlderVersions: true,
-		withDeleteMarkers: true,
-		showDir:           DirNone,
+		IsRecursive:       recursive,
+		WithOlderVersions: true,
+		WithDeleteMarkers: true,
+		ShowDir:           DirNone,
 	}) {
 		if content.Err != nil {
 			fatalIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")


### PR DESCRIPTION
This allows minio/console to take advantage of the current S3Client List function for removal of multiple objects.