### PR TITLE
Fix data race in mc admin subnet health

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -537,8 +537,8 @@ func fetchServerHealthInfo(ctx *cli.Context, client *madmin.AdminClient) (interf
 	// cases e.g. net perf data is empty in case of single server deployment)
 	// explicitly stop them
 	_ = admin(true) && cpu(true) && diskHw(true) && osInfo(true) &&
-		mem(true) && process(true) && config(true) && drive(true) && net(true) &&
-		syserr(true) && syssrv(true) && sysconfig(true)
+		mem(true) && syserr(true) && syssrv(true) && sysconfig(true) &&
+		process(true) && config(true) && drive(true) && net(true)
 
 	// cancel the context if obdChan has returned.
 	cancel()


### PR DESCRIPTION
The code that explicitly stops all spinners was not doing it in the same
sequence as the data returned by the server, resulting in a race
condition.

Fixed by correcting the sequence.