### PR TITLE
Avoid automatic copy of storage class

### DIFF
--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -43,9 +43,12 @@ func (s *TestSuite) TestList(c *C) {
 
 	reader := bytes.NewReader([]byte(data))
 	var n int64
-	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	},
+	)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -54,9 +57,11 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
-	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -82,9 +87,11 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
-	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -142,9 +149,11 @@ func (s *TestSuite) TestList(c *C) {
 	c.Assert(err, IsNil)
 
 	reader = bytes.NewReader([]byte(data))
-	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -249,9 +258,13 @@ func (s *TestSuite) TestPut(c *C) {
 	data := "hello"
 	reader := bytes.NewReader([]byte(data))
 	var n int64
-	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	},
+	)
+
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 }
@@ -269,9 +282,10 @@ func (s *TestSuite) TestGet(c *C) {
 	data := "hello"
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
-	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		}})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -297,9 +311,11 @@ func (s *TestSuite) TestGetRange(c *C) {
 	data := "hello world"
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
-	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -328,9 +344,12 @@ func (s *TestSuite) TestStatObject(c *C) {
 	data := "hello"
 	dataLen := len(data)
 	reader := bytes.NewReader([]byte(data))
-	n, err := fsClient.Put(context.Background(), reader, int64(dataLen), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err := fsClient.Put(context.Background(), reader, int64(dataLen), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	},
+	)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 
@@ -353,9 +372,11 @@ func (s *TestSuite) TestCopy(c *C) {
 
 	data := "hello world"
 	reader := bytes.NewReader([]byte(data))
-	n, err := fsClientSource.Put(context.Background(), reader, int64(len(data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err := fsClientSource.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
 	err = fsClientTarget.Copy(context.Background(), sourcePath, CopyOptions{size: int64(len(data))}, nil)

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -221,9 +221,11 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 
 	var reader io.Reader
 	reader = bytes.NewReader(object.data)
-	n, err := s3c.Put(context.Background(), reader, int64(len(object.data)), map[string]string{
-		"Content-Type": "application/octet-stream",
-	}, nil, nil, false, false, false)
+	n, err := s3c.Put(context.Background(), reader, int64(len(object.data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(object.data)))
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -51,6 +51,15 @@ type GetOptions struct {
 	VersionID string
 }
 
+// PutOptions holds options for PUT operation
+type PutOptions struct {
+	metadata              map[string]string
+	sse                   encrypt.ServerSide
+	md5, disableMultipart bool
+	isPreserve            bool
+	storageClass          string
+}
+
 // StatOptions holds options of the HEAD operation
 type StatOptions struct {
 	incomplete bool
@@ -80,6 +89,7 @@ type CopyOptions struct {
 	metadata         map[string]string
 	disableMultipart bool
 	isPreserve       bool
+	storageClass     string
 }
 
 // Client - client interface
@@ -109,7 +119,7 @@ type Client interface {
 	// I/O operations with metadata.
 	Get(ctx context.Context, opts GetOptions) (reader io.ReadCloser, err *probe.Error)
 
-	Put(ctx context.Context, reader io.Reader, size int64, metadata map[string]string, progress io.Reader, sse encrypt.ServerSide, md5, disableMultipart, isPreserve bool) (n int64, err *probe.Error)
+	Put(ctx context.Context, reader io.Reader, size int64, progress io.Reader, opts PutOptions) (n int64, err *probe.Error)
 
 	// Object Locking related API
 	PutObjectRetention(ctx context.Context, versionID string, mode minio.RetentionMode, retainUntilDate time.Time, bypassGovernance bool) *probe.Error

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -493,7 +493,7 @@ func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.
 
 				// Check and handle storage class if passed in command line args
 				if storageClass := cli.String("storage-class"); storageClass != "" {
-					cpURLs.TargetContent.Metadata["X-Amz-Storage-Class"] = storageClass
+					cpURLs.TargetContent.StorageClass = storageClass
 				}
 
 				if rm := cli.String(rmFlag); rm != "" {

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -406,7 +406,7 @@ func (mj *mirrorJob) doMirror(ctx context.Context, sURLs URLs) URLs {
 	sURLs.TargetContent.Metadata = make(map[string]string)
 
 	if mj.opts.storageClass != "" {
-		sURLs.TargetContent.Metadata["X-Amz-Storage-Class"] = mj.opts.storageClass
+		sURLs.TargetContent.StorageClass = mj.opts.storageClass
 	}
 
 	if mj.opts.activeActive {

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -87,11 +87,11 @@ func pipe(targetURL string, encKeyDB map[string][]prefixSSEPair, storageClass st
 	// Stream from stdin to multiple objects until EOF.
 	// Ignore size, since os.Stat() would not return proper size all the time
 	// for local filesystem for example /proc files.
-	var metadata map[string]string
-	if storageClass != "" {
-		metadata = map[string]string{"X-Amz-Storage-Class": storageClass}
+	opts := PutOptions{
+		sse:          sseKey,
+		storageClass: storageClass,
 	}
-	_, err := putTargetStreamWithURL(targetURL, os.Stdin, -1, sseKey, false, false, false, metadata)
+	_, err := putTargetStreamWithURL(targetURL, os.Stdin, -1, opts)
 	// TODO: See if this check is necessary.
 	switch e := err.ToGoError().(type) {
 	case *os.PathError:


### PR DESCRIPTION
Storage class is automatically copied from source to target  in mirror/cp commands.
This is not really needed since a storage class in source could be not supported in
the target server. Besides, users has --storage-class in mc & mirror commands that
they can use to specify the storage class during copy.