### PR TITLE
Show live updates for speedtest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.1.10
+	github.com/minio/madmin-go v1.1.11-0.20211102182201-e51fd3d6b104
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.15-0.20211004160302-3b57c1e369ca
 	github.com/minio/pkg v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,10 @@ github.com/minio/colorjson v1.0.1/go.mod h1:oPM3zQQY8Gz9NGtgvuBEjQ+gPZLKAGc7T+kj
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.0.12/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
-github.com/minio/madmin-go v1.1.10 h1:pfMgXkzdwADnNfVdNMJbwok2fjb2sJ7Q76kDt89RGzE=
-github.com/minio/madmin-go v1.1.10/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
+github.com/minio/madmin-go v1.1.7-0.20211001214410-8c928b2b7bda h1:nf1WPnmVKpfjFCOdX5yDwOi9tdqzJvh7hD2gMmOBM+A=
+github.com/minio/madmin-go v1.1.7-0.20211001214410-8c928b2b7bda/go.mod h1:vw+c3/u+DeVKqReEavo///Cl2OO8nt5s4ee843hJeLs=
+github.com/minio/madmin-go v1.1.11-0.20211102182201-e51fd3d6b104 h1:/N0JW/1+vbxdDgCI8+tac7GXKkis6rh8kVsLNejN6Ug=
+github.com/minio/madmin-go v1.1.11-0.20211102182201-e51fd3d6b104/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=


### PR DESCRIPTION
Shows live updates like this:

```
krishna@escape:~$ mc admin speedtest data1 -v
⠴ Performing speedtest (With 64 MiB object size, 32 concurrency) PUT: 14 GB/s GET: 34 GB/s
⠴ Performing speedtest (With 64 MiB object size, 48 concurrency) PUT: 15 GB/s GET: 36 GB/s
⠼ Performing speedtest (With 64 MiB object size, 72 concurrency) PUT: 15 GB/s GET: 36 GB/s

MinIO DEVELOPMENT.GOGET, 4 servers, 40 drives

PUT: 15 GB/s, 227 objs/s
   * http://data1:9000: 3.6 GB/s 54 objs/s
   * http://data2:9000: 4.0 GB/s 59 objs/s
   * http://data3:9000: 3.9 GB/s 57 objs/s
   * http://data4:9000: 3.8 GB/s 56 objs/s

GET: 36 GB/s, 542 objs/s
   * http://data1:9000: 7.1 GB/s 105 objs/s
   * http://data2:9000: 9.5 GB/s 141 objs/s
   * http://data3:9000: 9.2 GB/s 136 objs/s
   * http://data4:9000: 11 GB/s 158 objs/s

krishna@escape:~$ 

```