### PR TITLE
Fix `subnet health` crash on passing invalid flag

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -593,7 +593,7 @@ type HealthDataTypeFlag struct {
 
 // String - returns the string to be shown in the help message
 func (f HealthDataTypeFlag) String() string {
-	return fmt.Sprintf("--%s                       %s", f.Name, f.Usage)
+	return cli.FlagStringer(f)
 }
 
 // GetName - returns the name of the flag


### PR DESCRIPTION
The custom `String()` function written for the `HealthDataTypeFlag` was
resulting in a crash as it did not contain `\t` character on which the
usage gets split when printing the error message.

Fixed by reusing the `FlagStringer` from cli package, which is used by
`StringFlag.String()` as well.