### PR TITLE
Report bandwidth limit in --json mode

### DIFF
--- a/cmd/admin-bucket-remote-add.go
+++ b/cmd/admin-bucket-remote-add.go
@@ -72,7 +72,7 @@ var adminBucketRemoteAddCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET http(s)://ACCESSKEY:SECRETKEY@DEST_URL/DEST_BUCKET [--path | --region | --label| --bandwidth] --service
+  {{.HelpName}} TARGET http(s)://ACCESSKEY:SECRETKEY@DEST_URL/DEST_BUCKET [--path | --region | --bandwidth] --service
 
 TARGET:
   Also called as alias/sourcebucketname
@@ -130,7 +130,6 @@ type RemoteMessage struct {
 	Path                string        `json:"path,omitempty"`
 	Region              string        `json:"region,omitempty"`
 	ServiceType         string        `json:"service"`
-	TargetLabel         string        `json:"TargetLabel"`
 	Bandwidth           int64         `json:"bandwidth"`
 	ReplicationSync     bool          `json:"replicationSync"`
 	HealthCheckDuration time.Duration `json:"healthcheckDuration"`
@@ -140,10 +139,6 @@ func (r RemoteMessage) String() string {
 	switch r.op {
 	case "ls":
 		message := console.Colorize("TargetURL", fmt.Sprintf("%s ", r.TargetURL))
-		if r.TargetLabel != "" {
-			message += console.Colorize("TargetLabel", fmt.Sprintf("%s ", r.TargetLabel))
-		}
-
 		message += console.Colorize("SourceBucket", r.SourceBucket)
 		message += console.Colorize("Arrow", "->")
 		message += console.Colorize("TargetBucket", r.TargetBucket)
@@ -227,7 +222,6 @@ func fetchRemoteTarget(cli *cli.Context) (sourceBucket string, bktTarget *madmin
 		Type:                madmin.ServiceType(serviceType),
 		Region:              cli.String("region"),
 		BandwidthLimit:      int64(bandwidth),
-		Label:               strings.ToUpper(cli.String("label")),
 		ReplicationSync:     cli.Bool("sync"),
 		HealthCheckDuration: time.Duration(cli.Uint("healthcheck-seconds")) * time.Second,
 	}

--- a/cmd/admin-bucket-remote-edit.go
+++ b/cmd/admin-bucket-remote-edit.go
@@ -121,7 +121,6 @@ func fetchRemoteEditTarget(cli *cli.Context) (bktTarget *madmin.BucketTarget) {
 		Endpoint:     host,
 		API:          "s3v4",
 		Region:       cli.String("region"),
-		Label:        strings.ToUpper(cli.String("label")),
 		Arn:          cli.String("arn"),
 	}
 	return bktTarget

--- a/cmd/admin-bucket-remote-ls.go
+++ b/cmd/admin-bucket-remote-ls.go
@@ -79,7 +79,6 @@ func mainAdminBucketRemoteList(ctx *cli.Context) error {
 	console.SetColor("SourceBucket", color.New(color.FgYellow))
 	console.SetColor("TargetBucket", color.New(color.FgYellow))
 	console.SetColor("TargetURL", color.New(color.FgHiWhite))
-	console.SetColor("TargetLabel", color.New(color.FgHiCyan))
 	console.SetColor("ARN", color.New(color.FgCyan))
 	console.SetColor("Arrow", color.New(color.FgHiWhite))
 	console.SetColor("SyncLabel", color.New(color.FgHiYellow))
@@ -103,7 +102,6 @@ func printRemotes(ctx *cli.Context, urlStr string, targets []madmin.BucketTarget
 	maxURLLen := 10
 	maxTgtLen := 6
 	maxSrcLen := 6
-	maxLabelLen := 5
 	if !globalJSON {
 		if len(targets) == 0 {
 			console.Print(console.Colorize("RemoteListEmpty", fmt.Sprintf("No remote targets found for `%s`. \n", urlStr)))
@@ -120,12 +118,9 @@ func printRemotes(ctx *cli.Context, urlStr string, targets []madmin.BucketTarget
 			if len(t.SourceBucket) > maxSrcLen {
 				maxSrcLen = len(t.SourceBucket)
 			}
-			if len(t.Label) > maxLabelLen {
-				maxLabelLen = len(t.Label)
-			}
 		}
 		if maxURLLen > 0 {
-			console.Println(console.Colorize("RemoteListMessage", fmt.Sprintf("%-*.*s %-*.*s %-*.*s->%-*.*s %s", maxURLLen+8, maxURLLen+8, "Remote URL", maxLabelLen, maxLabelLen, "Label", maxSrcLen, maxSrcLen, "Source", maxTgtLen, maxTgtLen, "Target", "ARN")))
+			console.Println(console.Colorize("RemoteListMessage", fmt.Sprintf("%-*.*s %-*.*s->%-*.*s %s", maxURLLen+8, maxURLLen+8, "Remote URL", maxSrcLen, maxSrcLen, "Source", maxTgtLen, maxTgtLen, "Target", "ARN")))
 		}
 	}
 	for _, target := range targets {
@@ -141,9 +136,6 @@ func printRemotes(ctx *cli.Context, urlStr string, targets []madmin.BucketTarget
 			if maxSrcLen > 0 {
 				target.SourceBucket = fmt.Sprintf("%-*.*s", maxSrcLen, maxSrcLen, target.SourceBucket)
 			}
-			if maxLabelLen > 0 {
-				target.Label = fmt.Sprintf("%-*.*s", maxLabelLen, maxLabelLen, target.Label)
-			}
 		}
 		printMsg(RemoteMessage{
 			op:              ctx.Command.Name,
@@ -153,8 +145,8 @@ func printRemotes(ctx *cli.Context, urlStr string, targets []madmin.BucketTarget
 			SourceBucket:    target.SourceBucket,
 			RemoteARN:       target.Arn,
 			ServiceType:     string(target.Type),
-			TargetLabel:     target.Label,
 			ReplicationSync: target.ReplicationSync,
+			Bandwidth:       target.BandwidthLimit,
 		})
 	}
 }


### PR DESCRIPTION
for `mc admin bucket remote ls`
Removing label for remote target as it was meant for ilm and is no longer relevant.