### PR TITLE
Change GetOptions' fields to public

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -817,8 +817,8 @@ func (c *S3Client) Get(ctx context.Context, opts GetOptions) (io.ReadCloser, *pr
 	bucket, object := c.url2BucketAndObject()
 	reader, e := c.api.GetObject(ctx, bucket, object,
 		minio.GetObjectOptions{
-			ServerSideEncryption: opts.sse,
-			VersionID:            opts.versionID,
+			ServerSideEncryption: opts.SSE,
+			VersionID:            opts.VersionID,
 		})
 	if e != nil {
 		errResponse := minio.ToErrorResponse(e)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -46,8 +46,8 @@ const defaultMultipartThreadsNum = 4
 
 // GetOptions holds options of the GET operation
 type GetOptions struct {
-	sse       encrypt.ServerSide
-	versionID string
+	SSE       encrypt.ServerSide
+	VersionID string
 }
 
 // StatOptions holds options of the HEAD operation

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -222,7 +222,7 @@ func getSourceStream(ctx context.Context, alias, urlStr, versionID string, fetch
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
-	reader, err = sourceClnt.Get(ctx, GetOptions{sse: sse, versionID: versionID})
+	reader, err = sourceClnt.Get(ctx, GetOptions{SSE: sse, VersionID: versionID})
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}


### PR DESCRIPTION
This allows minio/console to take advantage of the current
S3Client Get function for downloading objects with version