### PR TITLE
Add option to upload health report to Subnet

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -187,16 +187,16 @@ func mainAdminHealth(ctx *cli.Context) error {
 
 	license := ctx.String("license")
 	if len(license) > 0 {
-		e = uploadHealthReport(filename, license, ctx.Bool("dev"))
+		e = uploadHealthReport(aliasedURL, filename, license, ctx.Bool("dev"))
 		fatalIf(probe.NewError(e), "Unable to upload health report to Subnet portal")
 	}
 
 	return nil
 }
 
-func uploadHealthReport(filename string, license string, dev bool) error {
-	uploadUrl := subnetUploadURL(filename, license, dev)
-	req, e := subnetUploadReq(uploadUrl, filename)
+func uploadHealthReport(alias string, filename string, license string, dev bool) error {
+	uploadURL := subnetUploadURL(alias, filename, license, dev)
+	req, e := subnetUploadReq(uploadURL, filename)
 	if e != nil {
 		return e
 	}
@@ -215,9 +215,9 @@ func uploadHealthReport(filename string, license string, dev bool) error {
 
 	if resp.StatusCode == http.StatusOK {
 		msg := "MinIO Health data was successfully uploaded to Subnet."
-		clusterUrl, _ := url.PathUnescape(gjson.Get(string(respBody), "cluster_url").String())
-		if len(clusterUrl) > 0 {
-			msg += fmt.Sprintf(" Can be viewed at: %s", clusterUrl)
+		clusterURL, _ := url.PathUnescape(gjson.Get(string(respBody), "cluster_url").String())
+		if len(clusterURL) > 0 {
+			msg += fmt.Sprintf(" Can be viewed at: %s", clusterURL)
 		}
 		console.Infoln(msg)
 		return nil
@@ -226,13 +226,13 @@ func uploadHealthReport(filename string, license string, dev bool) error {
 	return fmt.Errorf("Upload to subnet failed with status code %d: %s", resp.StatusCode, respBody)
 }
 
-func subnetUploadURL(filename string, license string, dev bool) string {
+func subnetUploadURL(alias string, filename string, license string, dev bool) string {
 	const apiPath = "/api/auth/health_reports"
 	baseURL := "https://subnet.min.io"
 	if dev {
 		baseURL = "http://localhost:9000"
 	}
-	return fmt.Sprintf("%s%s?license=%s&filename=%s", baseURL, apiPath, license, filename)
+	return fmt.Sprintf("%s%s?license=%s&clustername=%s&filename=%s", baseURL, apiPath, license, alias, filename)
 }
 
 func subnetUploadReq(url string, filename string) (*http.Request, error) {

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/inconshreveable/go-update"
-	"github.com/mattn/go-ieproxy"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/minio/cli"
 	json "github.com/minio/mc/pkg/colorjson"
@@ -242,16 +241,7 @@ func downloadReleaseURL(releaseChecksumURL string, timeout time.Duration) (conte
 	}
 	req.Header.Set("User-Agent", getUserAgent())
 
-	client := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			Proxy: ieproxy.GetProxyFunc(),
-			// need to close connection after usage.
-			DisableKeepAlives: true,
-		},
-	}
-
-	resp, e := client.Do(req)
+	resp, e := httpClient(timeout).Do(req)
 	if e != nil {
 		return content, probe.NewError(e)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,6 +33,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mattn/go-ieproxy"
 	"github.com/minio/cli"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
@@ -447,4 +449,15 @@ func getClient(aliasURL string) *madmin.AdminClient {
 	client, err := newAdminClient(aliasURL)
 	fatalIf(err, "Unable to initialize admin connection.")
 	return client
+}
+
+func httpClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy: ieproxy.GetProxyFunc(),
+			// need to close connection after usage.
+			DisableKeepAlives: true,
+		},
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/shirou/gopsutil/v3 v3.21.1
 	github.com/tidwall/gjson v1.6.8
-	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 // indirect
 	go.uber.org/zap v1.14.1 // indirect
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
 	golang.org/x/net v0.0.0-20201216054612-986b41b23924

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/xid v1.2.1
 	github.com/shirou/gopsutil/v3 v3.21.1
+	github.com/tidwall/gjson v1.6.8
+	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 // indirect
 	go.uber.org/zap v1.14.1 // indirect
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
 	golang.org/x/net v0.0.0-20201216054612-986b41b23924

--- a/go.sum
+++ b/go.sum
@@ -509,13 +509,11 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
-<<<<<<< HEAD
-=======
 github.com/tidwall/gjson v1.6.8 h1:CTmXMClGYPAmln7652e69B7OLXfTi5ABcPPwjIWUv7w=
 github.com/tidwall/gjson v1.6.8/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
->>>>>>> Print URL of the uploaded cluster in output
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/sjson v1.0.4/go.mod h1:bURseu1nuBkFpIES5cz6zBtjmYeOQmEESshn7VpF15Y=
 github.com/tinylib/msgp v1.1.3/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=

--- a/go.sum
+++ b/go.sum
@@ -509,6 +509,12 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
+<<<<<<< HEAD
+=======
+github.com/tidwall/gjson v1.6.8 h1:CTmXMClGYPAmln7652e69B7OLXfTi5ABcPPwjIWUv7w=
+github.com/tidwall/gjson v1.6.8/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+>>>>>>> Print URL of the uploaded cluster in output
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/sjson v1.0.4/go.mod h1:bURseu1nuBkFpIES5cz6zBtjmYeOQmEESshn7VpF15Y=


### PR DESCRIPTION
Add an optional text flag `license` to the `mc admin subnet health`
command. If this flag is passed, upload the generated health report to
Subnet passing the license key as auth.

For use in development mode (where the report needs to be uploaded to
Subnet running on localhost), introduce another optional (and hidden)
boolean flag called `dev`. If it is passed, use `http://localhost:9000`
as the base url for Subnet instead of `https://subnet.min.io`

This feature can subsequently be used to automate the health report
upload by either using a cron job or introducing another `frequency`
flag to the command.