### PR TITLE
Supports wildcard for 'mc ls' and 'mc cp' commands

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Client (C) 2015-2020 MinIO, Inc.
+ * MinIO Client (C) 2015-2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this fs except in compliance with the License.
@@ -595,7 +595,7 @@ func (f *fsClient) listPrefixes(prefix string, contentCh chan<- *ClientContent) 
 			continue
 		}
 
-		file := filepath.ToSlash(filepath.Join(dirName, fi.Name()))
+		file := filepath.Join(dirName, fi.Name())
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 			st, e := os.Stat(file)
 			if e != nil {

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -595,7 +595,7 @@ func (f *fsClient) listPrefixes(prefix string, contentCh chan<- *ClientContent) 
 			continue
 		}
 
-		file := filepath.Join(dirName, fi.Name())
+		file := filepath.ToSlash(filepath.Join(dirName, fi.Name()))
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 			st, e := os.Stat(file)
 			if e != nil {

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -1,5 +1,5 @@
 /*
- * MinIO Client (C) 2017 MinIO, Inc.
+ * MinIO Client (C) 2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -189,6 +189,17 @@ func mainList(cliCtx *cli.Context) error {
 	// check 'ls' cliCtx arguments.
 	args, isRecursive, isIncomplete, isSummary, timeRef, withOlderVersions := checkListSyntax(ctx, cliCtx)
 
+	tempTrgURLs := cli.Args{}
+	for _, tgtURL := range args {
+		if strings.HasSuffix(tgtURL, "*") {
+			tempTrgURLs = append(tempTrgURLs, tgtURL[:len(tgtURL)-1])
+		} else {
+			tempTrgURLs = append(tempTrgURLs, tgtURL)
+		}
+	}
+	args = tempTrgURLs
+	copy(cliCtx.Args(), tempTrgURLs)
+
 	var cErr error
 	for _, targetURL := range args {
 		clnt, err := newClient(targetURL)

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -224,10 +224,9 @@ func mainMove(cliCtx *cli.Context) error {
 	}
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(ctx, cliCtx, encKeyDB, true)
+	args := checkCopySyntax(ctx, cliCtx, encKeyDB, true)
 
-	if cliCtx.NArg() == 2 {
-		args := cliCtx.Args()
+	if len(args) == 2 {
 		srcURL := args.Get(0)
 		dstURL := args.Get(1)
 		if srcURL == dstURL {
@@ -237,7 +236,7 @@ func mainMove(cliCtx *cli.Context) error {
 
 	// Check if source URLs does not have object locking enabled
 	// since we cannot move them (remove them from the source)
-	for _, urlStr := range cliCtx.Args()[:cliCtx.NArg()-1] {
+	for _, urlStr := range args[:len(args)-1] {
 		client, err := newClient(urlStr)
 		if err != nil {
 			fatalIf(err.Trace(), "Unable to parse the provided url.")
@@ -274,7 +273,7 @@ func mainMove(cliCtx *cli.Context) error {
 	var session *sessionV8
 
 	if cliCtx.Bool("continue") {
-		sessionID := getHash("mv", cliCtx.Args())
+		sessionID := getHash("mv", args)
 		if isSessionExists(sessionID) {
 			session, err = loadSessionV8(sessionID)
 			fatalIf(err.Trace(sessionID), "Unable to load session.")
@@ -302,11 +301,11 @@ func mainMove(cliCtx *cli.Context) error {
 			}
 
 			// extract URLs.
-			session.Header.CommandArgs = cliCtx.Args()
+			session.Header.CommandArgs = args
 		}
 	}
 
-	e := doCopySession(ctx, cancelMove, cliCtx, session, encKeyDB, true)
+	e := doCopySession(ctx, cancelMove, cliCtx, args, session, encKeyDB, true)
 	if session != nil {
 		session.Delete()
 	}


### PR DESCRIPTION
Fixes issue #3374

Support for wildcard `*` support for `mc ls` and `mc cp` commands.