### PR TITLE
ilm: Fix adding ExpiredObjectDeleteMarker alone

### DIFF
--- a/cmd/ilm/options.go
+++ b/cmd/ilm/options.go
@@ -120,7 +120,7 @@ type LifecycleOptions struct {
 
 // ToConfig create lifecycle.Configuration based on LifecycleOptions
 func (opts LifecycleOptions) ToConfig(config *lifecycle.Configuration) (*lifecycle.Configuration, *probe.Error) {
-	expiry, err := parseExpiry(opts.ExpiryDate, opts.ExpiryDays)
+	expiry, err := parseExpiry(opts.ExpiryDate, opts.ExpiryDays, opts.ExpiredObjectDeleteMarker)
 	if err != nil {
 		return nil, err.Trace(opts.ExpiryDate, opts.ExpiryDays)
 	}

--- a/cmd/ilm/parse.go
+++ b/cmd/ilm/parse.go
@@ -160,7 +160,7 @@ func parseTransition(storageClass, transitionDateStr, transitionDayStr string) (
 }
 
 // Returns lifecycleExpiration to be included in lifecycleRule
-func parseExpiry(expiryDateStr, expiryDayStr string) (lfcExp lifecycle.Expiration, err *probe.Error) {
+func parseExpiry(expiryDateStr, expiryDayStr string, expiredDeleteMarker bool) (lfcExp lifecycle.Expiration, err *probe.Error) {
 	if expiryDateStr != "" {
 		date, e := time.Parse(defaultILMDateFormat, expiryDateStr)
 		if e != nil {
@@ -181,6 +181,10 @@ func parseExpiry(expiryDateStr, expiryDayStr string) (lfcExp lifecycle.Expiratio
 			return lifecycle.Expiration{}, probe.NewError(errors.New("expiration days cannot be set to zero"))
 		}
 		lfcExp.Days = lifecycle.ExpirationDays(days)
+	}
+
+	if expiredDeleteMarker {
+		lfcExp.DeleteMarker = true
 	}
 
 	return lfcExp, nil


### PR DESCRIPTION
It is not possible to add rule with only ExpiredObjectDeleteMarker
activated. This commit fixes the issue.

How to test:
`mc ilm add --expired-object-delete-marker myminio/testbucket/`