### PR TITLE
Fix client-s3.Makebucket behavior with object in path

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1196,10 +1196,7 @@ func (c *S3Client) MakeBucket(ctx context.Context, region string, ignoreExisting
 	}
 	if object != "" {
 		if !strings.HasSuffix(object, string(c.targetURL.Separator)) {
-			object = path.Dir(object)
-		}
-		if !strings.HasSuffix(object, string(c.targetURL.Separator)) {
-			return probe.NewError(BucketNameTopLevel{})
+			object += string(c.targetURL.Separator)
 		}
 		var retried bool
 		for {


### PR DESCRIPTION
The S3 client supports creating buckets & directories in MakeBucket call, but currently
it calls path.Dir() for no apparent reason.

Remove path.Dir() call and add a trailing slash to the object if it doesnt have one.