### PR TITLE
cp: Add --tags to tag uploaded objects

### DIFF
--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -811,7 +811,7 @@ FLAGS:
   --continue, -c                     create or resume copy session
   --encrypt value                    encrypt/decrypt objects (using server-side encryption with server managed keys)
   --encrypt-key value                encrypt/decrypt objects (using server-side encryption with customer provided keys)
-  --tags value                       apply tags to the uploaded objects
+  --tags value                       apply tags to the uploaded objects (eg. key=value&key2=value2, etc)
   --help, -h                         show help
 
 ENVIRONMENT VARIABLES:

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -811,6 +811,7 @@ FLAGS:
   --continue, -c                     create or resume copy session
   --encrypt value                    encrypt/decrypt objects (using server-side encryption with server managed keys)
   --encrypt-key value                encrypt/decrypt objects (using server-side encryption with customer provided keys)
+  --tags value                       apply tags to the uploaded objects
   --help, -h                         show help
 
 ENVIRONMENT VARIABLES:


### PR DESCRIPTION
Applying tagging to objects copied in an S3 object using --tags flag.