### PR TITLE
Fix 'did you mean' message

### DIFF
--- a/cmd/admin-bucket-remote-main.go
+++ b/cmd/admin-bucket-remote-main.go
@@ -18,23 +18,25 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminBucketRemoteSubcommands = []cli.Command{
+	adminBucketRemoteAddCmd,
+	adminBucketRemoteListCmd,
+	adminBucketRemoteRmCmd,
+}
+
 var adminBucketRemoteCmd = cli.Command{
-	Name:   "remote",
-	Usage:  "configure remote target buckets",
-	Action: mainadminBucketRemote,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminBucketRemoteAddCmd,
-		adminBucketRemoteListCmd,
-		adminBucketRemoteRmCmd,
-	},
+	Name:            "remote",
+	Usage:           "configure remote target buckets",
+	Action:          mainadminBucketRemote,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminBucketRemoteSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainadminBucketRemote is the handle for "mc admin bucket remote" command.
 func mainadminBucketRemote(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminBucketRemoteSubcommands)
 	return nil
 	// Sub-commands like "add", "ls", "rm" have their own main.
 }

--- a/cmd/admin-bucket.go
+++ b/cmd/admin-bucket.go
@@ -18,22 +18,24 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminBucketSubcommands = []cli.Command{
+	adminBucketQuotaCmd,
+	adminBucketRemoteCmd,
+}
+
 var adminBucketCmd = cli.Command{
-	Name:   "bucket",
-	Usage:  "manage buckets defined in the MinIO server",
-	Action: mainAdminBucket,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminBucketQuotaCmd,
-		adminBucketRemoteCmd,
-	},
+	Name:            "bucket",
+	Usage:           "manage buckets defined in the MinIO server",
+	Action:          mainAdminBucket,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminBucketSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminBucket is the handle for "mc admin bucket" command.
 func mainAdminBucket(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminBucketSubcommands)
 	return nil
 	// Sub-commands like "quota", "remote" have their own main.
 }

--- a/cmd/admin-config.go
+++ b/cmd/admin-config.go
@@ -18,27 +18,29 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminConfigSubcommands = []cli.Command{
+	adminConfigGetCmd,
+	adminConfigSetCmd,
+	adminConfigResetCmd,
+	adminConfigHistoryCmd,
+	adminConfigRestoreCmd,
+	adminConfigExportCmd,
+	adminConfigImportCmd,
+}
+
 var adminConfigCmd = cli.Command{
-	Name:   "config",
-	Usage:  "manage MinIO server configuration",
-	Action: mainAdminConfig,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminConfigGetCmd,
-		adminConfigSetCmd,
-		adminConfigResetCmd,
-		adminConfigHistoryCmd,
-		adminConfigRestoreCmd,
-		adminConfigExportCmd,
-		adminConfigImportCmd,
-	},
+	Name:            "config",
+	Usage:           "manage MinIO server configuration",
+	Action:          mainAdminConfig,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminConfigSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminConfig is the handle for "mc admin config" command.
 func mainAdminConfig(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminConfigSubcommands)
 	return nil
 	// Sub-commands like "get", "set" have their own main.
 }

--- a/cmd/admin-group.go
+++ b/cmd/admin-group.go
@@ -18,26 +18,28 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminGroupSubcommands = []cli.Command{
+	adminGroupAddCmd,
+	adminGroupRemoveCmd,
+	adminGroupInfoCmd,
+	adminGroupListCmd,
+	adminGroupEnableCmd,
+	adminGroupDisableCmd,
+}
+
 var adminGroupCmd = cli.Command{
-	Name:   "group",
-	Usage:  "manage groups",
-	Action: mainAdminGroup,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminGroupAddCmd,
-		adminGroupRemoveCmd,
-		adminGroupInfoCmd,
-		adminGroupListCmd,
-		adminGroupEnableCmd,
-		adminGroupDisableCmd,
-	},
+	Name:            "group",
+	Usage:           "manage groups",
+	Action:          mainAdminGroup,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminGroupSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminGroup is the handle for "mc admin config" command.
 func mainAdminGroup(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminGroupSubcommands)
 	return nil
 	// Sub-commands like "get", "set" have their own main.
 }

--- a/cmd/admin-kms-key.go
+++ b/cmd/admin-kms-key.go
@@ -18,21 +18,23 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminKMSKeySubcommands = []cli.Command{
+	adminKMSCreateKeyCmd,
+	adminKMSKeyStatusCmd,
+}
+
 var adminKMSKeyCmd = cli.Command{
-	Name:   "key",
-	Usage:  "manage KMS master keys: Request key status information",
-	Action: mainAdminKMSKey,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminKMSCreateKeyCmd,
-		adminKMSKeyStatusCmd,
-	},
+	Name:            "key",
+	Usage:           "manage KMS master keys: Request key status information",
+	Action:          mainAdminKMSKey,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminKMSKeySubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminKMSKey is the handle for the "mc admin kms key" command.
 func mainAdminKMSKey(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminKMSKeySubcommands)
 	return nil
 }

--- a/cmd/admin-kms.go
+++ b/cmd/admin-kms.go
@@ -18,20 +18,22 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminKMSSubcommands = []cli.Command{
+	adminKMSKeyCmd,
+}
+
 var adminKMSCmd = cli.Command{
-	Name:   "kms",
-	Usage:  "perform KMS management operations",
-	Action: mainAdminKMS,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminKMSKeyCmd,
-	},
+	Name:            "kms",
+	Usage:           "perform KMS management operations",
+	Action:          mainAdminKMS,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminKMSSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminKMS is the handle for the "mc admin kms" command.
 func mainAdminKMS(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminKMSSubcommands)
 	return nil
 }

--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -29,38 +29,40 @@ const (
 	check = "✔"
 )
 
+var adminCmdSubcommands = []cli.Command{
+	adminServiceCmd,
+	adminServerUpdateCmd,
+	adminInfoCmd,
+	adminUserCmd,
+	adminGroupCmd,
+	adminPolicyCmd,
+	adminConfigCmd,
+	adminHealCmd,
+	adminProfileCmd,
+	adminTopCmd,
+	adminTraceCmd,
+	adminConsoleCmd,
+	adminPrometheusCmd,
+	adminKMSCmd,
+	adminOBDCmd,
+	adminBucketCmd,
+}
+
 var adminCmd = cli.Command{
 	Name:            "admin",
 	Usage:           "manage MinIO servers",
 	Action:          mainAdmin,
+	Subcommands:     adminCmdSubcommands,
 	HideHelpCommand: true,
 	Before:          setGlobalsFromContext,
 	Flags:           append(adminFlags, globalFlags...),
-	Subcommands: []cli.Command{
-		adminServiceCmd,
-		adminServerUpdateCmd,
-		adminInfoCmd,
-		adminUserCmd,
-		adminGroupCmd,
-		adminPolicyCmd,
-		adminConfigCmd,
-		adminHealCmd,
-		adminProfileCmd,
-		adminTopCmd,
-		adminTraceCmd,
-		adminConsoleCmd,
-		adminPrometheusCmd,
-		adminKMSCmd,
-		adminOBDCmd,
-		adminBucketCmd,
-	},
 }
 
 const dateTimeFormatFilename = "2006-01-02T15-04-05.999999-07-00"
 
 // mainAdmin is the handle for "mc admin" command.
 func mainAdmin(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminCmdSubcommands)
 	return nil
 	// Sub-commands like "service", "heal", "top" have their own main.
 }

--- a/cmd/admin-policy.go
+++ b/cmd/admin-policy.go
@@ -18,25 +18,27 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminPolicySubcommands = []cli.Command{
+	adminPolicyAddCmd,
+	adminPolicyRemoveCmd,
+	adminPolicyListCmd,
+	adminPolicyInfoCmd,
+	adminPolicySetCmd,
+}
+
 var adminPolicyCmd = cli.Command{
-	Name:   "policy",
-	Usage:  "manage policies defined in the MinIO server",
-	Action: mainAdminPolicy,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminPolicyAddCmd,
-		adminPolicyRemoveCmd,
-		adminPolicyListCmd,
-		adminPolicyInfoCmd,
-		adminPolicySetCmd,
-	},
+	Name:            "policy",
+	Usage:           "manage policies defined in the MinIO server",
+	Action:          mainAdminPolicy,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminPolicySubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminPolicy is the handle for "mc admin policy" command.
 func mainAdminPolicy(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminPolicySubcommands)
 	return nil
 	// Sub-commands like "get", "set" have their own main.
 }

--- a/cmd/admin-profile.go
+++ b/cmd/admin-profile.go
@@ -20,21 +20,23 @@ import (
 	"github.com/minio/cli"
 )
 
+var adminProfileSubcommands = []cli.Command{
+	adminProfileStartCmd,
+	adminProfileStopCmd,
+}
+
 var adminProfileCmd = cli.Command{
-	Name:   "profile",
-	Usage:  "generate profile data for debugging purposes",
-	Action: mainAdminProfile,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminProfileStartCmd,
-		adminProfileStopCmd,
-	},
+	Name:            "profile",
+	Usage:           "generate profile data for debugging purposes",
+	Action:          mainAdminProfile,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminProfileSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminProfile is the handle for "mc admin profile" command.
 func mainAdminProfile(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminProfileSubcommands)
 	return nil
 }

--- a/cmd/admin-prometheus.go
+++ b/cmd/admin-prometheus.go
@@ -18,6 +18,10 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminPrometheusSubcommands = []cli.Command{
+	adminPrometheusGenerateCmd,
+}
+
 var adminPrometheusCmd = cli.Command{
 	Name:            "prometheus",
 	Usage:           "manages prometheus config",
@@ -25,9 +29,7 @@ var adminPrometheusCmd = cli.Command{
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
-	Subcommands: []cli.Command{
-		adminPrometheusGenerateCmd,
-	},
+	Subcommands:     adminPrometheusSubcommands,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
@@ -42,6 +44,6 @@ FLAGS:
 
 // mainAdminPrometheus is the handle for "mc admin prometheus" command.
 func mainAdminPrometheus(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminPrometheusSubcommands)
 	return nil
 }

--- a/cmd/admin-service.go
+++ b/cmd/admin-service.go
@@ -18,6 +18,11 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminServiceSubcommands = []cli.Command{
+	adminServiceRestartCmd,
+	adminServiceStopCmd,
+}
+
 var adminServiceCmd = cli.Command{
 	Name:            "service",
 	Usage:           "restart and stop all MinIO servers",
@@ -25,15 +30,12 @@ var adminServiceCmd = cli.Command{
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
-	Subcommands: []cli.Command{
-		adminServiceRestartCmd,
-		adminServiceStopCmd,
-	},
+	Subcommands:     adminServiceSubcommands,
 }
 
 // mainAdmin is the handle for "mc admin service" command.
 func mainAdminService(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminServiceSubcommands)
 	return nil
 	// Sub-commands like "status", "restart" have their own main.
 }

--- a/cmd/admin-top.go
+++ b/cmd/admin-top.go
@@ -18,21 +18,23 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminTopSubcommands = []cli.Command{
+	adminTopLocksCmd,
+}
+
 var adminTopCmd = cli.Command{
-	Name:   "top",
-	Usage:  "provide top like statistics for MinIO",
-	Action: mainAdminTop,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminTopLocksCmd,
-	},
+	Name:            "top",
+	Usage:           "provide top like statistics for MinIO",
+	Action:          mainAdminTop,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminTopSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminTop is the handle for "mc admin top" command.
 func mainAdminTop(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminTopSubcommands)
 	return nil
 	// Sub-commands like "locks" have their own main.
 }

--- a/cmd/admin-user.go
+++ b/cmd/admin-user.go
@@ -18,26 +18,28 @@ package cmd
 
 import "github.com/minio/cli"
 
+var adminUserSubcommands = []cli.Command{
+	adminUserAddCmd,
+	adminUserDisableCmd,
+	adminUserEnableCmd,
+	adminUserRemoveCmd,
+	adminUserListCmd,
+	adminUserInfoCmd,
+}
+
 var adminUserCmd = cli.Command{
-	Name:   "user",
-	Usage:  "manage users",
-	Action: mainAdminUser,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		adminUserAddCmd,
-		adminUserDisableCmd,
-		adminUserEnableCmd,
-		adminUserRemoveCmd,
-		adminUserListCmd,
-		adminUserInfoCmd,
-	},
+	Name:            "user",
+	Usage:           "manage users",
+	Action:          mainAdminUser,
+	Before:          setGlobalsFromContext,
+	Flags:           globalFlags,
+	Subcommands:     adminUserSubcommands,
 	HideHelpCommand: true,
 }
 
 // mainAdminUser is the handle for "mc admin config" command.
 func mainAdminUser(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, adminUserSubcommands)
 	return nil
 	// Sub-commands like "get", "set" have their own main.
 }

--- a/cmd/alias-main.go
+++ b/cmd/alias-main.go
@@ -38,6 +38,12 @@ var (
 	aliasFlags = []cli.Flag{}
 )
 
+var aliasSubcommands = []cli.Command{
+	aliasSetCmd,
+	aliasListCmd,
+	aliasRemoveCmd,
+}
+
 var aliasCmd = cli.Command{
 	Name:            "alias",
 	Usage:           "set, remove and list aliases in configuration file",
@@ -45,16 +51,12 @@ var aliasCmd = cli.Command{
 	Before:          setGlobalsFromContext,
 	HideHelpCommand: true,
 	Flags:           append(aliasFlags, globalFlags...),
-	Subcommands: []cli.Command{
-		aliasSetCmd,
-		aliasListCmd,
-		aliasRemoveCmd,
-	},
+	Subcommands:     aliasSubcommands,
 }
 
 // mainAlias is the handle for "mc alias" command. provides sub-commands which write configuration data in json format to config file.
 func mainAlias(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, aliasSubcommands)
 	return nil
 	// Sub-commands like add, list and remove have their own main.
 }

--- a/cmd/encrypt-main.go
+++ b/cmd/encrypt-main.go
@@ -18,6 +18,12 @@ package cmd
 
 import "github.com/minio/cli"
 
+var encryptSubcommands = []cli.Command{
+	encryptSetCmd,
+	encryptClearCmd,
+	encryptInfoCmd,
+}
+
 var encryptCmd = cli.Command{
 	Name:            "encrypt",
 	Usage:           "manage bucket encryption config",
@@ -25,16 +31,12 @@ var encryptCmd = cli.Command{
 	Action:          mainEncrypt,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
-	Subcommands: []cli.Command{
-		encryptSetCmd,
-		encryptClearCmd,
-		encryptInfoCmd,
-	},
+	Subcommands:     encryptSubcommands,
 }
 
 // mainEncrypt is the handle for "mc encrypt" command.
 func mainEncrypt(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, encryptSubcommands)
 	return nil
 	// Sub-commands like "info", "set", "clear" have their own main.
 }

--- a/cmd/event-main.go
+++ b/cmd/event-main.go
@@ -22,6 +22,12 @@ var (
 	eventFlags = []cli.Flag{}
 )
 
+var eventSubcommands = []cli.Command{
+	eventAddCmd,
+	eventRemoveCmd,
+	eventListCmd,
+}
+
 var eventCmd = cli.Command{
 	Name:            "event",
 	Usage:           "manage object notifications",
@@ -29,16 +35,12 @@ var eventCmd = cli.Command{
 	Action:          mainEvent,
 	Before:          setGlobalsFromContext,
 	Flags:           append(eventFlags, globalFlags...),
-	Subcommands: []cli.Command{
-		eventAddCmd,
-		eventRemoveCmd,
-		eventListCmd,
-	},
+	Subcommands:     eventSubcommands,
 }
 
 // mainEvent is the handle for "mc event" command.
 func mainEvent(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, eventSubcommands)
 	return nil
 	// Sub-commands like "add", "remove", "list" have their own main.
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -18,14 +18,7 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/minio/pkg/trie"
 )
-
-// Collection of mc commands currently supported
-var commands = []cli.Command{}
-
-// Collection of mc commands currently supported in a trie tree
-var commandsTree = trie.NewTrie()
 
 // Collection of mc flags currently supported
 var globalFlags = []cli.Flag{
@@ -62,10 +55,4 @@ var ioFlags = []cli.Flag{
 		Name:  "encrypt-key",
 		Usage: "encrypt/decrypt objects (using server-side encryption with customer provided keys)",
 	},
-}
-
-// registerCmd registers a cli command
-func registerCmd(cmd cli.Command) {
-	commands = append(commands, cmd)
-	commandsTree.Insert(cmd.Name)
 }

--- a/cmd/ilm-main.go
+++ b/cmd/ilm-main.go
@@ -22,21 +22,23 @@ import (
 	"github.com/minio/minio/pkg/console"
 )
 
-var bucketILMCmd = cli.Command{
+var ilmSubcommands = []cli.Command{
+	ilmLsCmd,
+	ilmAddCmd,
+	ilmRmCmd,
+	ilmSetCmd,
+	ilmExportCmd,
+	ilmImportCmd,
+}
+
+var ilmCmd = cli.Command{
 	Name:            "ilm",
 	Usage:           "manage bucket lifecycle",
 	Action:          mainILM,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
-	Subcommands: []cli.Command{
-		ilmLsCmd,
-		ilmAddCmd,
-		ilmRmCmd,
-		ilmSetCmd,
-		ilmExportCmd,
-		ilmImportCmd,
-	},
+	Subcommands:     ilmSubcommands,
 }
 
 const (
@@ -50,7 +52,7 @@ const (
 )
 
 func mainILM(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, ilmSubcommands)
 	return nil
 }
 

--- a/cmd/legalhold-main.go
+++ b/cmd/legalhold-main.go
@@ -29,17 +29,19 @@ import (
 	"github.com/minio/minio/pkg/console"
 )
 
+var legalHoldSubcommands = []cli.Command{
+	legalHoldSetCmd,
+	legalHoldClearCmd,
+	legalHoldInfoCmd,
+}
+
 var legalHoldCmd = cli.Command{
-	Name:   "legalhold",
-	Usage:  "manage legal hold for object(s)",
-	Action: mainLegalHold,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		legalHoldSetCmd,
-		legalHoldClearCmd,
-		legalHoldInfoCmd,
-	},
+	Name:        "legalhold",
+	Usage:       "manage legal hold for object(s)",
+	Action:      mainLegalHold,
+	Before:      setGlobalsFromContext,
+	Flags:       globalFlags,
+	Subcommands: legalHoldSubcommands,
 }
 
 // Structured message depending on the type of console.
@@ -111,6 +113,6 @@ func getBucketLockStatus(ctx context.Context, aliasedURL string) (status string,
 
 // main for retention command.
 func mainLegalHold(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, legalHoldSubcommands)
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -361,10 +361,6 @@ var appCmds = []cli.Command{
 }
 
 func registerApp(name string) *cli.App {
-	for _, cmd := range appCmds {
-		registerCmd(cmd)
-	}
-
 	cli.HelpFlag = cli.BoolFlag{
 		Name:  "help, h",
 		Usage: "show help",
@@ -403,7 +399,7 @@ func registerApp(name string) *cli.App {
 
 	app.HideHelpCommand = true
 	app.Usage = "MinIO Client for cloud storage and filesystems."
-	app.Commands = commands
+	app.Commands = appCmds
 	app.Author = "MinIO, Inc."
 	app.Version = ReleaseTag
 	app.Flags = append(mcFlags, globalFlags...)

--- a/cmd/replicate-main.go
+++ b/cmd/replicate-main.go
@@ -18,6 +18,15 @@ package cmd
 
 import "github.com/minio/cli"
 
+var replicateSubcommands = []cli.Command{
+	replicateAddCmd,
+	replicateSetCmd,
+	replicateListCmd,
+	replicateExportCmd,
+	replicateImportCmd,
+	replicateRemoveCmd,
+}
+
 var replicateCmd = cli.Command{
 	Name:            "replicate",
 	Usage:           "configure server side bucket replication",
@@ -25,19 +34,12 @@ var replicateCmd = cli.Command{
 	Action:          mainReplicate,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
-	Subcommands: []cli.Command{
-		replicateAddCmd,
-		replicateSetCmd,
-		replicateListCmd,
-		replicateExportCmd,
-		replicateImportCmd,
-		replicateRemoveCmd,
-	},
+	Subcommands:     replicateSubcommands,
 }
 
 // mainReplicate is the handle for "mc replicate" command.
 func mainReplicate(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, replicateSubcommands)
 	return nil
 	// Sub-commands like "list", "clear", "add" have their own main.
 }

--- a/cmd/retention-main.go
+++ b/cmd/retention-main.go
@@ -20,21 +20,23 @@ import (
 	"github.com/minio/cli"
 )
 
+var retentionSubcommands = []cli.Command{
+	retentionSetCmd,
+	retentionClearCmd,
+	retentionInfoCmd,
+}
+
 var retentionCmd = cli.Command{
-	Name:   "retention",
-	Usage:  "set retention for object(s)",
-	Action: mainRetention,
-	Before: setGlobalsFromContext,
-	Flags:  globalFlags,
-	Subcommands: []cli.Command{
-		retentionSetCmd,
-		retentionClearCmd,
-		retentionInfoCmd,
-	},
+	Name:        "retention",
+	Usage:       "set retention for object(s)",
+	Action:      mainRetention,
+	Before:      setGlobalsFromContext,
+	Flags:       globalFlags,
+	Subcommands: retentionSubcommands,
 }
 
 // main for retention command.
 func mainRetention(ctx *cli.Context) error {
-	cli.ShowCommandHelpAndExit(ctx, ctx.Args().First(), 1)
+	commandNotFound(ctx, retentionSubcommands)
 	return nil
 }

--- a/cmd/share-main.go
+++ b/cmd/share-main.go
@@ -29,6 +29,12 @@ var (
 	shareFlags = []cli.Flag{}
 )
 
+var shareSubcommands = []cli.Command{
+	shareDownload,
+	shareUpload,
+	shareList,
+}
+
 // Share documents via URL.
 var shareCmd = cli.Command{
 	Name:            "share",
@@ -37,11 +43,7 @@ var shareCmd = cli.Command{
 	Before:          setGlobalsFromContext,
 	Flags:           append(shareFlags, globalFlags...),
 	HideHelpCommand: true,
-	Subcommands: []cli.Command{
-		shareDownload,
-		shareUpload,
-		shareList,
-	},
+	Subcommands:     shareSubcommands,
 }
 
 // migrateShare migrate to newest version sequentially.
@@ -62,7 +64,7 @@ func migrateShare() {
 
 // mainShare - main handler for mc share command.
 func mainShare(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, shareSubcommands)
 	return nil
 	// Sub-commands like "upload" and "download" have their own main.
 }

--- a/cmd/tag-main.go
+++ b/cmd/tag-main.go
@@ -20,6 +20,12 @@ import (
 	"github.com/minio/cli"
 )
 
+var tagSubcommands = []cli.Command{
+	tagListCmd,
+	tagRemoveCmd,
+	tagSetCmd,
+}
+
 var tagCmd = cli.Command{
 	Name:            "tag",
 	Usage:           "manage tags for bucket and object(s)",
@@ -27,14 +33,10 @@ var tagCmd = cli.Command{
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	HideHelpCommand: true,
-	Subcommands: []cli.Command{
-		tagListCmd,
-		tagRemoveCmd,
-		tagSetCmd,
-	},
+	Subcommands:     tagSubcommands,
 }
 
 func mainTag(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, tagSubcommands)
 	return nil
 }

--- a/cmd/version-main.go
+++ b/cmd/version-main.go
@@ -18,6 +18,12 @@ package cmd
 
 import "github.com/minio/cli"
 
+var versionSubcommands = []cli.Command{
+	versionEnableCmd,
+	versionSuspendCmd,
+	versionInfoCmd,
+}
+
 var versionCmd = cli.Command{
 	Name:            "version",
 	Usage:           "manage bucket versioning",
@@ -25,16 +31,12 @@ var versionCmd = cli.Command{
 	Action:          mainVersion,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
-	Subcommands: []cli.Command{
-		versionEnableCmd,
-		versionSuspendCmd,
-		versionInfoCmd,
-	},
+	Subcommands:     versionSubcommands,
 }
 
 // mainVersion is the handle for "mc version" command.
 func mainVersion(ctx *cli.Context) error {
-	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	commandNotFound(ctx, versionSubcommands)
 	return nil
 	// Sub-commands like "info", "enable", "suspend" have their own main.
 }


### PR DESCRIPTION
Did you mean help message was not working properly, this commit fix it

It also adds support of sub-commands as well.

To check the enhancement that this commit brings:
```
mc adm<Enter>
mc admin ser<Enter>
```