### PR TITLE
admin-trace: Add missing asterisk to --path example in usage

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -104,7 +104,7 @@ EXAMPLES:
     {{.Prompt}} {{.HelpName}} -v --status-code 503 myminio
 
   4. Show console trace for a specific path
-    {{.Prompt}} {{.HelpName}} --path my-bucket/my-prefix/ myminio
+    {{.Prompt}} {{.HelpName}} --path my-bucket/my-prefix/* myminio
 
   5. Show console trace for requests with '404' and '503' status code
     {{.Prompt}} {{.HelpName}} --status-code 404 --status-code 503 myminio


### PR DESCRIPTION
Limiting tracing to a specific path requires an asterisk at the end. I
don't know if this is a regression or the example was always wrong. I
only ever figured this out by trial and error.

This fixes #3856.