### PR TITLE
Add flag to `mc replicate` for existing object replication

### DIFF
--- a/cmd/admin-bucket-remote-add.go
+++ b/cmd/admin-bucket-remote-add.go
@@ -138,6 +138,8 @@ type RemoteMessage struct {
 	ReplicationSync     bool          `json:"replicationSync"`
 	Proxy               bool          `json:"proxy"`
 	HealthCheckDuration time.Duration `json:"healthcheckDuration"`
+	ResetID             string        `json:"resetID"`
+	ResetBefore         time.Time     `json:"resetBeforeDate"`
 }
 
 func (r RemoteMessage) String() string {

--- a/cmd/admin-bucket-remote-ls.go
+++ b/cmd/admin-bucket-remote-ls.go
@@ -158,6 +158,8 @@ func printRemotes(ctx *cli.Context, urlStr string, targets []madmin.BucketTarget
 			ReplicationSync: target.ReplicationSync,
 			Bandwidth:       target.BandwidthLimit,
 			Proxy:           !target.DisableProxy,
+			ResetID:         target.ResetID,
+			ResetBefore:     target.ResetBeforeDate,
 		})
 	}
 }

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -272,6 +272,7 @@ var completeCmds = map[string]complete.Predictor{
 	"/replicate/export": s3Complete{deepLevel: 2},
 	"/replicate/import": s3Complete{deepLevel: 2},
 	"/replicate/status": s3Complete{deepLevel: 2},
+	"/replicate/resync": s3Complete{deepLevel: 2},
 
 	"/tag/list":   s3Completer,
 	"/tag/remove": s3Completer,

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -1171,6 +1171,15 @@ func (f *fsClient) GetReplicationMetrics(ctx context.Context) (replication.Metri
 	})
 }
 
+// ResetReplication - kicks off replication again on previously replicated objects if existing object
+// replication is enabled in the replication config, not implemented
+func (f *fsClient) ResetReplication(ctx context.Context, before time.Duration) (string, *probe.Error) {
+	return "", probe.NewError(APINotImplemented{
+		API:     "ResetReplication",
+		APIType: "filesystem",
+	})
+}
+
 // Get encryption info for a bucket, not implemented.
 func (f *fsClient) GetEncryption(ctx context.Context) (string, string, *probe.Error) {
 	return "", "", probe.NewError(APINotImplemented{

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -2478,6 +2478,21 @@ func (c *S3Client) GetReplicationMetrics(ctx context.Context) (replication.Metri
 	return metrics, nil
 }
 
+// ResetReplication - kicks off replication again on previously replicated objects if existing object
+// replication is enabled in the replication config.Optional to provide a timestamp
+func (c *S3Client) ResetReplication(ctx context.Context, before time.Duration) (string, *probe.Error) {
+	bucket, _ := c.url2BucketAndObject()
+	if bucket == "" {
+		return "", probe.NewError(BucketNameEmpty{})
+	}
+
+	rID, e := c.api.ResetBucketReplication(ctx, bucket, before)
+	if e != nil {
+		return "", probe.NewError(e)
+	}
+	return rID, nil
+}
+
 // GetEncryption - gets bucket encryption info.
 func (c *S3Client) GetEncryption(ctx context.Context) (algorithm, keyID string, err *probe.Error) {
 	bucket, _ := c.url2BucketAndObject()

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -159,6 +159,7 @@ type Client interface {
 	SetReplication(ctx context.Context, cfg *replication.Config, opts replication.Options) *probe.Error
 	RemoveReplication(ctx context.Context) *probe.Error
 	GetReplicationMetrics(ctx context.Context) (replication.Metrics, *probe.Error)
+	ResetReplication(ctx context.Context, before time.Duration) (string, *probe.Error)
 	// Encryption operations
 	GetEncryption(ctx context.Context) (string, string, *probe.Error)
 	SetEncryption(ctx context.Context, algorithm, kmsKeyID string) *probe.Error

--- a/cmd/replicate-edit.go
+++ b/cmd/replicate-edit.go
@@ -174,7 +174,7 @@ func mainReplicateEdit(cliCtx *cli.Context) error {
 			case "replica-metadata-sync":
 				replicasync = enableStatus
 			case "existing-objects":
-
+				existingReplState = enableStatus
 			default:
 				if opt != "" {
 					fatalIf(probe.NewError(fmt.Errorf("invalid value for --replicate flag %s", cliCtx.String("replicate"))), "--replicate flag takes one or more comma separated string with values \"delete, delete-marker, replica-metadata-sync\" or \"\"")

--- a/cmd/replicate-main.go
+++ b/cmd/replicate-main.go
@@ -24,6 +24,7 @@ var replicateSubcommands = []cli.Command{
 	replicateEditCmd,
 	replicateListCmd,
 	replicateStatusCmd,
+	replicateResetCmd,
 	replicateExportCmd,
 	replicateImportCmd,
 	replicateRemoveCmd,

--- a/cmd/replicate-reset.go
+++ b/cmd/replicate-reset.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/console"
+	"maze.io/x/duration"
+)
+
+var replicateResetFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "older-than",
+		Usage: "re-replicate objects older than n days",
+	},
+}
+
+var replicateResetCmd = cli.Command{
+	Name:         "resync",
+	Usage:        "re-replicate all previously replicated objects",
+	Aliases:      []string{"reset"},
+	Action:       mainReplicateReset,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        append(globalFlags, replicateResetFlags...),
+	CustomHelpTemplate: `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} TARGET
+
+FLAGS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}
+EXAMPLES:
+  1. Re-replicate previously replicated objects in bucket "mybucket" for alias "myminio".
+   {{.Prompt}} {{.HelpName}} myminio/mybucket
+
+  2. Re-replicate all objects older than 60 days in bucket "mybucket".
+   {{.Prompt}} {{.HelpName}} myminio/mybucket --older-than 60d
+`,
+}
+
+// checkReplicateResetSyntax - validate all the passed arguments
+func checkReplicateResetSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		cli.ShowCommandHelpAndExit(ctx, "reset", 1) // last argument is exit code
+	}
+}
+
+type replicateResetMessage struct {
+	Op      string `json:"op"`
+	URL     string `json:"url"`
+	ResetID string `json:"resetID"`
+	Status  string `json:"status"`
+}
+
+func (r replicateResetMessage) JSON() string {
+	r.Status = "success"
+	jsonMessageBytes, e := json.MarshalIndent(r, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+	return string(jsonMessageBytes)
+}
+
+func (r replicateResetMessage) String() string {
+	return console.Colorize("replicateResetMessage", fmt.Sprintf("Replication reset started for %s with ID %s", r.URL, r.ResetID))
+}
+
+func mainReplicateReset(cliCtx *cli.Context) error {
+	ctx, cancelReplicateReset := context.WithCancel(globalContext)
+	defer cancelReplicateReset()
+
+	console.SetColor("replicateResetMessage", color.New(color.FgGreen))
+
+	checkReplicateResetSyntax(cliCtx)
+
+	// Get the alias parameter from cli
+	args := cliCtx.Args()
+	aliasedURL := args.Get(0)
+	// Create a new Client
+	client, err := newClient(aliasedURL)
+	fatalIf(err, "Unable to initialize connection.")
+	var olderThanStr string
+	var olderThan time.Duration
+	if cliCtx.IsSet("older-than") {
+		olderThanStr = cliCtx.String("older-than")
+		if olderThanStr != "" {
+			days, e := duration.ParseDuration(olderThanStr)
+			if e != nil || !strings.ContainsAny(olderThanStr, "dwy") {
+				fatalIf(probe.NewError(e), "Unable to parse older-than=`"+olderThanStr+"`.")
+			}
+			if days == 0 {
+				fatalIf(probe.NewError(e), "older-than cannot be set to zero")
+			}
+			olderThan = time.Duration(days.Days())
+		}
+	}
+
+	replicateReset, err := client.ResetReplication(ctx, olderThan)
+	fatalIf(err.Trace(args...), "Unable to reset replication")
+	printMsg(replicateResetMessage{
+		Op:      "status",
+		URL:     aliasedURL,
+		ResetID: replicateReset,
+	})
+	return nil
+}

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -1883,3 +1883,9 @@ mc replicate export myminio/mybucket > /data/replicate/config
 ```
 mc replicate status myminio/mybucket
 ```
+
+*Example: Resync replication of previously replicated objects from `mybucket` on alias `myminio` to configured remote target in replication configuration.
+
+```
+mc replicate resync myminio/mybucket
+```

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.0.10-0.20210602195449-b1bf23ec13e4
+	github.com/minio/madmin-go v1.0.11
 	github.com/minio/md5-simd v1.1.1 // indirect
-	github.com/minio/minio-go/v7 v7.0.11-0.20210517200026-f0518ca447d6
+	github.com/minio/minio-go/v7 v7.0.11-0.20210607181445-e162fdb8e584
 	github.com/minio/pkg v1.0.3
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -41,4 +41,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	maze.io/x/duration v0.0.0-20160924141736-faac084b6075
 )
-replace github.com/minio/minio-go/v7 => ../minio-go

--- a/go.mod
+++ b/go.mod
@@ -41,3 +41,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	maze.io/x/duration v0.0.0-20160924141736-faac084b6075
 )
+replace github.com/minio/minio-go/v7 => ../minio-go

--- a/go.sum
+++ b/go.sum
@@ -249,14 +249,14 @@ github.com/minio/colorjson v1.0.1 h1:+hvfP8C1iMB95AT+ZFDRE+Knn9QPd9lg0CRJY9DRpos
 github.com/minio/colorjson v1.0.1/go.mod h1:oPM3zQQY8Gz9NGtgvuBEjQ+gPZLKAGc7T+kjMlwtOgs=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
-github.com/minio/madmin-go v1.0.10-0.20210602195449-b1bf23ec13e4 h1:AxtnO3AODg0t2IPXbrqmDBhGZTcrUhlT/ixdLQQ3164=
-github.com/minio/madmin-go v1.0.10-0.20210602195449-b1bf23ec13e4/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
+github.com/minio/madmin-go v1.0.11 h1:oyTsINMIgyF1OrjtAgef+gfbwH0i6Kxk3waY1mAcN58=
+github.com/minio/madmin-go v1.0.11/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.1 h1:9ojcLbuZ4gXbB2sX53MKn8JUZ0sB/2wfwsEcRw+I08U=
 github.com/minio/md5-simd v1.1.1/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/minio-go/v7 v7.0.11-0.20210302210017-6ae69c73ce78/go.mod h1:mTh2uJuAbEqdhMVl6CMIIZLUeiMiWtJR4JB8/5g2skw=
-github.com/minio/minio-go/v7 v7.0.11-0.20210517200026-f0518ca447d6 h1:GVR+UTvfe2r2YTYHWrA/yRF5nouMjJh3kwxNTZ8npso=
-github.com/minio/minio-go/v7 v7.0.11-0.20210517200026-f0518ca447d6/go.mod h1:td4gW1ldOsj1PbSNS+WYK43j+P1XVhX/8W8awaYlBFo=
+github.com/minio/minio-go/v7 v7.0.11-0.20210607181445-e162fdb8e584 h1:GgOqN/DE44zZh3+sg5elR6diWq+Qv4dN7U2KvPVfe1I=
+github.com/minio/minio-go/v7 v7.0.11-0.20210607181445-e162fdb8e584/go.mod h1:WoyW+ySKAKjY98B9+7ZbI8z8S3jaxaisdcvj9TGlazA=
 github.com/minio/pkg v1.0.3 h1:tUhM6lG/BdNB0+5f2RbE4ifCAYwMs6cRJnZ/AY0WIeQ=
 github.com/minio/pkg v1.0.3/go.mod h1:obU54TZ9QlMv0TRaDgQ/JTzf11ZSXxnSfLrm4tMtBP8=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
@@ -377,6 +377,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.1.1 h1:T/YLemO5Yp7KPzS+lVtu+WsHn8yoSwTfItdAd1r3cck=
 github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=


### PR DESCRIPTION
Needs https://github.com/minio/minio-go/pull/1483/files and https://github.com/minio/madmin-go/pull/6
For https://github.com/minio/minio/pull/12109

1.  for existing object replication
`mc replicate add|edit --replicate "existing-objects,.."`

2. for replication reset
`mc replicate resync alias/bucket`