### PR TITLE
du: Use recursive listing when no detailed report is asked

### DIFF
--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -123,12 +123,9 @@ func du(ctx context.Context, urlStr string, timeRef time.Time, withVersions bool
 		return 0, exitStatus(globalErrorExitStatus) // End of journey.
 	}
 
-	recursive := false
-	if depth == 1 {
-		// No disk usage details below this level,
-		// just do a recursive listing
-		recursive = true
-	}
+	// No disk usage details below this level,
+	// just do a recursive listing
+	recursive := depth == 1
 
 	contentCh := clnt.List(ctx, ListOptions{
 		TimeRef:           timeRef,


### PR DESCRIPTION
mc du will always count the size of all objects under a specified
path, du -r will show the disk usage in a more detailed fashion, but if
not specified, let's do a recursive LIST call instead of calling du()
multiple times.

Bonus: check if the passed argument is a directory and error out
otherwise.