### PR TITLE
Stops removing empty filesystem  paths

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -440,9 +440,9 @@ func isSysErrNotEmpty(err error) bool {
 	return false
 }
 
-// deleteFile deletes a file path if its empty. If it's successfully deleted,
-// it will recursively delete empty parent directories
-// until it finds one with files in it. Returns nil for a non-empty directory.
+// deleteFile does not delete the file path of the object if the file path becomes empty
+// after the object's removal, as the removal of empty paths is the usual object storage
+// behavior.
 func deleteFile(deletePath string) error {
 	// Attempt to remove path.
 	if e := os.Remove(deletePath); e != nil {
@@ -456,10 +456,6 @@ func deleteFile(deletePath string) error {
 	// slashpath.Dir() to work as intended.
 	parentPath := strings.TrimSuffix(deletePath, slashSeperator)
 	parentPath = path.Dir(parentPath)
-
-	if parentPath != "." {
-		return deleteFile(parentPath)
-	}
 
 	return nil
 }

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -440,9 +439,9 @@ func isSysErrNotEmpty(err error) bool {
 	return false
 }
 
-// deleteFile does not delete the file path of the object if the file path becomes empty
-// after the object's removal, as the removal of empty paths is the usual object storage
-// behavior.
+// deleteFile does not delete the file path of the object in a file system,
+// if the file path becomes empty after the object's removal. Normally, the
+// removal of empty paths is the usual object storage behavior.
 func deleteFile(deletePath string) error {
 	// Attempt to remove path.
 	if e := os.Remove(deletePath); e != nil {
@@ -451,11 +450,6 @@ func deleteFile(deletePath string) error {
 		}
 		return e
 	}
-
-	// Trailing slash is removed when found to ensure
-	// slashpath.Dir() to work as intended.
-	parentPath := strings.TrimSuffix(deletePath, slashSeperator)
-	parentPath = path.Dir(parentPath)
 
 	return nil
 }


### PR DESCRIPTION
Fix for #3621
`mc rm`, `mc mv`, or `mc mirror` commands stop removing the empty path after a file is successfully removed.
This fix does not change the behavior of object storage objects and prefixes.
So, it only works if the resource is a filesystem entity.