### PR TITLE
parallel: Allocate one channel for transferring big files

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -533,11 +533,11 @@ func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.
 				if isCopied != nil && isCopied(cpURLs.SourceContent.URL.String()) {
 					parallel.queueTask(func() URLs {
 						return doCopyFake(ctx, cpURLs, pg, isMvCmd)
-					})
+					}, false)
 				} else {
 					parallel.queueTask(func() URLs {
 						return doCopy(ctx, cpURLs, pg, encKeyDB, isMvCmd, preserve)
-					})
+					}, cpURLs.SourceContent.Size > 128*1024*1024)
 				}
 			}
 		}


### PR DESCRIPTION
Big files consume a lot of memory and they are also able to consume an
important bandwidth. Allocate one channel for them to be processed
separately from small files.

Working but the idea needs to be approved.