### PR TITLE
Uppercase tier name in `admin tier add` cmd

### DIFF
--- a/cmd/admin-tier-add.go
+++ b/cmd/admin-tier-add.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
@@ -341,7 +342,7 @@ func mainAdminTierAdd(ctx *cli.Context) error {
 	client, cerr := newAdminClient(aliasedURL)
 	fatalIf(cerr, "Unable to initialize admin connection.")
 
-	tCfg := fetchTierConfig(ctx, tierName, tierType)
+	tCfg := fetchTierConfig(ctx, strings.ToUpper(tierName), tierType)
 	if err = client.AddTier(globalContext, tCfg); err != nil {
 		fatalIf(probe.NewError(err).Trace(args...), "Unable to configure remote tier target")
 	}


### PR DESCRIPTION
Tier name is already enforced to be upper case on server side, it is more intuitive to upper case the tier name entered by user rather than throw an error.