### PR TITLE
mv: Fail only if bucket locking is enabled in source urls

### DIFF
--- a/cmd/legalhold-clear.go
+++ b/cmd/legalhold-clear.go
@@ -92,7 +92,13 @@ func mainLegalHoldClear(cliCtx *cli.Context) error {
 	ctx, cancelCopy := context.WithCancel(globalContext)
 	defer cancelCopy()
 
-	checkBucketLockSupport(ctx, targetURL)
+	enabled, err := isBucketLockEnabled(ctx, targetURL)
+	if err != nil {
+		fatalIf(err, "Unable to clear legalhold of `%s`", targetURL)
+	}
+	if !enabled {
+		fatalIf(errDummy().Trace(), "Bucket locking needs to be enabled in order to use this feature.")
+	}
 
 	return setLegalHold(ctx, targetURL, versionID, timeRef, withVersions, recursive, minio.LegalHoldDisabled)
 }

--- a/cmd/legalhold-info.go
+++ b/cmd/legalhold-info.go
@@ -236,7 +236,13 @@ func mainLegalHoldInfo(cliCtx *cli.Context) error {
 	ctx, cancelLegalHold := context.WithCancel(globalContext)
 	defer cancelLegalHold()
 
-	checkBucketLockSupport(ctx, targetURL)
+	enabled, err := isBucketLockEnabled(ctx, targetURL)
+	if err != nil {
+		fatalIf(err, "Unable to get legalhold info of `%s`", targetURL)
+	}
+	if !enabled {
+		fatalIf(errDummy().Trace(), "Bucket lock needs to be enabled in order to use this feature.")
+	}
 
 	return showLegalHoldInfo(ctx, targetURL, versionID, timeRef, withVersions, recursive)
 }

--- a/cmd/legalhold-main.go
+++ b/cmd/legalhold-main.go
@@ -18,7 +18,9 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/minio/cli"
 	json "github.com/minio/mc/pkg/colorjson"
@@ -75,22 +77,36 @@ func (l legalHoldCmdMessage) JSON() string {
 	return string(msgBytes)
 }
 
-// Check if the bucket corresponding to the target url has
-// object locking enabled, this to show a pretty error message
-func checkBucketLockSupport(ctx context.Context, aliasedURL string) {
+var errBucketLockConfigNotFound = errors.New("bucket lock config not found")
+
+func isBucketLockEnabled(ctx context.Context, aliasedURL string) (bool, *probe.Error) {
+	st, err := getBucketLockStatus(ctx, aliasedURL)
+	if err == nil {
+		return st == "Enabled", nil
+	}
+	if err.ToGoError() == errBucketLockConfigNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+// Check if the bucket corresponding to the target url has object locking enabled
+func getBucketLockStatus(ctx context.Context, aliasedURL string) (status string, err *probe.Error) {
 	clnt, err := newClient(aliasedURL)
 	if err != nil {
-		fatalIf(err.Trace(), "Unable to parse the provided url.")
+		return "", err
 	}
 
-	status, _, _, _, err := clnt.GetObjectLockConfig(ctx)
+	status, _, _, _, err = clnt.GetObjectLockConfig(ctx)
 	if err != nil {
-		fatalIf(err.Trace(), "Unable to get bucket object lock configuration from `%s`", aliasedURL)
+		errResp := minio.ToErrorResponse(err.ToGoError())
+		if errResp.StatusCode == http.StatusNotFound {
+			return "", probe.NewError(errBucketLockConfigNotFound)
+		}
+		return "", err
 	}
 
-	if status != "Enabled" {
-		fatalIf(errDummy().Trace(), "Remote bucket does not support locking `%s`", aliasedURL)
-	}
+	return status, nil
 }
 
 // main for retention command.

--- a/cmd/legalhold-set.go
+++ b/cmd/legalhold-set.go
@@ -209,7 +209,13 @@ func mainLegalHoldSet(cliCtx *cli.Context) error {
 	ctx, cancelLegalHold := context.WithCancel(globalContext)
 	defer cancelLegalHold()
 
-	checkBucketLockSupport(ctx, targetURL)
+	enabled, err := isBucketLockEnabled(ctx, targetURL)
+	if err != nil {
+		fatalIf(err, "Unable to set legalhold on `%s`", targetURL)
+	}
+	if !enabled {
+		fatalIf(errDummy().Trace(), "Bucket lock needs to be enabled in order to use this feature.")
+	}
 
 	return setLegalHold(ctx, targetURL, versionID, timeRef, withVersions, recursive, minio.LegalHoldEnabled)
 }

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -297,14 +297,19 @@ func mainMove(cliCtx *cli.Context) error {
 		}
 	}
 
-	for _, urlStr := range cliCtx.Args() {
+	// Check if source URLs does not have object locking enabled
+	// since we cannot move them (remove them from the source)
+	for _, urlStr := range cliCtx.Args()[:cliCtx.NArg()-1] {
 		client, err := newClient(urlStr)
 		if err != nil {
 			fatalIf(err.Trace(), "Unable to parse the provided url.")
 		}
-
-		if s3Client, ok := client.(*S3Client); ok {
-			if _, _, _, _, err = s3Client.GetObjectLockConfig(ctx); err == nil {
+		if _, ok := client.(*S3Client); ok {
+			enabled, err := isBucketLockEnabled(ctx, urlStr)
+			if err != nil {
+				fatalIf(err.Trace(), "Unable to get bucket lock configuration of `%s`", urlStr)
+			}
+			if enabled {
 				fatalIf(errDummy().Trace(), fmt.Sprintf("Object lock configuration is enabled on the specified bucket in alias %v.", urlStr))
 			}
 		}


### PR DESCRIPTION
Previously mv will fail if target URL does not support bucket locking,
but this is wrong, we only need to check for all source URLs

Also this PR adds this funciton: isBucketLockEnabled() to make it easier to return
a boolean true/false without having a non related kind of error (network issues..)