### PR TITLE
health: perform only lightweight tests by default

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -48,7 +48,7 @@ import (
 var adminHealthFlags = []cli.Flag{
 	HealthDataTypeFlag{
 		Name:   "test",
-		Usage:  "choose health tests to run [" + options.String() + "]",
+		Usage:  "choose health tests to run [" + fullOptions.String() + "]",
 		Value:  nil,
 		EnvVar: "MC_HEALTH_TEST,MC_OBD_TEST",
 		Hidden: true,
@@ -80,6 +80,11 @@ var adminHealthFlags = []cli.Flag{
 		Name:   "dev",
 		Usage:  "Development mode",
 		Hidden: true,
+	},
+	cli.BoolFlag{
+		Name:   "full",
+		Usage:  "Include long running tests (takes longer to generate the report)",
+		Hidden: false,
 	},
 }
 
@@ -357,7 +362,12 @@ func subnetUploadReq(url string, filename string) (*http.Request, error) {
 func fetchServerHealthInfo(ctx *cli.Context, client *madmin.AdminClient) (interface{}, string, error) {
 	opts := GetHealthDataTypeSlice(ctx, "test")
 	if len(*opts) == 0 {
-		opts = &options
+		full := ctx.Bool("full")
+		if full {
+			opts = &fullOptions
+		} else {
+			opts = &liteOptions
+		}
 	}
 
 	optsMap := make(map[madmin.HealthDataType]struct{})
@@ -554,7 +564,7 @@ func (d *HealthDataTypeSlice) Set(value string) error {
 		if obdData, ok := madmin.HealthDataTypesMap[strings.Trim(v, " ")]; ok {
 			*d = append(*d, obdData)
 		} else {
-			return fmt.Errorf("valid options include %s", options.String())
+			return fmt.Errorf("valid options include %s", fullOptions.String())
 		}
 	}
 	return nil
@@ -656,4 +666,5 @@ func (f HealthDataTypeFlag) ApplyWithError(set *flag.FlagSet) error {
 	return nil
 }
 
-var options = HealthDataTypeSlice(madmin.HealthDataTypesList)
+var liteOptions = HealthDataTypeSlice(madmin.HealthDataTypesLite)
+var fullOptions = HealthDataTypeSlice(madmin.HealthDataTypesList)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.1.6
+	github.com/minio/madmin-go v1.1.7-0.20211001214410-8c928b2b7bda
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.15-0.20210921183434-174b4c070788
 	github.com/minio/pkg v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/minio/colorjson v1.0.1/go.mod h1:oPM3zQQY8Gz9NGtgvuBEjQ+gPZLKAGc7T+kj
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.0.12/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
-github.com/minio/madmin-go v1.1.6 h1:L53ALIbAilaEvuvMMT4XkJpd6mtaorkMBwCQ+zraYBA=
-github.com/minio/madmin-go v1.1.6/go.mod h1:vw+c3/u+DeVKqReEavo///Cl2OO8nt5s4ee843hJeLs=
+github.com/minio/madmin-go v1.1.7-0.20211001214410-8c928b2b7bda h1:nf1WPnmVKpfjFCOdX5yDwOi9tdqzJvh7hD2gMmOBM+A=
+github.com/minio/madmin-go v1.1.7-0.20211001214410-8c928b2b7bda/go.mod h1:vw+c3/u+DeVKqReEavo///Cl2OO8nt5s4ee843hJeLs=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=


### PR DESCRIPTION
Perform only lightweight tests by default, and include the long running
tests only if specified through a `--full` flag in the `admin subnet
health` command.