### PR TITLE
Stops 'mc cp --attr' preserve file attributes without '--preserve'

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -522,7 +522,6 @@ func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.
 
 				preserve := cli.Bool("preserve")
 				if cli.String("attr") != "" {
-					preserve = true
 					userMetaMap, _ := getMetaDataEntry(cli.String("attr"))
 					for metadataKey, metaDataVal := range userMetaMap {
 						cpURLs.TargetContent.UserMetadata[metadataKey] = metaDataVal


### PR DESCRIPTION
Fixes #3579

Pretty simple and straight forward fix to stop `mc cp --attr` command to copy file attributes automatically as if `--preserve` (or `-a`) flag is also specified.

If user runs with both flags; `--attr` and `--preserve` and requests a specific file attribute to be replaced, as in:
```
mc cp --preserve --attr "X-Amz-Meta-Mc-Attrs=<key>=<value>" <source-file> <destination>
```
then, `--preserve` will be ignored and the file attribute specified with `-attr` flag will be honored. Both flags will be honored if user specifies any metadata other than `X-Amz-Meta-Mc-Attrs` key/value pairs with `--attr`.