### PR TITLE
Remove IsInstalled() call before auto-completion installation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -294,11 +294,6 @@ func installAutoCompletion() {
 		shellName = filepath.Base(shellName)
 	}
 
-	if completeinstall.IsInstalled(filepath.Base(os.Args[0])) || completeinstall.IsInstalled("mc") {
-		console.Infoln("autocompletion is already enabled in your '" + shellName + "' shell.")
-		return
-	}
-
 	err := completeinstall.Install(filepath.Base(os.Args[0]))
 	if err != nil {
 		fatalIf(probe.NewError(err), "Unable to install auto-completion.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -296,6 +296,11 @@ func installAutoCompletion() {
 
 	err := completeinstall.Install(filepath.Base(os.Args[0]))
 	if err != nil {
+		if completeinstall.IsInstalled(filepath.Base(os.Args[0])) || completeinstall.IsInstalled("mc") {
+			errStr := err.Error()
+			console.Infoln("autocompletion is already enabled in your '"+shellName+"' shell.\n", errStr[strings.Index(errStr, "\n")+1:])
+			return
+		}
 		fatalIf(probe.NewError(err), "Unable to install auto-completion.")
 	} else {
 		console.Infoln("enabled autocompletion in your '" + shellName + "' rc file. Please restart your shell.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -293,17 +293,30 @@ func installAutoCompletion() {
 	} else {
 		shellName = filepath.Base(shellName)
 	}
+	supportedShells := map[string]bool{
+		"bash": true,
+		"zsh":  true,
+		"fish": true,
+	}
 
 	err := completeinstall.Install(filepath.Base(os.Args[0]))
 	if err != nil {
 		if completeinstall.IsInstalled(filepath.Base(os.Args[0])) || completeinstall.IsInstalled("mc") {
 			errStr := err.Error()
-			console.Infoln("autocompletion is already enabled in your '"+shellName+"' shell.\n", errStr[strings.Index(errStr, "\n")+1:])
+			if supportedShells[shellName] {
+				console.Infoln("autocompletion is already enabled in your '"+shellName+"' shell.\n", errStr[strings.Index(errStr, "\n")+1:])
+			} else {
+				console.Infoln("autocompletion is already enabled\n", errStr[strings.Index(errStr, "\n")+1:])
+			}
 			return
 		}
 		fatalIf(probe.NewError(err), "Unable to install auto-completion.")
 	} else {
-		console.Infoln("enabled autocompletion in your '" + shellName + "' rc file. Please restart your shell.")
+		if supportedShells[shellName] {
+			console.Infoln("enabled autocompletion in your '" + shellName + "' rc file. Please restart your shell.")
+		} else {
+			console.Infoln("enabled autocompletion in bash, zsh and fish where possible.")
+		}
 	}
 }
 


### PR DESCRIPTION
At the moment posener/complete [1] doesn't allow specifying shell for
IsInstalled(), which might lead to confusing error messages, since it
just returns true if it's able to find completion definition in *any*
shell configurations even if it's not what the user currently uses.

Hence we should remove this check and call Install() directly, and user
can get more details in this case.

[1] https://github.com/posener/complete

For example, I'm currently using Zsh, but there are some leftover Fish configuration files in my system (I have uninstalled Fish).
```sh
# before this patch
# confusing error message when auto-completion is installed in Fish but not Zsh
$ mcli --autocompletion
mcli: autocompletion is already enabled in your 'zsh' shell.

# after this patch
$ mcli --autocompletion
mcli: <ERROR> Unable to install auto-completion. 1 error occurred:
        * already installed at /home/frederick/.config/fish/completions/mcli.fish.
# user can now know the details and optionally remove/update the files
$ rm -rf .config/fish
# side-effect: the `mcli --autocompletion` call above actually already installed it in Zsh
$ mcli --autocompletion
mcli: <ERROR> Unable to install auto-completion. 1 error occurred:
        * already installed in /home/frederick/.zshrc.
```