### PR TITLE
Fixes conflicting Failure&Successful msgs in 'mc rb' output

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1070,7 +1070,9 @@ func (c *S3Client) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 		defer close(errorCh)
 		if isRemoveBucket {
 			if _, object := c.url2BucketAndObject(); object != "" {
-				errorCh <- probe.NewError(errors.New("cannot delete prefixes with `mc rb` command - Use `mc rm` instead"))
+				errorCh <- probe.NewError(errors.New(
+					"use `mc rm` command to delete prefixes, or point your" +
+						"bucket directly, `mc rb <alias>/<bucket-name>/`"))
 				return
 			}
 		}

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1072,7 +1072,7 @@ func (c *S3Client) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 			if _, object := c.url2BucketAndObject(); object != "" {
 				errorCh <- probe.NewError(errors.New(
 					"use `mc rm` command to delete prefixes, or point your" +
-						"bucket directly, `mc rb <alias>/<bucket-name>/`"))
+						" bucket directly, `mc rb <alias>/<bucket-name>/`"))
 				return
 			}
 		}
@@ -1161,6 +1161,14 @@ func (c *S3Client) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 		// Write remove objects status to errorCh
 		if statusCh != nil {
 			for removeStatus := range statusCh {
+				// If the removeStatus error message is:
+				// "Object is WORM protected and cannot be overwritten",
+				// it is too generic. We have the object's name and vid.
+				// Adding the object's name and version id into the error msg
+				removeStatus.Err = errors.New(strings.Replace(
+					removeStatus.Err.Error(), "Object is WORM protected",
+					"Object, '"+removeStatus.ObjectName+" (Version ID="+
+						removeStatus.VersionID+")' is WORM protected", 1))
 				errorCh <- probe.NewError(removeStatus.Err)
 			}
 		}

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -168,13 +167,9 @@ func deleteBucket(ctx context.Context, url string) *probe.Error {
 		}
 	}()
 
-	foundErr := false
+	// Give up on the first error.
 	for perr := range errorCh {
-		errorIf(perr.Trace(url), "Failed to remove `"+url+"`, continuing..")
-		foundErr = true
-	}
-	if foundErr {
-		return probe.NewError(errors.New("Bucket not removed"))
+		return perr
 	}
 	return nil
 }

--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -167,8 +168,13 @@ func deleteBucket(ctx context.Context, url string) *probe.Error {
 		}
 	}()
 
+	foundErr := false
 	for perr := range errorCh {
 		errorIf(perr.Trace(url), "Failed to remove `"+url+"`, continuing..")
+		foundErr = true
+	}
+	if foundErr {
+		return probe.NewError(errors.New("Bucket not removed"))
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #3387

The fix only addresses the conflicting `Removed '<object-path>' successfully.` and `Failed to remove '<object-path>', continuing ...` messages for object storage, when bucket is not empty in the command:
`mc rb <alias>/<bucket>/[<prefix>/][<object>] --force` output 

The team decided not to address the file system side of the issue, as there is no concept of a `"bucket"` for file systems.