### PR TITLE
client-s3: Stat() should return data for passed directories

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1423,7 +1423,7 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 			return nil, probe.NewError(objectStat.Err)
 		}
 
-		if objectStat.Key == strings.TrimSuffix(object, string(c.targetURL.Separator)) {
+		if object == objectStat.Key || object == strings.TrimSuffix(objectStat.Key, string(c.targetURL.Separator)) {
 			return c.objectInfo2ClientContent(bucket, objectStat), nil
 		}
 		break


### PR DESCRIPTION
Fix copy regression introduced by 4e8e67fb042ccf75aae96aa9df9526c44f28bc4f