### PR TITLE
mirror: Fix behavior under Windows when source url is S3

### DIFF
--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -83,10 +83,6 @@ func checkMirrorSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[st
 				srcURL = origSrcURL
 			}
 		}
-
-		if !strings.HasSuffix(srcURL, string(srcContent.URL.Separator)) {
-			srcURL += string(srcContent.URL.Separator)
-		}
 	}
 
 	return


### PR DESCRIPTION
Removed one block of code which seems to be useless and no comment with
it. This was causing issue doing mirroring under Windows.