### PR TITLE
Ignore parallel net perf data when its empty

### DIFF
--- a/cmd/health_v1.go
+++ b/cmd/health_v1.go
@@ -168,7 +168,9 @@ func MapHealthInfoToV1(healthInfo madmin.HealthInfo, err error) HealthReportInfo
 	addKeysToSet(reflect.ValueOf(serverDrives).MapKeys(), &serverAddrs)
 	addKeysToSet(reflect.ValueOf(serverMems).MapKeys(), &serverAddrs)
 	addKeysToSet(reflect.ValueOf(serverNetPerfSerial).MapKeys(), &serverAddrs)
-	serverAddrs.Add(healthInfo.Perf.NetParallel.Addr)
+	if len(healthInfo.Perf.NetParallel.Addr) > 0 {
+		serverAddrs.Add(healthInfo.Perf.NetParallel.Addr)
+	}
 	addKeysToSet(reflect.ValueOf(serverDrivePerf).MapKeys(), &serverAddrs)
 
 	// Merge hardware info


### PR DESCRIPTION
When parallel net perf tests are not performed, for example in FS mode,
the server response contains an empty node for the net pef data with
value of `addr` as empty string (`""`).

This data should be ignored when mapping the server response to the
health report format. Otherwise we end up with a health report with an
empty server node under `hardware` section.