### PR TITLE
cp: Copy recursive paths having the passed prefix 

### DIFF
--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -200,6 +200,19 @@ func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encK
 	return client, content, nil
 }
 
+// firstURL2Stat returns the stat info of the first object having the specified prefix
+func firstURL2Stat(ctx context.Context, prefix string, timeRef time.Time) (client Client, content *ClientContent, err *probe.Error) {
+	client, err = newClient(prefix)
+	if err != nil {
+		return nil, nil, err.Trace(prefix)
+	}
+	content = <-client.List(ctx, ListOptions{Recursive: true, TimeRef: timeRef, Count: 1})
+	if content.Err != nil {
+		return nil, nil, err.Trace(prefix)
+	}
+	return client, content, nil
+}
+
 // url2Alias separates alias and path from the URL. Aliased URL is of
 // the form alias/path/to/blah.
 func url2Alias(aliasedURL string) (alias, path string) {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -69,6 +69,7 @@ type ListOptions struct {
 	WithDeleteMarkers bool
 	TimeRef           time.Time
 	ShowDir           DirOpt
+	Count             int
 }
 
 // CopyOptions holds options for copying operation

--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio/pkg/console"
 )
 
@@ -52,7 +53,12 @@ func checkCopySyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 
 	// Verify if source(s) exists.
 	for _, srcURL := range srcURLs {
-		_, _, err := url2Stat(ctx, srcURL, versionID, false, encKeyDB, timeRef)
+		var err *probe.Error
+		if !isRecursive {
+			_, _, err = url2Stat(ctx, srcURL, versionID, false, encKeyDB, timeRef)
+		} else {
+			_, _, err = firstURL2Stat(ctx, srcURL, timeRef)
+		}
 		if err != nil {
 			msg := "Unable to validate source `" + srcURL + "`"
 			if versionID != "" {

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -54,8 +54,14 @@ const (
 // functions to accurately report failure causes.
 func guessCopyURLType(ctx context.Context, sourceURLs []string, targetURL string, isRecursive bool, keys map[string][]prefixSSEPair, timeRef time.Time, versionID string) (copyURLsType, string, *probe.Error) {
 	if len(sourceURLs) == 1 { // 1 Source, 1 Target
+		var err *probe.Error
+		var sourceContent *ClientContent
 		sourceURL := sourceURLs[0]
-		_, sourceContent, err := url2Stat(ctx, sourceURL, versionID, false, keys, timeRef)
+		if !isRecursive {
+			_, sourceContent, err = url2Stat(ctx, sourceURL, versionID, false, keys, timeRef)
+		} else {
+			_, sourceContent, err = firstURL2Stat(ctx, sourceURL, timeRef)
+		}
 		if err != nil {
 			return copyURLsTypeInvalid, "", err
 		}


### PR DESCRIPTION
Some users used to copy a subset of files stored under one specific prefix
using `mc cp -r alias/bucket/[starting-characters] /dest`.

However this is not working anymore.

The reason is that before, let's say if we have a prefix containing
an object called '1.txt', client-s3.Stat() passed with a prefix '1'
will return the info of the object '1.txt'. However this behavior
was changed recently and client-s3.Stat() now only returns the
information of the exact object name '1'.

To solve this, we add firstURL2Stat() which returns the stat info of the
first object having the specified prefix.

Fixes https://github.com/minio/mc/issues/3562