### PR TITLE
Implement barrier in parallel manager

### DIFF
--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -34,6 +34,15 @@ const (
 // Number of workers added per bandwidth monitoring.
 var defaultWorkerFactor = runtime.GOMAXPROCS(0)
 
+// A task is a copy/mirror action that needs to be executed
+type task struct {
+	// The function to execute in this task
+	fn func() URLs
+	// If set to true, ensure no tasks are
+	// executed in parallel to this one.
+	barrier bool
+}
+
 // ParallelManager - helps manage parallel workers to run tasks
 type ParallelManager struct {
 	// Calculate sent bytes.
@@ -43,13 +52,14 @@ type ParallelManager struct {
 	sentBytes int64
 
 	// Synchronize workers
-	wg *sync.WaitGroup
+	wg          *sync.WaitGroup
+	barrierSync sync.RWMutex
 
 	// Current threads number
 	workersNum uint32
 
 	// Channel to receive tasks to run
-	queueCh chan func() URLs
+	queueCh chan task
 
 	// Channel to send back results
 	resultCh chan URLs
@@ -73,15 +83,21 @@ func (p *ParallelManager) addWorker() {
 	go func() {
 		for {
 			// Wait for jobs
-			fn, ok := <-p.queueCh
+			t, ok := <-p.queueCh
 			if !ok {
 				// No more tasks, quit
 				p.wg.Done()
 				return
 			}
-			// Execute the task and send the result
-			// to result channel.
-			p.resultCh <- fn()
+
+			// Execute the task and send the result to channel.
+			p.resultCh <- t.fn()
+
+			if t.barrier {
+				p.barrierSync.Unlock()
+			} else {
+				p.barrierSync.RUnlock()
+			}
 		}
 	}()
 }
@@ -135,8 +151,25 @@ func (p *ParallelManager) monitorProgress() {
 	}()
 }
 
+// Queue task in parallel
 func (p *ParallelManager) queueTask(fn func() URLs) {
-	p.queueCh <- fn
+	p.doQueueTask(task{fn: fn})
+}
+
+// Queue task but ensures that no tasks is running at parallel,
+// which also means wait until all concurrent tasks finish before
+// queueing this and execute it solely.
+func (p *ParallelManager) queueTaskWithBarrier(fn func() URLs) {
+	p.doQueueTask(task{fn: fn, barrier: true})
+}
+
+func (p *ParallelManager) doQueueTask(t task) {
+	if t.barrier {
+		p.barrierSync.Lock()
+	} else {
+		p.barrierSync.RLock()
+	}
+	p.queueCh <- t
 }
 
 // Wait for all workers to finish tasks before shutting down Parallel
@@ -152,7 +185,7 @@ func newParallelManager(resultCh chan URLs) *ParallelManager {
 		wg:            &sync.WaitGroup{},
 		workersNum:    0,
 		stopMonitorCh: make(chan struct{}),
-		queueCh:       make(chan func() URLs),
+		queueCh:       make(chan task),
 		resultCh:      resultCh,
 	}
 


### PR DESCRIPTION
Mirroring watch supports parallel manager to run actions of the received
events in parallel, but sometimes the order of the execution of those
actions matter.

For example:
- A new bucket is created
- A new file is uploaded in the new bucket

This PR will bring support of the barrier concept. A task with a barrier
will only executed after all the previous tasks finish, the
subsequent tasks will also be only executed when the barrier task is
finished.

Later, we will bring support of tasks dependency to optimize the
parallelism.