### PR TITLE
Control multipart upload options

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1001,6 +1001,14 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, progre
 		DisableMultipart:     putOpts.disableMultipart,
 	}
 
+	if putOpts.numThreads > 0 {
+		opts.NumThreads = putOpts.numThreads
+	}
+
+	if putOpts.partSize > 0 {
+		opts.PartSize = putOpts.partSize
+	}
+
 	if !retainUntilDate.IsZero() && !retainUntilDate.Equal(timeSentinel) {
 		opts.RetainUntilDate = retainUntilDate
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -57,6 +57,8 @@ type PutOptions struct {
 	metadata              map[string]string
 	sse                   encrypt.ServerSide
 	md5, disableMultipart bool
+	partSize              uint64
+	numThreads            uint
 	isPreserve            bool
 	storageClass          string
 }

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -558,6 +558,8 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 			storageClass:     urls.TargetContent.StorageClass,
 			md5:              urls.MD5,
 			disableMultipart: urls.DisableMultipart,
+			partSize:         uint64(urls.MultipartSize),
+			numThreads:       uint(urls.MultipartThreads),
 			isPreserve:       preserve,
 		}
 

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -45,6 +45,8 @@ func checkMirrorSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[st
 	srcURL = URLs[0]
 	tgtURL = URLs[1]
 
+	checkMultipartFlags(cliCtx)
+
 	if cliCtx.Bool("force") && cliCtx.Bool("remove") {
 		errorIf(errInvalidArgument().Trace(URLs...), "`--force` is deprecated, please use `--overwrite` instead with `--remove` for the same functionality.")
 	} else if cliCtx.Bool("force") {
@@ -208,6 +210,8 @@ type mirrorOptions struct {
 	excludeOptions                    []string
 	encKeyDB                          map[string][]prefixSSEPair
 	md5, disableMultipart             bool
+	partSize                          uint64
+	partThreads                       uint
 	olderThan, newerThan              string
 	storageClass                      string
 	userMetadata                      map[string]string

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -68,6 +68,14 @@ var (
 			Name:  "disable-multipart",
 			Usage: "disable multipart upload feature",
 		},
+		cli.StringFlag{
+			Name:  "part-size",
+			Usage: "set the size of a part in a multipart upload",
+		},
+		cli.IntFlag{
+			Name:  "part-threads",
+			Usage: "set the number of parallel parts uploads",
+		},
 	}
 )
 
@@ -295,6 +303,8 @@ func mainMove(cliCtx *cli.Context) error {
 			}
 			session.Header.UserMetaData = userMetaMap
 			session.Header.CommandBoolFlags["disable-multipart"] = cliCtx.Bool("disable-multipart")
+			session.Header.CommandStringFlags["part-size"] = cliCtx.String("part-size")
+			session.Header.CommandIntFlags["part-threads"] = cliCtx.Int("part-threads")
 
 			var e error
 			if session.Header.RootPath, e = os.Getwd(); e != nil {

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -31,6 +31,8 @@ type URLs struct {
 	TotalSize        int64
 	MD5              bool
 	DisableMultipart bool
+	MultipartThreads uint
+	MultipartSize    uint64
 	encKeyDB         map[string][]prefixSSEPair
 	Error            *probe.Error `json:"-"`
 	ErrorCond        differType   `json:"-"`


### PR DESCRIPTION
Add --part-size and --part-threads to control the part size and the
number of threads used when uploading parts.