### PR TITLE
fix: mirror cmd Invalid Request error

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -929,6 +930,10 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, metada
 
 	contentType, ok := metadata["Content-Type"]
 	if ok {
+		typ, _, _ := mime.ParseMediaType(contentType)
+		if typ == "multipart/form-data" {
+			contentType = "application/octet-stream"
+		}
 		delete(metadata, "Content-Type")
 	} else {
 		// Set content-type if not specified.


### PR DESCRIPTION
mirror cmd `Invalid Request` error occur when file size large than minPartSize(128Mi) and Content-Type is multipart/form-data;

```
./mc stat  xxx
Metadata  :
  Content-Type: multipart/form-data;
```

```
./mc mirror xxx/flash new1/flash
 425.56 MiB / 425.56 MiB ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  22.10 GiB/s
mc: <ERROR> Failed to copy `xxxxxx`. Invalid Request
```


