### PR TITLE
Fix build on 32-bit systems (OpenBSD/solaris)

### DIFF
--- a/pkg/disk/stat_other.go
+++ b/pkg/disk/stat_other.go
@@ -38,7 +38,7 @@ func GetFileSystemAttrs(file string) (string, error) {
 
 	var fileAttr strings.Builder
 	fileAttr.WriteString("atime:")
-	fileAttr.WriteString(strconv.FormatInt(st.Atim.Sec, 10) + "#" + strconv.FormatInt(st.Atim.Nsec, 10))
+	fileAttr.WriteString(strconv.FormatInt(int64(st.Atim.Sec), 10) + "#" + strconv.FormatInt(int64(st.Atim.Nsec), 10))
 	fileAttr.WriteString("/gid:")
 	fileAttr.WriteString(strconv.Itoa(int(st.Gid)))
 
@@ -51,7 +51,7 @@ func GetFileSystemAttrs(file string) (string, error) {
 	fileAttr.WriteString("/mode:")
 	fileAttr.WriteString(strconv.Itoa(int(st.Mode)))
 	fileAttr.WriteString("/mtime:")
-	fileAttr.WriteString(strconv.FormatInt(st.Mtim.Sec, 10) + "#" + strconv.FormatInt(st.Mtim.Nsec, 10))
+	fileAttr.WriteString(strconv.FormatInt(int64(st.Mtim.Sec), 10) + "#" + strconv.FormatInt(int64(st.Mtim.Nsec), 10))
 	fileAttr.WriteString("/uid:")
 	fileAttr.WriteString(strconv.Itoa(int(st.Uid)))
 


### PR DESCRIPTION
Hi,

This is currently broken with `pkg/disk/stat_other.go:40:91: cannot use st.Atim.Nsec (type int32) as type int64 in argument to strconv.FormatInt` (line number is off because it's an old release).

Does it make sense to  you? I can't test it unfortunately because I don't have access to a 32-bit system.

`go build` works on my amd64 system so no regression on that side I guess.

Cheers,
Daniel