### PR TITLE
fix: Avoid crash when asking for no existing transition/expiry info

### DIFF
--- a/cmd/ilm-ls.go
+++ b/cmd/ilm-ls.go
@@ -116,8 +116,10 @@ func (i ilmListMessage) String() string {
 	tbl = newPrettyTable(tableSeperator, fields...)
 	tblContents = getILMHeader(&tbl, alignedHdrLabels...)
 
-	// Reuse the fields
-	fields = nil
+	// If no data to show at all, quit here
+	if len(cellDataNoTags) == 0 && len(cellDataWithTags) == 0 {
+		return tblContents
+	}
 
 	// The data table
 	var tblRowField *[]string
@@ -126,6 +128,9 @@ func (i ilmListMessage) String() string {
 	} else {
 		tblRowField = &cellDataNoTags[0]
 	}
+
+	// Reuse the fields
+	fields = nil
 
 	for _, hdr := range *tblRowField {
 		fields = append(fields, Field{ilmThemeRow, len(hdr)})


### PR DESCRIPTION
mc ilm ls has --expiry and --transition to show for only expiry or
transition information, but if one of them doesn't exist, mc crashes.

fixes #3770 