### PR TITLE
Fix incorrect error related to "name" flag

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -177,9 +177,6 @@ func mainAdminHealth(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	license, schedule, dev, name := fetchSubnetUploadFlags(ctx)
-	if len(name) == 0 {
-		name = aliasedURL
-	}
 
 	uploadToSubnet := len(license) > 0
 	uploadPeriodically := schedule != 0
@@ -191,6 +188,9 @@ func mainAdminHealth(ctx *cli.Context) error {
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Unable to initialize admin connection.")
 
+	if len(name) == 0 {
+		name = aliasedURL
+	}
 	// Main execution
 	execAdminHealth(ctx, client, aliasedURL, license, name, dev)
 


### PR DESCRIPTION
The command `mc admin subnet health alias` is throwing an error saying
"--name is applicable only when --license is also passe" even when the
flag `--name` is not passed.

This is happening because the name is default-populated with the alias
passed in the command. Fixed my moving the default-population after the
validation.