### PR TITLE
Fix usage validation in `mc admin service restart`

### DIFF
--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -95,7 +95,7 @@ func (s serviceRestartMessage) JSON() string {
 
 // checkAdminServiceRestartSyntax - validate all the passed arguments
 func checkAdminServiceRestartSyntax(ctx *cli.Context) {
-	if len(ctx.Args()) == 0 || len(ctx.Args()) > 2 {
+	if len(ctx.Args()) != 1 {
 		cli.ShowCommandHelpAndExit(ctx, "restart", 1) // last argument is exit code
 	}
 }


### PR DESCRIPTION
The command needs exactly one argument, but was allowing two and
ignoring the second if passed. Fixed the validation.