### PR TITLE
Add --summarize for ls

### DIFF
--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -98,7 +98,7 @@ EXAMPLES:
   8. List all contents versions if the bucket versioning is enabled.
      {{.Prompt}} {{.HelpName}} --versions s3/mybucket
 
-  9. List number of objects and total size.
+  9. List all objects on `mybucket`, summarize the number of objects and total size.
      {{.Prompt}} {{.HelpName}} --recursive --summarize s3/mybucket
 `,
 }

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -98,7 +98,7 @@ EXAMPLES:
   8. List all contents versions if the bucket versioning is enabled.
      {{.Prompt}} {{.HelpName}} --versions s3/mybucket
 
-  9. List all objects on `mybucket`, summarize the number of objects and total size.
+  9. List all objects on mybucket, summarize the number of objects and total size.
      {{.Prompt}} {{.HelpName}} --recursive --summarize s3/mybucket
 `,
 }

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -183,6 +183,7 @@ func mainList(cliCtx *cli.Context) error {
 	console.SetColor("Dir", color.New(color.FgCyan, color.Bold))
 	console.SetColor("Size", color.New(color.FgYellow))
 	console.SetColor("Time", color.New(color.FgGreen))
+	console.SetColor("Summarize", color.New(color.Bold))
 
 	// check 'ls' cliCtx arguments.
 	args, isRecursive, isIncomplete, isSummary, timeRef, withOlderVersions := checkListSyntax(ctx, cliCtx)

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -99,7 +99,7 @@ EXAMPLES:
      {{.Prompt}} {{.HelpName}} --versions s3/mybucket
 
   9. List all objects on mybucket, summarize the number of objects and total size.
-     {{.Prompt}} {{.HelpName}} --recursive --summarize s3/mybucket
+     {{.Prompt}} {{.HelpName}} --summarize s3/mybucket/
 `,
 }
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -252,7 +252,7 @@ func doList(ctx context.Context, clnt Client, isRecursive, isIncomplete, isSumma
 
 		perObjectVersions = append(perObjectVersions, content)
 		totalSize += content.Size
-		totalObjects += 1
+		totalObjects++
 	}
 
 	printObjectVersions(clnt.GetURL(), perObjectVersions, withOlderVersions, isSummary)

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -179,8 +179,9 @@ type summaryMessage struct {
 
 // String colorized string message
 func (s summaryMessage) String() string {
-	message := console.Colorize("Total Objects", fmt.Sprintf("Total Objects: %d", s.TotalObjects)) + "\n" + console.Colorize("Total Size", fmt.Sprintf("%14s %s", "Total Size:", strings.Join(strings.Fields(humanize.IBytes(uint64(s.TotalSize))), "")))
-	return message
+	msg := console.Colorize("Summarize", fmt.Sprintf("\nTotal Size: %s", humanize.IBytes(uint64(s.TotalSize))))
+	msg += "\n" + console.Colorize("Summarize", fmt.Sprintf("Total Objects: %d", s.TotalObjects))
+	return msg
 }
 
 // JSON jsonified summary message
@@ -258,11 +259,10 @@ func doList(ctx context.Context, clnt Client, isRecursive, isIncomplete, isSumma
 	printObjectVersions(clnt.GetURL(), perObjectVersions, withOlderVersions, isSummary)
 
 	if isSummary {
-		sm := summaryMessage{
+		printMsg(summaryMessage{
 			TotalObjects: totalObjects,
 			TotalSize:    totalSize,
-		}
-		printMsg(sm)
+		})
 	}
 
 	return cErr

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -283,7 +283,7 @@ func mainTree(cliCtx *cli.Context) error {
 			}
 			clnt, err := newClientFromAlias(targetAlias, targetURL)
 			fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
-			if e := doList(ctx, clnt, true, false, timeRef, false); e != nil {
+			if e := doList(ctx, clnt, true, false, false, timeRef, false); e != nil {
 				cErr = e
 			}
 		}


### PR DESCRIPTION
To achieve the same goal as `aws s3 ls --recursive --summarize --human-readable`.

```bash
$ aws s3 ls s3://tmp --recursive --summarize --human-readable
2020-11-02 15:48:28  146 Bytes tmp/metadata
2020-11-02 15:48:25   95 Bytes tmp/test-schema-create.sql
2020-11-02 15:48:26  490 Bytes tmp/test.t-schema.sql
2020-11-02 15:48:26   11.1 MiB tmp/test.t.0.sql
2020-11-02 11:27:25  484 Bytes tmp/test.t1-schema.sql
2020-11-02 11:27:26    8.8 MiB tmp/test.t1.0.sql
2020-11-02 11:27:25  182 Bytes tmp/test.test-schema.sql

Total Objects: 7
   Total Size: 19.9 MiB

$ ./mc ls s3/tmp --recursive --summarize
[2020-11-02 15:48:28 CST]   146B tmp/metadata
[2020-11-02 15:48:25 CST]    95B tmp/test-schema-create.sql
[2020-11-02 15:48:26 CST]   490B tmp/test.t-schema.sql
[2020-11-02 15:48:26 CST]  11MiB tmp/test.t.0.sql
[2020-11-02 11:27:25 CST]   484B tmp/test.t1-schema.sql
[2020-11-02 11:27:26 CST] 8.8MiB tmp/test.t1.0.sql
[2020-11-02 11:27:25 CST]   182B tmp/test.test-schema.sql
Total Objects: 7
   Total Size: 20MiB
```