### PR TITLE
s3: Stat() to filter object name when falling back to listing

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1433,6 +1433,10 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 			return nil, probe.NewError(objectStat.Err)
 		}
 
+		if objectStat.Key != object {
+			break
+		}
+
 		return c.objectInfo2ClientContent(bucket, objectStat), nil
 	}
 


### PR DESCRIPTION
client S3 Stat() API tries to use HEAD requests but fall back to regular
listing when there is a permission issue with HEAD or when the object is
encrypted using SSE-C.

However the code accepts any entry from the minio-go listing API
which is wrong. It needs to only accept the object name as passed
by the the upper layer.