### PR TITLE
Bump CI Go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: on
-      CGO_ENABLED: 0
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     name: Test on Go ${{ matrix.go-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: on
+      CGO_ENABLED: 0
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]
@@ -25,22 +28,16 @@ jobs:
 
       - name: Build on ${{ matrix.os }}
         if: matrix.os == 'windows-latest'
-        env:
-          GO111MODULE: on
         run: |
           go build --ldflags="-s -w" -o %GOPATH%\bin\mc.exe
           go test -v -race --timeout 30m ./...
       - name: Build on ${{ matrix.os }}
         if: matrix.os == 'macos-latest'
-        env:
-          GO111MODULE: on
         run: |
           go build --ldflags="-s -w" -o %GOPATH%\bin\mc
           go test -v -race --timeout 30m ./...
       - name: Build on ${{ matrix.os }}
         if: matrix.os == 'ubuntu-latest'
-        env:
-          GO111MODULE: on
         run: |
           make
           make test-race

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.16.x]
-        os: [ubuntu-latest, windows-latest]
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}
         uses: actions/setup-go@v1
@@ -31,14 +31,37 @@ jobs:
           go build --ldflags="-s -w" -o %GOPATH%\bin\mc.exe
           go test -v -race --timeout 30m ./...
       - name: Build on ${{ matrix.os }}
+        if: matrix.os == 'macos-latest'
+        env:
+          GO111MODULE: on
+        run: |
+          go build --ldflags="-s -w" -o %GOPATH%\bin\mc
+          go test -v -race --timeout 30m ./...
+      - name: Build on ${{ matrix.os }}
         if: matrix.os == 'ubuntu-latest'
         env:
           GO111MODULE: on
         run: |
           make
-          diff -au <(gofmt -d *.go) <(printf "")
-          diff -au <(gofmt -s -d cmd) <(printf "")
-          diff -au <(gofmt -s -d pkg) <(printf "")
           make test-race
           make verify
           make crosscompile
+  vetchecks: # Run vet checks against one version.
+    env:
+      CGO_ENABLED: 0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: fmt
+        run: diff -au <(gofmt -s -d .) <(printf "")
+
+      - name: Test 386
+        run: GOOS=linux GOARCH=386 go test -short ./...
+

--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/client-fs_darwin.go
+++ b/cmd/client-fs_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/client-fs_linux.go
+++ b/cmd/client-fs_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/client-fs_other.go
+++ b/cmd/client-fs_other.go
@@ -1,3 +1,4 @@
+//go:build solaris || openbsd
 // +build solaris openbsd
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/client-fs_windows.go
+++ b/cmd/client-fs_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -421,6 +422,10 @@ func TestStringReplace(t *testing.T) {
 
 // Tests exit status, getExitStatus() function
 func TestGetExitStatus(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping on non-linux")
+		return
+	}
 	testCases := []struct {
 		command            string
 		expectedExitStatus int

--- a/cmd/fs-pathutils_nix.go
+++ b/cmd/fs-pathutils_nix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/fs-pathutils_windows.go
+++ b/cmd/fs-pathutils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/cmd/update_fips.go
+++ b/cmd/update_fips.go
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build fips
 // +build fips
 
 package cmd

--- a/cmd/update_nofips.go
+++ b/cmd/update_nofips.go
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build !fips
 // +build !fips
 
 package cmd

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/mc
 
-go 1.14
+go 1.16
 
 require (
 	github.com/briandowns/spinner v1.16.0

--- a/main.go
+++ b/main.go
@@ -1,5 +1,3 @@
-// +build go1.13
-
 // Copyright (c) 2015-2021 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack

--- a/pkg/disk/stat_darwin.go
+++ b/pkg/disk/stat_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/pkg/disk/stat_linux.go
+++ b/pkg/disk/stat_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/pkg/disk/stat_other.go
+++ b/pkg/disk/stat_other.go
@@ -1,3 +1,4 @@
+//go:build openbsd || solaris
 // +build openbsd solaris
 
 // Copyright (c) 2015-2021 MinIO, Inc.

--- a/pkg/disk/stat_windows.go
+++ b/pkg/disk/stat_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright (c) 2015-2021 MinIO, Inc.


### PR DESCRIPTION
* Fix changed fmt.
* Only check fmt on one Go version.
* Bump minimum go version in go.mod
* Add Darwin test.
* Test 386 on Linux.

Replaces #3807