### PR TITLE
Remove transition targets

### DIFF
--- a/cmd/ilm-add.go
+++ b/cmd/ilm-add.go
@@ -58,11 +58,6 @@ EXAMPLES:
   3. Add expiry and transition days rules on a prefix in mybucket.
      {{.Prompt}} {{.HelpName}} --expiry-days "300" --transition-days "200" \
           --storage-class "GLACIER" s3/mybucket/doc
-
-  4. Add expiry and transition days rules on a prefix in mybucket for a MinIO transition target specified by label "hdd_tier".
-     "hdd_tier" is the label specified when adding a remote target with "mc admin bucket remote add --service ilm --label hdd_tier"
-     {{.Prompt}} {{.HelpName}} --expiry-days "300" --transition-days "200" \
-          --storage-class "hdd_tier" myminio/mybucket/doc
 `,
 }
 
@@ -89,7 +84,7 @@ var ilmAddFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "storage-class",
-		Usage: "storage class for transition (STANDARD_IA, ONEZONE_IA, GLACIER. Etc). For setting up transition to a MinIO target, use the label defined for the target",
+		Usage: "storage class for transition (STANDARD_IA, ONEZONE_IA, GLACIER. Etc).",
 	},
 	cli.BoolFlag{
 		Name:  "disable",

--- a/docs/minio-admin-complete-guide.md
+++ b/docs/minio-admin-complete-guide.md
@@ -909,21 +909,6 @@ ARN = `arn:minio:replication:us-west-1:1f8712ba-e38f-4429-bcb1-a7bb5aa97447:targ
 ```
 mc admin bucket remote add myminio/srcbucket https://foobar:foobar12345@minio2:9000/targetbucket --service "replication" --region "us-west-1" --bandwidth "2Gi"
 
-*Example: Add a new ILM transition target `targetbucket` with label "hdd_tier" in region `us-west-1` on `https://minio2:9000` for bucket `srcbucket` on MinIO server. `foobar` and `foo12345` are credentials to target endpoint.
-*
-
-```
-mc admin bucket remote add myminio/srcbucket https://foobar:foobar12345@minio2:9000/targetbucket --service "ilm" --region "us-west-1" --label "hdd_tier"
-ARN = `arn:minio:replication:us-west-1:1f8712ba-e38f-4429-bcb1-a7bb5aa97447:targetbucket`
-```
-
-*Example: Change credentials for existing replication target `targetbucket` with arn `arn:minio:replication:us-west-1:1f8712ba-e38f-4429-bcb1-a7bb5aa97447:targetbucket` on `https://minio2:9000` for bucket `srcbucket` on MinIO server. New credentials are `foobar1` and `foobarnew`
-
-```
-mc admin bucket remote edit myminio/srcbucket https://foobar1:foobarnew@minio2:9000/targetbucket --arn `arn:minio:replication:us-west-1:1f8712ba-e38f-4429-bcb1-a7bb5aa97447:targetbucket`
-ARN = `arn:minio:replication:us-west-1:1f8712ba-e38f-4429-bcb1-a7bb5aa97447:targetbucket`
-```
-
 *Example: Get remote target for replication on bucket 'srcbucket' in MinIO.*
 
 ```

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -1377,12 +1377,6 @@ mc ilm ls myminio/testbucket
 
 For more details about the lifecycle configuration, refer to official AWS S3 documentation [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html)
 
-
-*Example: Add rule for prefix "dev" in bucket "testbucket" on play and transition after 2 days to transition tier specified by storage class label "hdd_tier". "hdd_tier" is the label specified when setting up MinIO transition target via `mc admin bucket remote add` command*
-```
-mc ilm add --expiry-date "2020-09-17" play/testbucket/dev --transition-days 2 --storage-class "hdd_tier"
-Lifecycle configuration rule added with ID `btd6pdot8748n94elvl0` to play/testbucket/dev.
-```
 *Example: Edit the lifecycle management configuration rule given by ID "btd6pdot8748n94elvl0" to set tags*
 ```
 mc ilm edit --id "Documents" --tags "k1=v1&k2=v2" play/testbucket/dev


### PR DESCRIPTION
from `mc admin bucket remote` command and references to
transition s.c label in `mc ilm add` command and docs.

This is being deprecated in favor of an improved approach
to transition in the works.