### PR TITLE
cleanup 'admin health' command

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -457,8 +457,13 @@ func httpClient(timeout time.Duration) *http.Client {
 		Timeout: timeout,
 		Transport: &http.Transport{
 			Proxy: ieproxy.GetProxyFunc(),
-			// need to close connection after usage.
-			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				RootCAs: globalRootCAs,
+				// Can't use SSLv3 because of POODLE and BEAST
+				// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+				// Can't use TLSv1.1 because of RC4 cipher usage
+				MinVersion: tls.VersionTLS12,
+			},
 		},
 	}
 }


### PR DESCRIPTION
- do not reach out to subnet if no license is provided
  this is a breaking change for customers where subnet.min.io
  is not reachable such as no "internet" access.

- use a proper httpClient when reaching out to subnet
  with a 10sec timeout, and also support custom proxies
  with self-signed certs.

- also fix some error messages and cleanup help with correct
  wording and grammar.