### PR TITLE
make fields in *opts visible

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -301,8 +301,8 @@ func (f *fsClient) put(ctx context.Context, reader io.Reader, size int64, progre
 	}
 
 	attr := make(map[string]string)
-	if _, ok := opts.metadata[metadataKey]; ok && opts.isPreserve {
-		attr, e = parseAttribute(opts.metadata)
+	if _, ok := opts.Metadata[metadataKey]; ok && opts.IsPreserve {
+		attr, e = parseAttribute(opts.Metadata)
 		if e != nil {
 			tmpFile.Close()
 			return 0, probe.NewError(e)
@@ -359,7 +359,7 @@ func (f *fsClient) put(ctx context.Context, reader io.Reader, size int64, progre
 		return totalWritten, err.Trace(objectPartPath, objectPath)
 	}
 
-	if len(attr) != 0 && opts.isPreserve {
+	if len(attr) != 0 && opts.IsPreserve {
 		atime, mtime, err := parseAtimeMtime(attr)
 		if err != nil {
 			return totalWritten, err.Trace()
@@ -405,12 +405,12 @@ func (f *fsClient) Copy(ctx context.Context, source string, opts CopyOptions, pr
 	defer rc.Close()
 
 	putOpts := PutOptions{
-		metadata:   opts.metadata,
-		isPreserve: opts.isPreserve,
+		Metadata:   opts.Metadata,
+		IsPreserve: opts.IsPreserve,
 	}
 
 	destination := f.PathURL.Path
-	if _, err := f.put(ctx, rc, opts.size, progress, putOpts); err != nil {
+	if _, err := f.put(ctx, rc, opts.Size, progress, putOpts); err != nil {
 		return err.Trace(destination, source)
 	}
 	return nil
@@ -1008,7 +1008,7 @@ func (f *fsClient) SetAccess(ctx context.Context, access string, isJSON bool) *p
 
 // Stat - get metadata from path.
 func (f *fsClient) Stat(ctx context.Context, opts StatOptions) (content *ClientContent, err *probe.Error) {
-	st, err := f.fsStat(opts.incomplete)
+	st, err := f.fsStat(opts.Incomplete)
 	if err != nil {
 		return nil, err.Trace(f.PathURL.String())
 	}
@@ -1025,7 +1025,7 @@ func (f *fsClient) Stat(ctx context.Context, opts StatOptions) (content *ClientC
 	path := f.PathURL.String()
 	// Populates meta data with file system attribute only in case of
 	// when preserve flag is passed.
-	if opts.preserve {
+	if opts.Preserve {
 		fileAttr, err := disk.GetFileSystemAttrs(path)
 		if err != nil {
 			return content, nil

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -45,7 +45,7 @@ func (s *TestSuite) TestList(c *C) {
 	reader := bytes.NewReader([]byte(data))
 	var n int64
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	},
@@ -59,7 +59,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	})
@@ -89,7 +89,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	})
@@ -151,7 +151,7 @@ func (s *TestSuite) TestList(c *C) {
 
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	})
@@ -260,7 +260,7 @@ func (s *TestSuite) TestPut(c *C) {
 	reader := bytes.NewReader([]byte(data))
 	var n int64
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	},
@@ -284,7 +284,7 @@ func (s *TestSuite) TestGet(c *C) {
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		}})
 	c.Assert(err, IsNil)
@@ -313,7 +313,7 @@ func (s *TestSuite) TestGetRange(c *C) {
 	var reader io.Reader
 	reader = bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	})
@@ -346,7 +346,7 @@ func (s *TestSuite) TestStatObject(c *C) {
 	dataLen := len(data)
 	reader := bytes.NewReader([]byte(data))
 	n, err := fsClient.Put(context.Background(), reader, int64(dataLen), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	},
@@ -374,12 +374,12 @@ func (s *TestSuite) TestCopy(c *C) {
 	data := "hello world"
 	reader := bytes.NewReader([]byte(data))
 	n, err := fsClientSource.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	})
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(len(data)))
-	err = fsClientTarget.Copy(context.Background(), sourcePath, CopyOptions{size: int64(len(data))}, nil)
+	err = fsClientTarget.Copy(context.Background(), sourcePath, CopyOptions{Size: int64(len(data))}, nil)
 	c.Assert(err, IsNil)
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -834,14 +834,14 @@ func (c *S3Client) Copy(ctx context.Context, source string, opts CopyOptions, pr
 		return probe.NewError(BucketNameEmpty{})
 	}
 
-	metadata := make(map[string]string, len(opts.metadata))
-	for k, v := range opts.metadata {
+	metadata := make(map[string]string, len(opts.Metadata))
+	for k, v := range opts.Metadata {
 		metadata[k] = v
 	}
 
 	delete(metadata, "X-Amz-Storage-Class")
-	if opts.storageClass != "" {
-		metadata["X-Amz-Storage-Class"] = opts.storageClass
+	if opts.StorageClass != "" {
+		metadata["X-Amz-Storage-Class"] = opts.StorageClass
 	}
 
 	tokens := splitStr(source, string(c.targetURL.Separator), 3)
@@ -850,16 +850,16 @@ func (c *S3Client) Copy(ctx context.Context, source string, opts CopyOptions, pr
 	srcOpts := minio.CopySrcOptions{
 		Bucket:     tokens[1],
 		Object:     tokens[2],
-		Encryption: opts.srcSSE,
-		VersionID:  opts.versionID,
+		Encryption: opts.SrcSSE,
+		VersionID:  opts.VersionID,
 	}
 
 	destOpts := minio.CopyDestOptions{
 		Bucket:     dstBucket,
 		Object:     dstObject,
-		Encryption: opts.tgtSSE,
+		Encryption: opts.TgtSSE,
 		Progress:   progress,
-		Size:       opts.size,
+		Size:       opts.Size,
 	}
 
 	if lockModeStr, ok := metadata[AmzObjectLockMode]; ok {
@@ -884,7 +884,7 @@ func (c *S3Client) Copy(ctx context.Context, source string, opts CopyOptions, pr
 	destOpts.ReplaceMetadata = len(metadata) > 0
 
 	var e error
-	if opts.disableMultipart || opts.size < 64*1024*1024 {
+	if opts.DisableMultipart || opts.Size < 64*1024*1024 {
 		_, e = c.api.CopyObject(ctx, destOpts, srcOpts)
 	} else {
 		_, e = c.api.ComposeObject(ctx, destOpts, srcOpts)
@@ -922,8 +922,8 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, progre
 		return 0, probe.NewError(BucketNameEmpty{})
 	}
 
-	metadata := make(map[string]string, len(putOpts.metadata))
-	for k, v := range putOpts.metadata {
+	metadata := make(map[string]string, len(putOpts.Metadata))
+	for k, v := range putOpts.Metadata {
 		metadata[k] = v
 	}
 
@@ -994,12 +994,12 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, progre
 		ContentDisposition:   contentDisposition,
 		ContentEncoding:      contentEncoding,
 		ContentLanguage:      contentLanguage,
-		StorageClass:         strings.ToUpper(putOpts.storageClass),
-		ServerSideEncryption: putOpts.sse,
-		SendContentMd5:       putOpts.md5,
-		DisableMultipart:     putOpts.disableMultipart,
-		PartSize:             putOpts.multipartSize,
-		NumThreads:           putOpts.multipartThreads,
+		StorageClass:         strings.ToUpper(putOpts.StorageClass),
+		ServerSideEncryption: putOpts.SSE,
+		SendContentMd5:       putOpts.MD5,
+		DisableMultipart:     putOpts.DisableMultipart,
+		PartSize:             putOpts.MultipartSize,
+		NumThreads:           putOpts.MultipartThreads,
 	}
 
 	if !retainUntilDate.IsZero() && !retainUntilDate.Equal(timeSentinel) {
@@ -1423,7 +1423,7 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 	}
 
 	// If the request is for incomplete upload stat, handle it here.
-	if opts.incomplete {
+	if opts.Incomplete {
 		return c.statIncompleteUpload(ctx, bucket, object)
 	}
 
@@ -1439,10 +1439,10 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 	// because the list could be very large. At the same time, the HEAD call is avoided if the
 	// object already contains a trailing prefix or we passed rewind flag to know the object version
 	// created just before the rewind parameter.
-	if !strings.HasSuffix(object, string(c.targetURL.Separator)) && opts.timeRef.IsZero() {
+	if !strings.HasSuffix(object, string(c.targetURL.Separator)) && opts.TimeRef.IsZero() {
 		// Issue HEAD request first but ignore no such key error
 		// so we can check if there is such prefix which exists
-		ctnt, err := c.getObjectStat(ctx, bucket, object, minio.StatObjectOptions{ServerSideEncryption: opts.sse, VersionID: opts.versionID})
+		ctnt, err := c.getObjectStat(ctx, bucket, object, minio.StatObjectOptions{ServerSideEncryption: opts.SSE, VersionID: opts.VersionID})
 		if err == nil {
 			return ctnt, nil
 		}
@@ -1457,7 +1457,7 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 	// Prefix to pass to minio-go listing in order to fetch if a prefix exists
 	prefix := strings.TrimRight(object, string(c.targetURL.Separator))
 
-	for objectStat := range c.listObjectWrapper(ctx, bucket, prefix, nonRecursive, opts.timeRef, false, false, false, 1) {
+	for objectStat := range c.listObjectWrapper(ctx, bucket, prefix, nonRecursive, opts.TimeRef, false, false, false, 1) {
 		if objectStat.Err != nil {
 			return nil, probe.NewError(objectStat.Err)
 		}
@@ -1468,7 +1468,7 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 		break
 	}
 
-	return nil, probe.NewError(ObjectMissing{opts.timeRef})
+	return nil, probe.NewError(ObjectMissing{opts.TimeRef})
 }
 
 // getObjectStat returns the metadata of an object from a HEAD call.

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -223,7 +223,7 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	var reader io.Reader
 	reader = bytes.NewReader(object.data)
 	n, err := s3c.Put(context.Background(), reader, int64(len(object.data)), nil, PutOptions{
-		metadata: map[string]string{
+		Metadata: map[string]string{
 			"Content-Type": "application/octet-stream",
 		},
 	})

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -194,7 +194,7 @@ func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encK
 	alias, _ := url2Alias(urlStr)
 	sse := getSSE(urlStr, encKeyDB[alias])
 
-	content, err = client.Stat(ctx, StatOptions{preserve: fileAttr, sse: sse, timeRef: timeRef, versionID: versionID})
+	content, err = client.Stat(ctx, StatOptions{Preserve: fileAttr, SSE: sse, TimeRef: timeRef, VersionID: versionID})
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -51,22 +51,22 @@ type GetOptions struct {
 
 // PutOptions holds options for PUT operation
 type PutOptions struct {
-	metadata              map[string]string
-	sse                   encrypt.ServerSide
-	md5, disableMultipart bool
-	isPreserve            bool
-	storageClass          string
-	multipartSize         uint64
-	multipartThreads      uint
+	Metadata              map[string]string
+	SSE                   encrypt.ServerSide
+	MD5, DisableMultipart bool
+	IsPreserve            bool
+	StorageClass          string
+	MultipartSize         uint64
+	MultipartThreads      uint
 }
 
 // StatOptions holds options of the HEAD operation
 type StatOptions struct {
-	incomplete bool
-	preserve   bool
-	sse        encrypt.ServerSide
-	timeRef    time.Time
-	versionID  string
+	Incomplete bool
+	Preserve   bool
+	SSE        encrypt.ServerSide
+	TimeRef    time.Time
+	VersionID  string
 }
 
 // ListOptions holds options for listing operation
@@ -83,13 +83,13 @@ type ListOptions struct {
 
 // CopyOptions holds options for copying operation
 type CopyOptions struct {
-	versionID        string
-	size             int64
-	srcSSE, tgtSSE   encrypt.ServerSide
-	metadata         map[string]string
-	disableMultipart bool
-	isPreserve       bool
-	storageClass     string
+	VersionID        string
+	Size             int64
+	SrcSSE, TgtSSE   encrypt.ServerSide
+	Metadata         map[string]string
+	DisableMultipart bool
+	IsPreserve       bool
+	StorageClass     string
 }
 
 // Client - client interface

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -252,7 +252,7 @@ func getSourceStream(ctx context.Context, alias, urlStr, versionID string, fetch
 			}
 			st.ETag = oinfo.ETag
 		} else {
-			st, err = sourceClnt.Stat(ctx, StatOptions{preserve: preserve, sse: sse})
+			st, err = sourceClnt.Stat(ctx, StatOptions{Preserve: preserve, SSE: sse})
 			if err != nil {
 				return nil, nil, err.Trace(alias, urlStr)
 			}
@@ -315,13 +315,13 @@ func putTargetStream(ctx context.Context, alias, urlStr, mode, until, legalHold 
 	}
 
 	if mode != "" {
-		opts.metadata[AmzObjectLockMode] = mode
+		opts.Metadata[AmzObjectLockMode] = mode
 	}
 	if until != "" {
-		opts.metadata[AmzObjectLockRetainUntilDate] = until
+		opts.Metadata[AmzObjectLockRetainUntilDate] = until
 	}
 	if legalHold != "" {
-		opts.metadata[AmzObjectLockLegalHold] = legalHold
+		opts.Metadata[AmzObjectLockLegalHold] = legalHold
 	}
 
 	n, err := targetClnt.Put(ctx, reader, size, progress, opts)
@@ -338,10 +338,10 @@ func putTargetStreamWithURL(urlStr string, reader io.Reader, size int64, opts Pu
 		return 0, err.Trace(alias, urlStr)
 	}
 	contentType := guessURLContentType(urlStr)
-	if opts.metadata == nil {
-		opts.metadata = map[string]string{}
+	if opts.Metadata == nil {
+		opts.Metadata = map[string]string{}
 	}
-	opts.metadata["Content-Type"] = contentType
+	opts.Metadata["Content-Type"] = contentType
 	return putTargetStream(context.Background(), alias, urlStrFull, "", "", "", reader, size, nil, opts)
 }
 
@@ -353,11 +353,11 @@ func copySourceToTargetURL(ctx context.Context, alias, urlStr, source, sourceVer
 		return err.Trace(alias, urlStr)
 	}
 
-	opts.versionID = sourceVersionID
-	opts.size = size
-	opts.metadata[AmzObjectLockMode] = mode
-	opts.metadata[AmzObjectLockRetainUntilDate] = until
-	opts.metadata[AmzObjectLockLegalHold] = legalHold
+	opts.VersionID = sourceVersionID
+	opts.Size = size
+	opts.Metadata[AmzObjectLockMode] = mode
+	opts.Metadata[AmzObjectLockRetainUntilDate] = until
+	opts.Metadata[AmzObjectLockLegalHold] = legalHold
 
 	err = targetClnt.Copy(ctx, source, opts, progress)
 	if err != nil {
@@ -390,7 +390,7 @@ func getAllMetadata(ctx context.Context, sourceAlias, sourceURLStr string, srcSS
 		return nil, err.Trace(sourceAlias, sourceURLStr)
 	}
 
-	st, err := sourceClnt.Stat(ctx, StatOptions{preserve: true, sse: srcSSE})
+	st, err := sourceClnt.Stat(ctx, StatOptions{Preserve: true, SSE: srcSSE})
 	if err != nil {
 		return nil, err.Trace(sourceAlias, sourceURLStr)
 	}
@@ -500,12 +500,12 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 		}
 
 		opts := CopyOptions{
-			srcSSE:           srcSSE,
-			tgtSSE:           tgtSSE,
-			metadata:         filterMetadata(metadata),
-			disableMultipart: urls.DisableMultipart,
-			isPreserve:       preserve,
-			storageClass:     urls.TargetContent.StorageClass,
+			SrcSSE:           srcSSE,
+			TgtSSE:           tgtSSE,
+			Metadata:         filterMetadata(metadata),
+			DisableMultipart: urls.DisableMultipart,
+			IsPreserve:       preserve,
+			StorageClass:     urls.TargetContent.StorageClass,
 		}
 
 		err = copySourceToTargetURL(ctx, targetAlias, targetURL.String(), sourcePath, sourceVersion, mode, until,
@@ -570,14 +570,14 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 		}
 
 		putOpts := PutOptions{
-			metadata:         filterMetadata(metadata),
-			sse:              tgtSSE,
-			storageClass:     urls.TargetContent.StorageClass,
-			md5:              urls.MD5,
-			disableMultipart: urls.DisableMultipart,
-			isPreserve:       preserve,
-			multipartSize:    uint64(multipartSize),
-			multipartThreads: uint(multipartThreads),
+			Metadata:         filterMetadata(metadata),
+			SSE:              tgtSSE,
+			StorageClass:     urls.TargetContent.StorageClass,
+			MD5:              urls.MD5,
+			DisableMultipart: urls.DisableMultipart,
+			IsPreserve:       preserve,
+			MultipartSize:    uint64(multipartSize),
+			MultipartThreads: uint(multipartThreads),
 		}
 
 		if isReadAt(reader) {

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -196,7 +196,7 @@ func mainList(cliCtx *cli.Context) error {
 		fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
 		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 			var st *ClientContent
-			st, err = clnt.Stat(ctx, StatOptions{incomplete: isIncomplete})
+			st, err = clnt.Stat(ctx, StatOptions{Incomplete: isIncomplete})
 			if st != nil && err == nil && st.Type.IsDir() {
 				targetURL = targetURL + string(clnt.GetURL().Separator)
 				clnt, err = newClient(targetURL)

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -365,7 +365,7 @@ func (mj *mirrorJob) doMirrorWatch(ctx context.Context, targetPath string, tgtSS
 			// cannot create targetclient
 			return sURLs.WithError(err)
 		}
-		_, err = targetClient.Stat(ctx, StatOptions{sse: tgtSSE})
+		_, err = targetClient.Stat(ctx, StatOptions{SSE: tgtSSE})
 		if err == nil {
 			if !sURLs.SourceContent.RetentionEnabled && !sURLs.SourceContent.LegalHoldEnabled {
 				return sURLs.WithError(probe.NewError(ObjectAlreadyExists{}))

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -103,9 +103,9 @@ func pipe(targetURL string, encKeyDB map[string][]prefixSSEPair, storageClass st
 	// Ignore size, since os.Stat() would not return proper size all the time
 	// for local filesystem for example /proc files.
 	opts := PutOptions{
-		sse:          sseKey,
-		storageClass: storageClass,
-		metadata:     meta,
+		SSE:          sseKey,
+		StorageClass: storageClass,
+		Metadata:     meta,
 	}
 	_, err := putTargetStreamWithURL(targetURL, os.Stdin, -1, opts)
 	// TODO: See if this check is necessary.

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -136,7 +136,7 @@ func doShareDownloadURL(ctx context.Context, targetURL, versionID string, isRecu
 	// Channel which will receive objects whose URLs need to be shared
 	objectsCh := make(chan *ClientContent)
 
-	content, err := clnt.Stat(ctx, StatOptions{versionID: versionID})
+	content, err := clnt.Stat(ctx, StatOptions{VersionID: versionID})
 	if err != nil {
 		return err.Trace(clnt.GetURL().String())
 	}


### PR DESCRIPTION
**- What I did**
I'm coding a tiny tool importing `mc/cmd/Client`,  but the fields in PutOptions/StatOptions/CopyOptions are invisible (GetOptions/ListOptions are visible), so I propose to make them visible.

**- How I did it**
Capitalize the fileds in PutOptions/StatOptions/CopyOptions

**- How to verify it**
build and smoke test already
