### PR TITLE
Add ipv4 flag

### DIFF
--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"hash/fnv"
-	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -93,10 +92,8 @@ func NewAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 
 			var transport http.RoundTripper = &http.Transport{
 				Proxy: ieproxy.GetProxyFunc(),
-				DialContext: (&net.Dialer{
-					Timeout:   10 * time.Second,
-					KeepAlive: 15 * time.Second,
-				}).DialContext,
+				// Peza: Use dial context that uses ipv4 if set.
+				DialContext: newDialContext(10, 15, false),
 				MaxIdleConnsPerHost:   256,
 				IdleConnTimeout:       90 * time.Second,
 				TLSHandshakeTimeout:   10 * time.Second,

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -92,7 +92,7 @@ func NewAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 
 			var transport http.RoundTripper = &http.Transport{
 				Proxy: ieproxy.GetProxyFunc(),
-				// Peza: Use dial context that uses ipv4 if set.
+				// Use dial context that uses ipv4 if set.
 				DialContext: newDialContext(10, 15, false),
 				MaxIdleConnsPerHost:   256,
 				IdleConnTimeout:       90 * time.Second,

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -145,10 +144,8 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			} else {
 				tr := &http.Transport{
 					Proxy: http.ProxyFromEnvironment,
-					DialContext: (&net.Dialer{
-						Timeout:   10 * time.Second,
-						KeepAlive: 15 * time.Second,
-					}).DialContext,
+					// Peza: Use dial context that uses ipv4 if set.
+					DialContext:           newDialContext(10, 15, false),
 					MaxIdleConnsPerHost:   256,
 					IdleConnTimeout:       90 * time.Second,
 					TLSHandshakeTimeout:   10 * time.Second,

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -144,7 +144,7 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			} else {
 				tr := &http.Transport{
 					Proxy: http.ProxyFromEnvironment,
-					// Peza: Use dial context that uses ipv4 if set.
+					// Use dial context that uses ipv4 if set.
 					DialContext:           newDialContext(10, 15, false),
 					MaxIdleConnsPerHost:   256,
 					IdleConnTimeout:       90 * time.Second,

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -216,6 +216,7 @@ type Config struct {
 	Insecure     bool
 	Lookup       minio.BucketLookupType
 	Transport    *http.Transport
+	IPv4     bool
 }
 
 // SelectObjectOpts - opts entered for select API

--- a/cmd/dial-context.go
+++ b/cmd/dial-context.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+type dialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// newDialContext creates a dial context that switches to ipv4 if the ipv4 flag is set.
+//
+// The parameters are set on the dialer.
+func newDialContext(timeout, keepAlive time.Duration, dualStack bool) dialContextFunc {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		d := &net.Dialer{
+			Timeout:   timeout * time.Second,
+			KeepAlive: keepAlive * time.Second,
+			DualStack: dualStack,
+		}
+		
+		// Use v4
+		if globalIPv4Only {
+			switch network {
+			case "tcp", "tcp6":
+				network = "tcp4"
+			case "udp", "udp6":
+				network = "udp4"
+			case "ip", "ip6":
+				network = "ip4"
+			}
+		}
+		return d.DialContext(ctx, network, address)
+	}
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -48,6 +48,10 @@ var globalFlags = []cli.Flag{
 		Name:  "insecure",
 		Usage: "disable SSL certificate verification",
 	},
+	cli.BoolFlag{
+		Name:  "ipv4",
+		Usage: "force ipv4",
+	},
 }
 
 // Flags common across all I/O commands such as cp, mirror, stat, pipe etc.

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -65,6 +65,8 @@ var (
 	globalDevMode        = false  // dev flag set via command line
 	globalSubnetProxyURL *url.URL // Proxy to be used for communication with subnet
 
+	globalIPv4Only = false
+
 	globalContext, globalCancel = context.WithCancel(context.Background())
 )
 
@@ -77,7 +79,7 @@ var (
 )
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
-func setGlobals(quiet, debug, json, noColor, insecure, devMode bool, subnetProxyURL *url.URL) {
+func setGlobals(quiet, debug, json, noColor, insecure, devMode bool, subnetProxyURL *url.URL, ipv4Only bool) {
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
 	globalJSONLine = !isTerminal() && json
@@ -86,6 +88,8 @@ func setGlobals(quiet, debug, json, noColor, insecure, devMode bool, subnetProxy
 	globalInsecure = globalInsecure || insecure
 	globalDevMode = globalDevMode || devMode
 	globalSubnetProxyURL = subnetProxyURL
+
+	globalIPv4Only = ipv4Only
 
 	// Disable colorified messages if requested.
 	if globalNoColor || globalQuiet {
@@ -102,6 +106,8 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	insecure := ctx.IsSet("insecure") || ctx.GlobalIsSet("insecure")
 	devMode := ctx.IsSet("dev") || ctx.GlobalIsSet("dev")
 
+	ipv4Only := ctx.IsSet("ipv4") || ctx.GlobalIsSet("ipv4")
+
 	subnetProxy := ctx.String("subnet-proxy")
 
 	var proxyURL *url.URL
@@ -113,6 +119,6 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 		}
 	}
 
-	setGlobals(quiet, debug, json, noColor, insecure, devMode, proxyURL)
+	setGlobals(quiet, debug, json, noColor, insecure, devMode, proxyURL, ipv4Only)
 	return nil
 }

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -384,7 +384,7 @@ var (
 func getUpdateTransport(timeout time.Duration) http.RoundTripper {
 	var updateTransport http.RoundTripper = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		// Peza: Use dial context that uses ipv4 if set.
+		// Use dial context that uses ipv4 if set.
 		DialContext: newDialContext(10, 15, true),
 		IdleConnTimeout:       timeout,
 		TLSHandshakeTimeout:   timeout,

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -385,11 +384,8 @@ var (
 func getUpdateTransport(timeout time.Duration) http.RoundTripper {
 	var updateTransport http.RoundTripper = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   timeout,
-			KeepAlive: timeout,
-			DualStack: true,
-		}).DialContext,
+		// Peza: Use dial context that uses ipv4 if set.
+		DialContext: newDialContext(10, 15, true),
 		IdleConnTimeout:       timeout,
 		TLSHandshakeTimeout:   timeout,
 		ExpectContinueTimeout: timeout,


### PR DESCRIPTION
I added this feature to facilitate testing on dual stack networks
where ipv6 did not work due to network configuration issues.

Feel free to reject if not useful for production.