### PR TITLE
inspect: Save data unencrypted by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/prometheus/common v0.31.1 // indirect
 	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/xid v1.3.0
+	github.com/secure-io/sio-go v0.3.1
 	github.com/shirou/gopsutil/v3 v3.21.8
 	github.com/tidwall/gjson v1.9.1
 	github.com/tinylib/msgp v1.1.6 // indirect


### PR DESCRIPTION
By default decrypt the data. Add `--encrypt` to keep encryption.