### PR TITLE
fix `mc stat` with --versions flag to show versionID correctly

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1470,6 +1470,10 @@ func (c *S3Client) getObjectStat(ctx context.Context, bucket, object string, opt
 		}
 		return nil, probe.NewError(e)
 	}
+	// HEAD with a version ID will not return version in the response headers
+	if objectMetadata.VersionID == "" {
+		objectMetadata.VersionID = opts.VersionID
+	}
 	return objectMetadata, nil
 }
 

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -155,10 +155,6 @@ func mainStat(cliCtx *cli.Context) error {
 
 	// check 'stat' cli arguments.
 	args, isRecursive, versionID, rewind, withVersions := parseAndCheckStatSyntax(ctx, cliCtx, encKeyDB)
-	if withVersions && rewind.IsZero() {
-		rewind = time.Now().UTC()
-	}
-
 	// mimic operating system tool behavior.
 	if len(args) == 0 {
 		args = []string{"."}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -180,7 +180,7 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 	case versionID != "":
 		lstOptions.WithOlderVersions = true
 		lstOptions.WithDeleteMarkers = true
-	case !timeRef.IsZero():
+	case !timeRef.IsZero(), includeOlderVersions:
 		lstOptions.WithOlderVersions = includeOlderVersions
 		lstOptions.WithDeleteMarkers = true
 		lstOptions.TimeRef = timeRef
@@ -224,8 +224,7 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 				continue
 			}
 		}
-
-		clnt, stat, err := url2Stat(ctx, url, versionID, true, encKeyDB, timeRef)
+		clnt, stat, err := url2Stat(ctx, url, content.VersionID, true, encKeyDB, timeRef)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
If --versions flag is specified, instead of HEAD on each version, currently
repeated listing is being done and latest version ID reported
for all the versions instead of actual version ID.

`mc stat source/bucket/obj --versions` 