### PR TITLE
cp: Fix crash with recursive copy with non existant resource

### DIFF
--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -207,8 +207,11 @@ func firstURL2Stat(ctx context.Context, prefix string, timeRef time.Time) (clien
 		return nil, nil, err.Trace(prefix)
 	}
 	content = <-client.List(ctx, ListOptions{Recursive: true, TimeRef: timeRef, Count: 1})
+	if content == nil {
+		return nil, nil, probe.NewError(ObjectMissing{timeRef: timeRef}).Trace(prefix)
+	}
 	if content.Err != nil {
-		return nil, nil, err.Trace(prefix)
+		return nil, nil, content.Err.Trace(prefix)
 	}
 	return client, content, nil
 }


### PR DESCRIPTION
Recent change in the code introduced a crash when copying a non
existant bucket or prefix when --recursive flag is passed.

This PR fixes it.

Fixes https://github.com/minio/mc/issues/3591