### PR TITLE
trace: Add source IP in verbose mode

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -395,7 +395,7 @@ func (t traceMessage) String() string {
 	ri := trc.ReqInfo
 	rs := trc.RespInfo
 	fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[REQUEST %s] ", trc.FuncName)))
-	fmt.Fprintf(b, "%s\n", ri.Time.Format(timeFormat))
+	fmt.Fprintf(b, "[%s] %s\n", ri.Time.Format(timeFormat), console.Colorize("Host", fmt.Sprintf("[Client IP: %s]", ri.Client)))
 	fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("Method", fmt.Sprintf("%s %s", ri.Method, ri.Path)))
 	if ri.RawQuery != "" {
 		fmt.Fprintf(b, "?%s", ri.RawQuery)


### PR DESCRIPTION
Add the source IP information in the REQUEST trace line when the verbose
mode is enabled.

Fixes https://github.com/minio/mc/issues/3608