### PR TITLE
validation for namespace removal

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -210,7 +210,7 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 		url = filepath.ToSlash(filepath.Clean(url))
 		// namespace removal applies only for non FS. So filter out if passed url represents a directory
 		dir := isAliasURLDir(ctx, url, encKeyDB, time.Time{})
-		if !dir {
+		if dir {
 			_, path := url2Alias(url)
 			isNamespaceRemoval = (path == "")
 			break
@@ -231,17 +231,15 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 
 	// For all recursive or versions bulk deletion operations make sure to check for 'force' flag.
 	if (isVersions || isRecursive || isStdin) && !isForce {
-		if isNamespaceRemoval {
-			fatalIf(errDummy().Trace(),
-				"This operation results in site-wide removal of objects. If you are really sure, retry this command with ‘--dangerous’ and ‘--force’ flags.")
-		}
 		fatalIf(errDummy().Trace(),
 			"Removal requires --force flag. This operation is *IRREVERSIBLE*. Please review carefully before performing this *DANGEROUS* operation.")
 	}
-	if (isRecursive || isStdin) && isNamespaceRemoval && !isDangerous {
+
+	if isNamespaceRemoval && !(isDangerous && isForce) {
 		fatalIf(errDummy().Trace(),
 			"This operation results in site-wide removal of objects. If you are really sure, retry this command with ‘--dangerous’ and ‘--force’ flags.")
 	}
+
 }
 
 // Remove a single object or a single version in a versioned bucket


### PR DESCRIPTION
## Expected behavior
 rm-main.go a site-wide removal (e.g. `mc rm <alias>`) should require both the `--force` and `--dangerous` options.

## Actual behavior

It is possible to simply use `mc rm --force <alias>` to remove all buckets the aliased user has access to.

## Steps to reproduce the behavior

1. Run minio as a local S3 server: `./minio server ./data`
2. Setup a `mc alias` for the local S3 server: `./mc alias set local http://localhost:9000 minioadmin minioadmin`
3. Create some buckets and upload objects, e.g.
    ```bash
    for i in {0..5}; do ./mc mb "local/new$i"; ./mc cp mc "local/new$i"; done
    ```
4. Execute `./mc rm --force local`.


## System information

- Using an openSUSE-Leap-15.2 WSL2 instance on Windows.
Closes #3776 