### PR TITLE
fix: make listing consistent with top level delete marker

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1408,8 +1408,9 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 		if err == nil {
 			return ctnt, nil
 		}
+
 		// Ignore object missing error but return for other errors
-		if !errors.As(err.ToGoError(), &ObjectMissing{}) {
+		if !errors.As(err.ToGoError(), &ObjectMissing{}) && !errors.As(err.ToGoError(), &ObjectIsDeleteMarker{}) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
```
~ mc ls s3/tbucket13/x.txt
[2021-01-25 13:24:09 PST]   525B z.txt
```

```
~ mc ls s3/tbucket132/x.txt
[2021-01-25 13:31:41 PST]   525B x.txt/z.txt
```