### PR TITLE
Keep coloring even when Stdout is a pipe

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -73,6 +73,8 @@ func setGlobals(quiet, debug, json, noColor, insecure bool) {
 	// Disable colorified messages if requested.
 	if globalNoColor || globalQuiet {
 		console.SetColorOff()
+	} else {
+		console.SetColorOn()
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -34,3 +34,4 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.5
 	gopkg.in/yaml.v2 v2.3.0
 )
+replace github.com/minio/minio => ../minio

--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,3 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.5
 	gopkg.in/yaml.v2 v2.3.0
 )
-replace github.com/minio/minio => ../minio


### PR DESCRIPTION
Fixes #3632

With this fix, together with its minio part minio/minio#11834, `mc` commands coloring schema will be maintained even when Stdout is a pipe. 