### PR TITLE
trace: Add more filters options

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -47,7 +47,7 @@ var adminTraceFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "status-codes",
-		Usage: "trace only a specific status codes",
+		Usage: "trace only specific status codes",
 	},
 	cli.StringFlag{
 		Name:  "methods",


### PR DESCRIPTION
Filter options are necessary if the server receives a lot of requests,
especially when verbose mode is passed.