### PR TITLE
mirror: Stop mirroring loop using source IPs

### DIFF
--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -63,6 +63,19 @@ func (d differType) String() string {
 	return "unknown"
 }
 
+const activeActiveSourceURLsKey = "X-Amz-Meta-Mm-Source-Urls"
+
+func getSourceURLsKey(metadata map[string]string) string {
+	if metadata[activeActiveSourceURLsKey] != "" {
+		return metadata[activeActiveSourceURLsKey]
+	}
+	loweredSourceURLsKey := strings.ToLower(activeActiveSourceURLsKey)
+	if metadata[loweredSourceURLsKey] != "" {
+		return metadata[loweredSourceURLsKey]
+	}
+	return ""
+}
+
 const activeActiveSourceModTimeKey = "X-Amz-Meta-Mm-Source-Mtime"
 
 func getSourceModTimeKey(metadata map[string]string) string {


### PR DESCRIPTION
Currently, mc mirror avoid mirroring an object if its contains MM mtime
header, but this causes an issue for users running two mc mirror
commands to synchronize three sites, A -> B and B -> C.

The solution for this is to record the endpoint address of the source
server in the object metadata of each mirroring operation and stops the
mirroring when the target server already exists in the metadata itself.

-- 
Has some issues that need discussion, we might need to get server's deployment ID instead of relying on server addresses