### PR TITLE
fix: health report incompatibility with old minio

### DIFF
--- a/cmd/health_v1.go
+++ b/cmd/health_v1.go
@@ -137,7 +137,7 @@ func (ch ClusterHealthV1) GetTimestamp() time.Time {
 }
 
 // MapHealthInfoToV1 - maps the health info returned by minio server to V1 format
-func MapHealthInfoToV1(healthInfo madmin.HealthInfoV0, err error) HealthReportInfo {
+func MapHealthInfoToV1(healthInfo madmin.HealthInfoV0, err error) ClusterHealthV1 {
 	ch := ClusterHealthV1{}
 	ch.TimeStamp = healthInfo.TimeStamp
 	if err != nil {


### PR DESCRIPTION
When the subnet health command from current mc is used with the MinIO
versions before the latest health data structure changes (v2) were
introduced, the generated report doesn't contain the cluster information
(minio -> info).

This is because these old versions of minio don't return this
information in the output of the `healthinfo` api.

Fixed this by explicitly pulling the server info separately when we
detect that the health schema version is not v2.