### PR TITLE
multiple bug fixes for mirror, ls, rm

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -200,7 +200,7 @@ func mainAdminHeal(ctx *cli.Context) error {
 		return nil
 	}
 
-	for content := range clnt.List(globalContext, ListOptions{IsRecursive: false, ShowDir: DirNone}) {
+	for content := range clnt.List(globalContext, ListOptions{Recursive: false, ShowDir: DirNone}) {
 		if content.Err != nil {
 			fatalIf(content.Err.Trace(clnt.GetURL().String()), "Unable to heal bucket `"+bucket+"`.")
 			return nil

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -96,7 +96,7 @@ func completeS3Path(s3Path string) (prediction []string) {
 
 	// List dirPath content and only pick elements that corresponds
 	// to the path that we want to complete
-	for content := range clnt.List(globalContext, ListOptions{IsRecursive: false, ShowDir: DirFirst}) {
+	for content := range clnt.List(globalContext, ListOptions{Recursive: false, ShowDir: DirFirst}) {
 		cmplS3Path := alias + getKey(content)
 		if content.Type.IsDir() {
 			if !strings.HasSuffix(cmplS3Path, "/") {

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -506,14 +506,14 @@ func (f *fsClient) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 	contentCh := make(chan *ClientContent)
 	filteredCh := make(chan *ClientContent)
 
-	if opts.IsRecursive {
+	if opts.Recursive {
 		if opts.ShowDir == DirNone {
-			go f.listRecursiveInRoutine(contentCh, opts.IsFetchMeta)
+			go f.listRecursiveInRoutine(contentCh, opts.WithMetadata)
 		} else {
-			go f.listDirOpt(contentCh, opts.IsIncomplete, opts.IsFetchMeta, opts.ShowDir)
+			go f.listDirOpt(contentCh, opts.Incomplete, opts.WithMetadata, opts.ShowDir)
 		}
 	} else {
-		go f.listInRoutine(contentCh, opts.IsFetchMeta)
+		go f.listInRoutine(contentCh, opts.WithMetadata)
 	}
 
 	// This function filters entries from any  listing go routine
@@ -521,7 +521,7 @@ func (f *fsClient) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 	// only show partly uploaded files,
 	go func() {
 		for c := range contentCh {
-			if opts.IsIncomplete {
+			if opts.Incomplete {
 				if !strings.HasSuffix(c.URL.Path, partSuffix) {
 					continue
 				}

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -109,7 +109,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List recursively all files and verify.
-	for content := range fsClient.List(globalContext, ListOptions{IsRecursive: true, ShowDir: DirNone}) {
+	for content := range fsClient.List(globalContext, ListOptions{Recursive: true, ShowDir: DirNone}) {
 		if content.Err != nil {
 			err = content.Err
 			break
@@ -153,7 +153,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	contents = nil
 	// List recursively all files and verify.
-	for content := range fsClient.List(globalContext, ListOptions{IsRecursive: true, ShowDir: DirNone}) {
+	for content := range fsClient.List(globalContext, ListOptions{Recursive: true, ShowDir: DirNone}) {
 		if content.Err != nil {
 			err = content.Err
 			break

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -230,7 +230,7 @@ func isURLPrefixExists(urlPrefix string, incomplete bool) bool {
 	if err != nil {
 		return false
 	}
-	for entry := range clnt.List(globalContext, ListOptions{IsRecursive: false, IsIncomplete: incomplete, IsFetchMeta: false, ShowDir: DirNone}) {
+	for entry := range clnt.List(globalContext, ListOptions{Recursive: false, Incomplete: incomplete, WithMetadata: false, ShowDir: DirNone}) {
 		return entry.Err == nil
 	}
 	return false

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -61,9 +61,9 @@ type StatOptions struct {
 
 // ListOptions holds options for listing operation
 type ListOptions struct {
-	IsRecursive       bool
-	IsIncomplete      bool
-	IsFetchMeta       bool
+	Recursive         bool
+	Incomplete        bool
+	WithMetadata      bool
 	WithOlderVersions bool
 	WithDeleteMarkers bool
 	TimeRef           time.Time

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -166,7 +166,7 @@ func prepareCopyURLsTypeC(ctx context.Context, sourceURL, targetURL string, isRe
 			return
 		}
 
-		for sourceContent := range sourceClient.List(ctx, ListOptions{IsRecursive: isRecursive, TimeRef: timeRef, ShowDir: DirNone}) {
+		for sourceContent := range sourceClient.List(ctx, ListOptions{Recursive: isRecursive, TimeRef: timeRef, ShowDir: DirNone}) {
 			if sourceContent.Err != nil {
 				// Listing failed.
 				copyURLsCh <- URLs{Error: sourceContent.Err.Trace(sourceClient.GetURL().String())}

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -140,11 +140,14 @@ func checkDiffSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 	// Verify if secondURL is accessible.
 	_, secondContent, err := url2Stat(ctx, secondURL, "", false, encKeyDB, time.Time{})
 	if err != nil {
-		fatalIf(err.Trace(secondURL), fmt.Sprintf("Unable to stat '%s'.", secondURL))
+		// Destination doesn't exist is okay.
+		if _, ok := err.ToGoError().(ObjectMissing); !ok {
+			fatalIf(err.Trace(secondURL), fmt.Sprintf("Unable to stat '%s'.", secondURL))
+		}
 	}
 
 	// Verify if its a directory.
-	if !secondContent.Type.IsDir() {
+	if err == nil && !secondContent.Type.IsDir() {
 		fatalIf(errInvalidArgument().Trace(secondURL), fmt.Sprintf("`%s` is not a folder.", secondURL))
 	}
 }

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -170,8 +170,8 @@ func dirDifference(ctx context.Context, sourceClnt, targetClnt Client, sourceURL
 
 func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, targetURL string, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt, diffCh chan<- diffMessage) *probe.Error {
 	// Set default values for listing.
-	srcCh := sourceClnt.List(ctx, ListOptions{IsRecursive: isRecursive, IsFetchMeta: isMetadata, ShowDir: dirOpt})
-	tgtCh := targetClnt.List(ctx, ListOptions{IsRecursive: isRecursive, IsFetchMeta: isMetadata, ShowDir: dirOpt})
+	srcCh := sourceClnt.List(ctx, ListOptions{Recursive: isRecursive, WithMetadata: isMetadata, ShowDir: dirOpt})
+	tgtCh := targetClnt.List(ctx, ListOptions{Recursive: isRecursive, WithMetadata: isMetadata, ShowDir: dirOpt})
 
 	srcCtnt, srcOk := <-srcCh
 	tgtCtnt, tgtOk := <-tgtCh

--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -123,7 +123,7 @@ func du(urlStr string, timeRef time.Time, withVersions bool, depth int, encKeyDB
 	contentCh := clnt.List(globalContext, ListOptions{
 		TimeRef:           timeRef,
 		WithOlderVersions: withVersions,
-		IsRecursive:       false,
+		Recursive:         false,
 		ShowDir:           DirFirst,
 	})
 	size := int64(0)

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -249,7 +249,7 @@ func doFind(ctxCtx context.Context, ctx *findContext) error {
 	var prevKeyName string
 
 	// iterate over all content which is within the given directory
-	for content := range ctx.clnt.List(globalContext, ListOptions{IsRecursive: true, ShowDir: DirFirst}) {
+	for content := range ctx.clnt.List(globalContext, ListOptions{Recursive: true, ShowDir: DirFirst}) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {
 			// handle this specifically for filesystem related errors.

--- a/cmd/legalhold-info.go
+++ b/cmd/legalhold-info.go
@@ -164,7 +164,7 @@ func showLegalHoldInfo(ctx context.Context, urlStr, versionID string, timeRef ti
 	var cErr error
 	errorsFound := false
 	objectsFound := false
-	lstOptions := ListOptions{IsRecursive: recursive, ShowDir: DirNone}
+	lstOptions := ListOptions{Recursive: recursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
 		lstOptions.WithOlderVersions = withOlderVersions
 		lstOptions.TimeRef = timeRef

--- a/cmd/legalhold-set.go
+++ b/cmd/legalhold-set.go
@@ -117,7 +117,7 @@ func setLegalHold(ctx context.Context, urlStr, versionID string, timeRef time.Ti
 	alias, _, _ := mustExpandAlias(urlStr)
 	var cErr error
 	objectsFound := false
-	lstOptions := ListOptions{IsRecursive: recursive, ShowDir: DirNone}
+	lstOptions := ListOptions{Recursive: recursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
 		lstOptions.WithOlderVersions = withOlderVersions
 		lstOptions.TimeRef = timeRef

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -190,12 +190,12 @@ func doList(ctx context.Context, clnt Client, isRecursive, isIncomplete bool, ti
 	)
 
 	for content := range clnt.List(ctx, ListOptions{
-		IsRecursive:       isRecursive,
-		IsIncomplete:      isIncomplete,
+		Recursive:         isRecursive,
+		Incomplete:        isIncomplete,
 		TimeRef:           timeRef,
 		WithOlderVersions: withOlderVersions || !timeRef.IsZero(),
 		WithDeleteMarkers: true,
-		ShowDir:           DirFirst,
+		ShowDir:           DirNone,
 	}) {
 		if content.Err != nil {
 			switch content.Err.ToGoError().(type) {

--- a/cmd/policy-main.go
+++ b/cmd/policy-main.go
@@ -391,7 +391,7 @@ func runPolicyLinksCmd(args cli.Args, recursive bool) {
 		clnt, err := newClient(newURL)
 		fatalIf(err.Trace(newURL), "Unable to initialize target `"+targetURL+"`.")
 		// Search for public objects
-		for content := range clnt.List(globalContext, ListOptions{IsRecursive: recursive, ShowDir: DirFirst}) {
+		for content := range clnt.List(globalContext, ListOptions{Recursive: recursive, ShowDir: DirFirst}) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
 				continue

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -129,7 +129,7 @@ func deleteBucket(ctx context.Context, url string) *probe.Error {
 	go func() {
 		defer close(contentCh)
 		opts := ListOptions{
-			IsRecursive:       true,
+			Recursive:         true,
 			WithOlderVersions: true,
 			WithDeleteMarkers: true,
 			ShowDir:           DirLast,
@@ -222,7 +222,7 @@ func mainRemoveBucket(cliCtx *cli.Context) error {
 		// Check if the bucket contains any object, version or delete marker.
 		isEmpty := true
 		opts := ListOptions{
-			IsRecursive:       true,
+			Recursive:         true,
 			ShowDir:           DirNone,
 			WithOlderVersions: true,
 			WithDeleteMarkers: true,

--- a/cmd/retention-common.go
+++ b/cmd/retention-common.go
@@ -223,7 +223,7 @@ func applyRetention(ctx context.Context, op lockOpType, target, versionID string
 		return nil
 	}
 
-	lstOptions := ListOptions{IsRecursive: isRecursive, ShowDir: DirNone}
+	lstOptions := ListOptions{Recursive: isRecursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
 		lstOptions.WithOlderVersions = withOlderVersions
 		lstOptions.WithDeleteMarkers = true

--- a/cmd/retention-info.go
+++ b/cmd/retention-info.go
@@ -310,7 +310,7 @@ func getRetention(ctx context.Context, target, versionID string, timeRef time.Ti
 		return nil
 	}
 
-	lstOptions := ListOptions{IsRecursive: isRecursive, ShowDir: DirNone}
+	lstOptions := ListOptions{Recursive: isRecursive, ShowDir: DirNone}
 	if !timeRef.IsZero() {
 		lstOptions.WithOlderVersions = withOlderVersions
 		lstOptions.WithDeleteMarkers = true

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -344,7 +344,7 @@ func listAndRemove(url string, timeRef time.Time, withVersions, isRecursive, isI
 
 	errorCh := clnt.Remove(ctx, isIncomplete, isRemoveBucket, isBypass, contentCh)
 
-	listOpts := ListOptions{IsRecursive: isRecursive, IsIncomplete: isIncomplete, ShowDir: DirNone}
+	listOpts := ListOptions{Recursive: isRecursive, Incomplete: isIncomplete, ShowDir: DirLast}
 	if !timeRef.IsZero() {
 		listOpts.WithOlderVersions = withVersions
 		listOpts.WithDeleteMarkers = true

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -155,7 +155,7 @@ func doShareDownloadURL(ctx context.Context, targetURL, versionID string, isRecu
 		// Recursive mode: Share list of objects
 		go func() {
 			defer close(objectsCh)
-			for content := range clnt.List(ctx, ListOptions{IsRecursive: isRecursive, ShowDir: DirNone}) {
+			for content := range clnt.List(ctx, ListOptions{Recursive: isRecursive, ShowDir: DirNone}) {
 				objectsCh <- content
 			}
 		}()

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -472,7 +472,7 @@ func mainSQL(cliCtx *cli.Context) error {
 			continue
 		}
 
-		for content := range clnt.List(ctx, ListOptions{IsRecursive: cliCtx.Bool("recursive"), ShowDir: DirNone}) {
+		for content := range clnt.List(ctx, ListOptions{Recursive: cliCtx.Bool("recursive"), ShowDir: DirNone}) {
 			if content.Err != nil {
 				errorIf(content.Err.Trace(url), "Unable to list on target `"+url+"`.")
 				continue

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -175,7 +175,7 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 	if !strings.HasSuffix(prefixPath, separator) {
 		prefixPath = prefixPath[:strings.LastIndex(prefixPath, separator)+1]
 	}
-	lstOptions := ListOptions{IsRecursive: isRecursive, IsIncomplete: isIncomplete, ShowDir: DirNone}
+	lstOptions := ListOptions{Recursive: isRecursive, Incomplete: isIncomplete, ShowDir: DirNone}
 	switch {
 	case versionID != "":
 		lstOptions.WithOlderVersions = true

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -226,7 +226,7 @@ func doTree(ctx context.Context, url string, timeRef time.Time, level int, leaf 
 		return nil
 	}
 
-	for content := range clnt.List(ctx, ListOptions{IsRecursive: false, TimeRef: timeRef, ShowDir: DirFirst}) {
+	for content := range clnt.List(ctx, ListOptions{Recursive: false, TimeRef: timeRef, ShowDir: DirFirst}) {
 		if content.Err != nil {
 			errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to tree.")
 			continue

--- a/cmd/undo-main.go
+++ b/cmd/undo-main.go
@@ -198,7 +198,7 @@ func undoURL(ctx context.Context, aliasedURL string, last int, recursive, dryRun
 	)
 
 	for content := range clnt.List(ctx, ListOptions{
-		IsRecursive:       recursive,
+		Recursive:         recursive,
 		WithOlderVersions: true,
 		WithDeleteMarkers: true,
 		ShowDir:           DirNone,


### PR DESCRIPTION
- fixes errant top level directory creation, regression introduced in #3313
- fixes `mc ls -r` regression introduced in #3476
- fixes other bugs such as `mc mirror` would perpetually hang if the
  destination bucket doesn't exist, create and proceed instead.
- removes DirOpt style implementations for List, ListIncompleteUploads
  these are not useful anymore.