### PR TITLE
Add single line json output

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -41,11 +41,6 @@ var globalFlags = []cli.Flag{
 		Usage: "enable JSON lines formatted output",
 	},
 	cli.BoolFlag{
-		Name:   "jsonl",
-		Usage:  "enable JSON single line output",
-		Hidden: true,
-	},
-	cli.BoolFlag{
 		Name:  "debug",
 		Usage: "enable debug output",
 	},

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -41,6 +41,11 @@ var globalFlags = []cli.Flag{
 		Usage: "enable JSON lines formatted output",
 	},
 	cli.BoolFlag{
+		Name:   "jsonl",
+		Usage:  "enable JSON single line output",
+		Hidden: true,
+	},
+	cli.BoolFlag{
 		Name:  "debug",
 		Usage: "enable debug output",
 	},

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -57,7 +57,7 @@ const (
 var (
 	globalQuiet    = false // Quiet flag set via command line
 	globalJSON     = false // Json flag set via command line
-	globalJSONLine = false // Jsonl flag set via command line
+	globalJSONLine = false // Print json as single line.
 	globalDebug    = false // Debug flag set via command line
 	globalNoColor  = false // No Color flag set via command line
 	globalInsecure = false // Insecure flag set via command line
@@ -74,11 +74,11 @@ var (
 )
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
-func setGlobals(quiet, debug, json, jsonl, noColor, insecure bool) {
+func setGlobals(quiet, debug, json, noColor, insecure bool) {
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
-	globalJSONLine = globalJSONLine || jsonl
-	globalJSON = globalJSON || globalJSONLine || json
+	globalJSONLine = !isTerminal() && json
+	globalJSON = globalJSON || json
 	globalNoColor = globalNoColor || noColor || globalJSONLine
 	globalInsecure = globalInsecure || insecure
 
@@ -93,9 +93,8 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	quiet := ctx.IsSet("quiet") || ctx.GlobalIsSet("quiet")
 	debug := ctx.IsSet("debug") || ctx.GlobalIsSet("debug")
 	json := ctx.IsSet("json") || ctx.GlobalIsSet("json")
-	jsonl := ctx.IsSet("jsonl") || ctx.GlobalIsSet("jsonl")
 	noColor := ctx.IsSet("no-color") || ctx.GlobalIsSet("no-color")
 	insecure := ctx.IsSet("insecure") || ctx.GlobalIsSet("insecure")
-	setGlobals(quiet, debug, json, jsonl, noColor, insecure)
+	setGlobals(quiet, debug, json, noColor, insecure)
 	return nil
 }

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -57,6 +57,7 @@ const (
 var (
 	globalQuiet    = false // Quiet flag set via command line
 	globalJSON     = false // Json flag set via command line
+	globalJSONLine = false // Jsonl flag set via command line
 	globalDebug    = false // Debug flag set via command line
 	globalNoColor  = false // No Color flag set via command line
 	globalInsecure = false // Insecure flag set via command line
@@ -73,11 +74,12 @@ var (
 )
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
-func setGlobals(quiet, debug, json, noColor, insecure bool) {
+func setGlobals(quiet, debug, json, jsonl, noColor, insecure bool) {
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
-	globalJSON = globalJSON || json
-	globalNoColor = globalNoColor || noColor
+	globalJSONLine = globalJSONLine || jsonl
+	globalJSON = globalJSON || globalJSONLine || json
+	globalNoColor = globalNoColor || noColor || globalJSONLine
 	globalInsecure = globalInsecure || insecure
 
 	// Disable colorified messages if requested.
@@ -91,8 +93,9 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	quiet := ctx.IsSet("quiet") || ctx.GlobalIsSet("quiet")
 	debug := ctx.IsSet("debug") || ctx.GlobalIsSet("debug")
 	json := ctx.IsSet("json") || ctx.GlobalIsSet("json")
+	jsonl := ctx.IsSet("jsonl") || ctx.GlobalIsSet("jsonl")
 	noColor := ctx.IsSet("no-color") || ctx.GlobalIsSet("no-color")
 	insecure := ctx.IsSet("insecure") || ctx.GlobalIsSet("insecure")
-	setGlobals(quiet, debug, json, noColor, insecure)
+	setGlobals(quiet, debug, json, jsonl, noColor, insecure)
 	return nil
 }

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 
 	"github.com/minio/pkg/console"
 )
@@ -37,7 +38,7 @@ func printMsg(msg message) {
 		msgStr = msg.String()
 	} else {
 		msgStr = msg.JSON()
-		if globalJSONLine {
+		if globalJSONLine && strings.ContainsRune(msgStr, '\n') {
 			// Reformat.
 			var dst bytes.Buffer
 			if err := json.Compact(&dst, []byte(msgStr)); err == nil {

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -38,7 +38,7 @@ func printMsg(msg message) {
 	} else {
 		msgStr = msg.JSON()
 		if globalJSONLine {
-			// Reformat
+			// Reformat.
 			var dst bytes.Buffer
 			if err := json.Compact(&dst, []byte(msgStr)); err == nil {
 				msgStr = dst.String()

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -18,6 +18,9 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+
 	"github.com/minio/pkg/console"
 )
 
@@ -34,6 +37,13 @@ func printMsg(msg message) {
 		msgStr = msg.String()
 	} else {
 		msgStr = msg.JSON()
+		if globalJSONLine {
+			// Reformat
+			var dst bytes.Buffer
+			if err := json.Compact(&dst, []byte(msgStr)); err == nil {
+				msgStr = dst.String()
+			}
+		}
 	}
 	console.Println(msgStr)
 }


### PR DESCRIPTION
Always reformat if returned JSON contains "\n".
Always disables color.

This way we don't have to rely on deeply nested implementations to provide this correctly.

Before:
```
$ ./mc admin trace --json play/ | tee                                       
{                                                                                                                                      
 "status": "success",                                                                                                                  
 "host": "play.min.io",                                                                                                                
 "time": "2021-06-08T12:30:14.93251887Z",                                                                                              
 "client": "175.98.141.254",                                                                                                           
 "callStats": {                                                                                                                        
  "rx": 205,                                                                                                                           
  "tx": 746,                                                                                                                           
  "duration": 141030034,                                                                                                               
  "timeToFirstByte": 0                                                                                                                 
 },                                                                                                                                    
 "api": "s3.PutObject",                                                                                                                
 "path": "/dev11/1bff60e9-a4c4-437e-862a-100630b1e6de/event/20210608/1620/1623140422442_cf79affc-c7b7-4e04-8bec-8a90493140fd.json",    
 "query": "x-id=PutObject",                                                                                                            
 "statusCode": 404,                                                                                                                    
 "statusMsg": "Not Found",                                                                                                             
 "storageStats": {                                                                                                                     
  "duration": 0,                                                                                                                       
  "path": ""                                                                                                                           
 },                                                                                                                                    
 "osStats": {                                                                                                                          
  "duration": 0,                                                                                                                       
  "path": ""                                                                                                                           
 },                                                                                                                                    
 "type": 0                                                                                                                             
}                                                                                                                                      
                                                                                                                                       
{                                                                                                                                      
 "status": "success",                                                                                                                  
 "host": "play.min.io",                                                                                                                
```

After:
```
$  ./mc admin trace --json play/ | tee
{"status":"success","host":"play.min.io","time":"2021-06-08T12:27:32.401869663Z","client":"175.98.141.254","callStats":{"rx":205,"tx":746,"duration":125847269,"timeToFirstByte":0},"api":"s3.PutObject","path":"/dev11/1bff60e9-a4c4-437e-862a-100630b1e6de/event/20210608/1208/1623125284099_0bf92b8b-0de1-42fd-835e-7809c775fdfd.json","query":"x-id=PutObject","statusCode":404,"statusMsg":"Not Found","storageStats":{"duration":0,"path":""},"osStats":{"duration":0,"path":""},"type":0}
{"status":"success","host":"play.min.io","time":"2021-06-08T12:27:32.415940974Z","client":"175.98.141.254","callStats":{"rx":205,"tx":746,"duration":154060728,"timeToFirstByte":0},"api":"s3.PutObject","path":"/dev11/1bff60e9-a4c4-437e-862a-100630b1e6de/event/20210608/1617/1623140267333_a5cc20ce-1dfa-490b-800d-6f796c1ce158.json","query":"x-id=PutObject","statusCode":404,"statusMsg":"Not Found","storageStats":{"duration":0,"path":""},"osStats":{"duration":0,"path":""},"type":0}
```