### PR TITLE
Check all possible locks on an object before 'mc mv'

### DIFF
--- a/cmd/legalhold-info.go
+++ b/cmd/legalhold-info.go
@@ -242,7 +242,7 @@ func mainLegalHoldInfo(cliCtx *cli.Context) error {
 		fatalIf(err, "Unable to get legalhold info of `%s`", targetURL)
 	}
 	if !enabled {
-		fatalIf(errDummy().Trace(), "Bucket lock needs to be enabled in order to use this feature.")
+		fatalIf(errDummy().Trace(), "Bucket is not created with '--with-lock' flag.")
 	}
 
 	return showLegalHoldInfo(ctx, targetURL, versionID, timeRef, withVersions, recursive)

--- a/cmd/legalhold-set.go
+++ b/cmd/legalhold-set.go
@@ -215,7 +215,7 @@ func mainLegalHoldSet(cliCtx *cli.Context) error {
 		fatalIf(err, "Unable to set legalhold on `%s`", targetURL)
 	}
 	if !enabled {
-		fatalIf(errDummy().Trace(), "Bucket lock needs to be enabled in order to use this feature.")
+		fatalIf(errDummy().Trace(), "Bucket is not created with '--with-lock' flag.")
 	}
 
 	return setLegalHold(ctx, targetURL, versionID, timeRef, withVersions, recursive, minio.LegalHoldEnabled)

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -20,14 +20,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/lifecycle"
 	"github.com/minio/minio/pkg/console"
 )
 
@@ -246,16 +244,10 @@ func mainMove(cliCtx *cli.Context) error {
 			fatalIf(err.Trace(), "Unable to parse the provided url.")
 		}
 		if _, ok := client.(*S3Client); ok {
-			var lifeCycleConfig *lifecycle.Configuration
 			var legalHoldStatus minio.LegalHoldStatus
 			var retentionMode minio.RetentionMode
 			var err *probe.Error
 			ignoreErr := "The specified object does not have a ObjectLock configuration"
-			if lifeCycleConfig, err = client.GetLifecycle(ctx); err != nil && strings.Contains(err.Cause.Error(), ignoreErr) {
-				fatalIf(err.Trace(), "Unable to get ilm lock configuration for `%s`", urlStr)
-			} else if lifeCycleConfig != nil {
-				fatalIf(errDummy().Trace(), fmt.Sprintf("Object is locked with lifeCycle(ilm). `%s` cannot be moved.", urlStr))
-			}
 
 			if legalHoldStatus, err = client.GetObjectLegalHold(ctx, ""); err != nil && err.Cause.Error() != ignoreErr {
 				fatalIf(err.Trace(), "Unable to get legalhold lock configuration for `%s`", urlStr)


### PR DESCRIPTION
Fixes #3674 

The fix introduces checks if any one of the 3 possible lock configurations exists for the object. If one found, then `mc mv` is rejected with a clear error message.