### PR TITLE
Deprecate 'admin health', add 'admin subnet health'

### DIFF
--- a/cmd/admin-main.go
+++ b/cmd/admin-main.go
@@ -44,7 +44,8 @@ var adminCmdSubcommands = []cli.Command{
 	adminConsoleCmd,
 	adminPrometheusCmd,
 	adminKMSCmd,
-	adminOBDCmd,
+	adminHealthCmd,
+	adminSubnetCmd,
 	adminBucketCmd,
 }
 

--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -52,13 +52,12 @@ var adminOBDFlags = []cli.Flag{
 	},
 }
 
-var adminOBDCmd = cli.Command{
-	Name:    "health",
-	Aliases: []string{"obd"},
-	Usage:   "run on-board diagnostics",
-	Action:  mainAdminOBD,
-	Before:  setGlobalsFromContext,
-	Flags:   append(adminOBDFlags, globalFlags...),
+var adminSubnetHealthCmd = cli.Command{
+	Name:   "health",
+	Usage:  "run health check for Subnet",
+	Action: mainAdminOBD,
+	Before: setGlobalsFromContext,
+	Flags:  append(adminOBDFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/admin-subnet.go
+++ b/cmd/admin-subnet.go
@@ -1,0 +1,58 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+)
+
+var adminSubnetCmd = cli.Command{
+	Name:   "subnet",
+	Usage:  "Subnet related commands",
+	Action: mainAdminSubnet,
+	Before: setGlobalsFromContext,
+	Flags:  globalFlags,
+	Subcommands: []cli.Command{
+		adminSubnetHealthCmd,
+		// adminSubnetRegister to be added
+	},
+	HideHelpCommand: true,
+}
+
+// mainAdminSubnet is the handle for "mc admin subnet" command.
+func mainAdminSubnet(ctx *cli.Context) error {
+	cli.ShowCommandHelp(ctx, ctx.Args().First())
+	return nil
+	// Sub-commands like "health", "register" have their own main.
+}
+
+// Deprecated - to be removed in a future release
+// mainAdminSubnet is the handle for "mc admin subnet" command.
+func mainAdminHealth(ctx *cli.Context) error {
+	color.Yellow("Deprecated - please use 'mc admin subnet health'")
+	return nil
+}
+
+var adminHealthCmd = cli.Command{
+	Name:               "health",
+	Aliases:            []string{"obd"},
+	Usage:              "Deprecated - please use 'mc admin subnet health'",
+	Action:             mainAdminHealth,
+	CustomHelpTemplate: `{{.Usage}}`,
+	Hidden:             true,
+}

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -351,7 +351,7 @@ var completeCmds = map[string]complete.Predictor{
 	"/admin/kms/key/create": aliasCompleter,
 	"/admin/kms/key/status": aliasCompleter,
 
-	"/admin/health": aliasCompleter,
+	"/admin/subnet/health": aliasCompleter,
 
 	"/alias/set":    nil,
 	"/alias/list":   aliasCompleter,


### PR DESCRIPTION
The existing command `admin health` is being restructured to `admin subnet health` as the reports generated by this command are primarily intended to be uploaded to Subnet.

If user runs the `admin health` command, they'll be asked to run `admin
subnet health` command.