### PR TITLE
parallel-manager: Reduce parallelism when there is not enough memory

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -527,11 +527,11 @@ func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.
 				if isCopied != nil && isCopied(cpURLs.SourceContent.URL.String()) {
 					parallel.queueTask(func() URLs {
 						return doCopyFake(ctx, cpURLs, pg)
-					})
+					}, 0)
 				} else {
 					parallel.queueTask(func() URLs {
 						return doCopy(ctx, cpURLs, pg, encKeyDB, isMvCmd, preserve)
-					})
+					}, cpURLs.SourceContent.Size)
 				}
 			}
 		}

--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -193,6 +193,7 @@ func (p *ParallelManager) enoughMemForUpload(uploadSize int64) bool {
 	}
 
 	smem := runtime.MemStats{}
+	runtime.GC()
 	runtime.ReadMemStats(&smem)
 
 	return estimateNeededMemoryForUpload(uploadSize)+smem.Alloc < p.maxMem
@@ -225,7 +226,7 @@ func newParallelManager(resultCh chan URLs) *ParallelManager {
 	var maxMem float64
 	memStats, err := mem.VirtualMemory()
 	if err == nil {
-		maxMem = float64(memStats.Available) * 0.8 // use upto 80% of available memory.
+		maxMem = float64(memStats.Available) / 2 // use upto 50% of available memory.
 	}
 
 	p := &ParallelManager{


### PR DESCRIPTION
Some users with low memory and good connection uploading some big files
can see OOM crash, since mc will increase upload parallelism over
time when the bandwidth and the server is able to carry the load.

This PR will check the free OS memory before starting mirror/cp and will
, it will stop parallelism until the memory gets some room.