### PR TITLE
Set default value for `--event` flag of omitted

### DIFF
--- a/cmd/event-remove.go
+++ b/cmd/event-remove.go
@@ -36,6 +36,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "event",
+			Value: "put,delete,get",
 			Usage: "filter specific type of event. Defaults to all event",
 		},
 		cli.StringFlag{


### PR DESCRIPTION
When using the `mc event remove` command, if the `--prefix` flag is provided but the `--event` flag is **not** provided, mc errors with a cryptic message:

```
mc: <ERROR> Unable to disable notification on the specified bucket. Invalid arguments provided, please refer `mc <command> -h` for relevant documentation.
```

This is because this code block (https://github.com/minio/mc/blob/a1ba511f16d9ee1f02812a1bf1613433b6b1c7b2/cmd/client-s3.go#L336) assumes the event flag will have a value (either set by the user or defaulted). 

This PR simply copies the default value from the `add` command implementation.