### PR TITLE
Fix net perf spinner not finishing in subnet health

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -380,6 +380,12 @@ func fetchServerHealthInfo(ctx *cli.Context, client *madmin.AdminClient) (madmin
 		progress(adminHealthInfo)
 	}
 
+	// In case any of the spinners have not stopped yet (can happen in some
+	// cases e.g. net perf data is empty in case of single server deployment)
+	// explicitly stop them
+	_ = admin(true) && cpu(true) && diskHw(true) && osInfo(true) &&
+		mem(true) && process(true) && config(true) && drive(true) && net(true)
+
 	// cancel the context if obdChan has returned.
 	cancel()
 	return healthInfo, err


### PR DESCRIPTION
In case of single server setups, the network performance data is empty.
Because of this, the condition that indicates that the network test step
is over never evaluates to true and hence the spinner doesn't finish
(doesn't show the tickmark indicating the step has completed).

While this is a nigligible issue in normal execution of the subnet
health command, it has a weird side effect when the `--license` flag is
passed. In such cases, the network test spinner finishes _after_ the
message about succesful generation of the report is printed.

Ensuring that all the spinners are stopped explicitly after the api call
returns resolves this issue.