### PR TITLE
mc: Parallel tasks with names dependency

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -530,11 +530,11 @@ func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.
 
 				// Verify if previously copied, notify progress bar.
 				if isCopied != nil && isCopied(cpURLs.SourceContent.URL.String()) {
-					parallel.queueTask(func() URLs {
+					parallel.queueTask("", func() URLs {
 						return doCopyFake(ctx, cpURLs, pg, isMvCmd)
 					})
 				} else {
-					parallel.queueTask(func() URLs {
+					parallel.queueTask(cpURLs.SourceContent.URL.String(), func() URLs {
 						return doCopy(ctx, cpURLs, pg, encKeyDB, isMvCmd, preserve)
 					})
 				}

--- a/cmd/locker.go
+++ b/cmd/locker.go
@@ -1,0 +1,68 @@
+/*
+ * MinIO Client (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"sync"
+)
+
+type lock struct {
+	sync.Mutex
+	ref int
+}
+
+type namedLocker struct {
+	mu    sync.Mutex
+	locks map[string]*lock
+}
+
+// Lock a name
+func (m *namedLocker) Lock(name string) {
+	m.mu.Lock()
+	l, ok := m.locks[name]
+	if !ok {
+		l = &lock{}
+		m.locks[name] = l
+	}
+	l.ref++
+	m.mu.Unlock()
+
+	l.Mutex.Lock()
+}
+
+// Unlock a name, do nothing if name is not locked
+func (m *namedLocker) Unlock(name string) {
+	m.mu.Lock()
+	l, ok := m.locks[name]
+	if !ok {
+		m.mu.Unlock()
+		// No lock found, do nothing
+		return
+	}
+	l.ref--
+	if l.ref < 1 {
+		delete(m.locks, name)
+	}
+	m.mu.Unlock()
+
+	l.Mutex.Unlock()
+}
+
+// newNamedLocker initializes a new named locker
+func NewNamedLocker() *namedLocker {
+	return &namedLocker{locks: make(map[string]*lock)}
+}

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -479,7 +479,7 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 				// to avoid copying it.
 				continue
 			}
-			mj.parallel.queueTask(func() URLs {
+			mj.parallel.queueTask(sourceURL.String(), func() URLs {
 				return mj.doMirrorWatch(ctx, targetPath, tgtSSE, mirrorURL)
 			})
 		} else if event.Type == EventRemove {
@@ -498,7 +498,7 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 			mirrorURL.TotalCount = mj.status.GetCounts()
 			mirrorURL.TotalSize = mj.status.Get()
 			if mirrorURL.TargetContent != nil && (mj.opts.isRemove || mj.opts.activeActive) {
-				mj.parallel.queueTask(func() URLs {
+				mj.parallel.queueTask(targetURL.String(), func() URLs {
 					return mj.doRemove(ctx, mirrorURL)
 				})
 			}
@@ -528,7 +528,7 @@ func (mj *mirrorJob) watchMirror(ctx context.Context, stopParallel func()) {
 				return
 			}
 			if err != nil {
-				mj.parallel.queueTask(func() URLs {
+				mj.parallel.queueTask("", func() URLs {
 					return URLs{Error: err}
 				})
 			}
@@ -585,11 +585,11 @@ func (mj *mirrorJob) startMirror(ctx context.Context, cancelMirror context.Cance
 			sURLs.TotalSize = mj.status.Get()
 
 			if sURLs.SourceContent != nil {
-				mj.parallel.queueTask(func() URLs {
+				mj.parallel.queueTask(sURLs.SourceContent.URL.String(), func() URLs {
 					return mj.doMirror(ctx, sURLs)
 				})
 			} else if sURLs.TargetContent != nil && mj.opts.isRemove {
-				mj.parallel.queueTask(func() URLs {
+				mj.parallel.queueTask(sURLs.TargetContent.URL.String(), func() URLs {
 					return mj.doRemove(ctx, sURLs)
 				})
 			}


### PR DESCRIPTION
This commit ensures that the order of the execution of events concerning
the same object is always kept when queued in the parallel manager.

So we never execute DELETE before PUT, if the order of events is PUT
then DELETE.