### PR TITLE
mirror: FS should ignore some non supported S3 events

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -149,7 +149,8 @@ func (f *fsClient) Watch(ctx context.Context, options WatchOptions) (*WatchObjec
 		case "get":
 			fsEvents = append(fsEvents, EventTypeGet...)
 		default:
-			return nil, errInvalidArgument().Trace(event)
+			// Event type not supported by FS client, such as
+			// bucket creation or deletion, ignore it.
 		}
 	}
 


### PR DESCRIPTION
Bucket creation & removal are events only supported by MinIO server and
they are not meaningful for FS. Just ignore them at FS level and avoid
reporting an error.

Fixes https://github.com/minio/mc/issues/3550