### PR TITLE
Adds error exit codes for SIGINT, SIGTERM and SIGKILL

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -42,6 +42,15 @@ const (
 
 	// Global error exit status.
 	globalErrorExitStatus = 1
+
+	// Global CTRL-C (SIGINT, #2) exit status.
+	globalCancelExitStatus = 130
+
+	// Global SIGKILL (#9) exit status.
+	globalKillExitStatus = 137
+
+	// Global SIGTERM (#15) exit status
+	globalTerminatExitStatus = 143
 )
 
 var (

--- a/cmd/signals.go
+++ b/cmd/signals.go
@@ -32,13 +32,24 @@ func trapSignals(sig ...os.Signal) {
 	signal.Notify(sigCh, sig...)
 
 	// Wait for the signal.
-	<-sigCh
+	s := <-sigCh
 
 	// Once signal has been received stop signal Notify handler.
-
 	signal.Stop(sigCh)
 
 	// Cancel the global context
 	globalCancel()
 
+	var exitCode int
+	switch s.String() {
+	case "interrupt":
+		exitCode = globalCancelExitStatus
+	case "killed":
+		exitCode = globalKillExitStatus
+	case "terminated":
+		exitCode = globalTerminatExitStatus
+	default:
+		exitCode = globalErrorExitStatus
+	}
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
Fixes #3643 (mc cp should return non-zero exit code when it is interrupted by sigterm and so on.)