### PR TITLE
ls: Fix listing buckets with --versions

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1654,8 +1654,16 @@ func (c *S3Client) versionedList(ctx context.Context, contentCh chan *ClientCont
 			}
 			return
 		}
-		for _, bucket := range buckets {
 
+		// List only buckets if not recursive
+		if !opts.IsRecursive {
+			for _, bucket := range buckets {
+				contentCh <- c.bucketInfo2ClientContent(bucket)
+			}
+			return
+		}
+
+		for _, bucket := range buckets {
 			if opts.ShowDir == DirFirst {
 				contentCh <- c.bucketInfo2ClientContent(bucket)
 			}


### PR DESCRIPTION
mc ls --versions alias/ has an unexpected output due to missing
consideration of this use case. This commit fixes the behavior.

To test:
```mc ls --versions play/```