### PR TITLE
rb: --force flag forces bucket removal after BucketNotEmpty err

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -894,6 +894,15 @@ func (f *fsClient) MakeBucket(ctx context.Context, region string, ignoreExisting
 	return nil
 }
 
+// RemoveBucket - remove a bucket
+func (f *fsClient) RemoveBucket(ctx context.Context, forceRemove bool) *probe.Error {
+	e := os.Remove(f.PathURL.Path)
+	if e != nil {
+		return probe.NewError(e)
+	}
+	return nil
+}
+
 // Set object lock configuration of bucket.
 func (f *fsClient) SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error {
 	return probe.NewError(APINotImplemented{

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -896,11 +896,13 @@ func (f *fsClient) MakeBucket(ctx context.Context, region string, ignoreExisting
 
 // RemoveBucket - remove a bucket
 func (f *fsClient) RemoveBucket(ctx context.Context, forceRemove bool) *probe.Error {
-	e := os.Remove(f.PathURL.Path)
-	if e != nil {
-		return probe.NewError(e)
+	var e error
+	if forceRemove {
+		e = os.RemoveAll(f.PathURL.Path)
+	} else {
+		e = os.Remove(f.PathURL.Path)
 	}
-	return nil
+	return probe.NewError(e)
 }
 
 // Set object lock configuration of bucket.

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1264,6 +1264,23 @@ func (c *S3Client) MakeBucket(ctx context.Context, region string, ignoreExisting
 	return nil
 }
 
+// RemoveBucket removes a bucket, forcibly if asked
+func (c *S3Client) RemoveBucket(ctx context.Context, forceRemove bool) *probe.Error {
+	bucket, object := c.url2BucketAndObject()
+	if bucket == "" {
+		return probe.NewError(BucketNameEmpty{})
+	}
+	if object != "" {
+		return errInvalidArgument()
+	}
+
+	opts := minio.BucketOptions{ForceDelete: forceRemove}
+	if e := c.api.RemoveBucketWithOptions(ctx, bucket, opts); e != nil {
+		return probe.NewError(e)
+	}
+	return nil
+}
+
 // GetAccessRules - get configured policies from the server
 func (c *S3Client) GetAccessRules(ctx context.Context) (map[string]string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -101,6 +101,8 @@ type Client interface {
 
 	// Bucket operations
 	MakeBucket(ctx context.Context, region string, ignoreExisting, withLock bool) *probe.Error
+	RemoveBucket(ctx context.Context, forceRemove bool) *probe.Error
+
 	// Object lock config
 	SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error
 	GetObjectLockConfig(ctx context.Context) (status string, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit, perr *probe.Error)

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -920,7 +920,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 				diffBucket := strings.TrimPrefix(d.SecondURL, dstClt.GetURL().String())
 				if isRemove {
 					aliasedDstBucket := path.Join(dstURL, diffBucket)
-					err := deleteBucket(ctx, aliasedDstBucket)
+					err := deleteBucket(ctx, aliasedDstBucket, false)
 					mj.status.fatalIf(err, "Failed to start mirroring.")
 				}
 				continue

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/minio/filepath v1.0.0
 	github.com/minio/madmin-go v1.0.20
 	github.com/minio/md5-simd v1.1.1 // indirect
-	github.com/minio/minio-go/v7 v7.0.11-0.20210607181445-e162fdb8e584
+	github.com/minio/minio-go/v7 v7.0.13-0.20210819151058-7877ed5b8110
 	github.com/minio/pkg v1.0.10
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/minio/md5-simd v1.1.1/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77Z
 github.com/minio/minio-go/v7 v7.0.11-0.20210302210017-6ae69c73ce78/go.mod h1:mTh2uJuAbEqdhMVl6CMIIZLUeiMiWtJR4JB8/5g2skw=
 github.com/minio/minio-go/v7 v7.0.11-0.20210607181445-e162fdb8e584 h1:GgOqN/DE44zZh3+sg5elR6diWq+Qv4dN7U2KvPVfe1I=
 github.com/minio/minio-go/v7 v7.0.11-0.20210607181445-e162fdb8e584/go.mod h1:WoyW+ySKAKjY98B9+7ZbI8z8S3jaxaisdcvj9TGlazA=
+github.com/minio/minio-go/v7 v7.0.13-0.20210819151058-7877ed5b8110 h1:IFcUDB04Qdqbbn4Vn3A4UGCpIruEvaMHhZ0ymVnC7W8=
+github.com/minio/minio-go/v7 v7.0.13-0.20210819151058-7877ed5b8110/go.mod h1:S23iSP5/gbMwtxeY5FM71R+TkAYyzEdoNEDDwpt8yWs=
 github.com/minio/pkg v1.0.3/go.mod h1:obU54TZ9QlMv0TRaDgQ/JTzf11ZSXxnSfLrm4tMtBP8=
 github.com/minio/pkg v1.0.10 h1:fohpAm/0ttQFf4BzmzH5r6A9JUIfg63AyGCPM0f9/9U=
 github.com/minio/pkg v1.0.10/go.mod h1:32x/3OmGB0EOi1N+3ggnp+B5VFkSBBB9svPMVfpnf14=
@@ -471,6 +473,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=


### PR DESCRIPTION
Some users struggle to remove a bucket when they don't use recommanded
setups, such as NFS disks.

This command will force bucket removal in server side, using
x-minio-force-delete during DELETE bucket call.