### PR TITLE
Support multiple ordered filters to exclude and include files in 'mc mirror'

### DIFF
--- a/cmd/name-filter-flag.go
+++ b/cmd/name-filter-flag.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+// NB. Since go 1.16 go-flags have "Func" and it might help to reduce code but go 1.12 specified in the package "cli"
+import "github.com/minio/cli"
+
+// nameFiltersFlagValue is a type for []nameFilter to satisfy flag.Value and flag.Getter
+// We have multiple flag values refers to this slice,
+// so we use an indirect structure to change it in the all places simultaneously
+type nameFiltersFlagValue struct {
+	filters []nameFilter
+}
+
+// Set appends the type pattern value to the list
+func (f *nameFiltersFlagValue) Set(filter nameFilter) error {
+	f.filters = append(f.filters, filter)
+	return nil
+}
+
+// String designed return a readable representation of this value (for usage defaults) but return empty string
+// because it is a compound flag
+func (f *nameFiltersFlagValue) String() string {
+	// Not implemented because it is a compound flag
+	return ""
+}
+
+// Get returns the slice of filter set by this flag
+func (f *nameFiltersFlagValue) Get() []nameFilter {
+	return f.filters
+}
+
+// nameFilterTypeMapper is a type to bind multiple flags with single slice and to map flags to corresponding types
+// We should use separate entities for mappers and values but Set(string) is not compatible for this right now
+type nameFilterTypeMapper struct {
+	// value is the reference to a shared flag value
+	value *nameFiltersFlagValue
+
+	// mapFunc is the function that maps string representation of a command line argument to an instance of nameFilter.
+	// This works as a factory function
+	mapFunc func(pattern string) (nameFilter, error)
+}
+
+func (f nameFilterTypeMapper) Set(value string) error {
+	// Set do not provide information about the flag, so we cannot store multiple flags with different logic
+	// in one slice. For this reason, we map the string to a typed value, so we can distinguish between them later
+	filter, err := f.mapFunc(value)
+
+	if err != nil {
+		return err
+	}
+
+	return f.value.Set(filter)
+}
+
+func (f nameFilterTypeMapper) String() string {
+	return f.value.String()
+}
+
+func (f nameFilterTypeMapper) Get() []nameFilter {
+	return f.value.Get()
+}
+
+func newExcludeWildcardFilterFlag(name string, usage string, flagValue *nameFiltersFlagValue) *cli.GenericFlag {
+	// We do not have the special function in the package 'cli' to create a typed flag, so we use a generic type
+	return &cli.GenericFlag{
+		Name:  name,
+		Usage: usage,
+		Value: nameFilterTypeMapper{
+			flagValue,
+			func(pattern string) (nameFilter, error) {
+				return excludeWildcardFilter{pattern}, nil
+			}},
+	}
+}
+
+func newIncludeWildcardFilterFlag(name string, usage string, flagValue *nameFiltersFlagValue) *cli.GenericFlag {
+	// We do not have the special function in the package 'cli' to create a typed flag, so we use a generic type
+	return &cli.GenericFlag{
+		Name:  name,
+		Usage: usage,
+		Value: nameFilterTypeMapper{
+			flagValue,
+			func(pattern string) (nameFilter, error) {
+				return includeWildcardFilter{pattern}, nil
+			}},
+	}
+}

--- a/cmd/name-filter-flag_test.go
+++ b/cmd/name-filter-flag_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"github.com/minio/cli"
+	. "gopkg.in/check.v1"
+)
+
+func (s *TestSuite) TestNameFilterNoFlagSet(c *C) {
+	flagValue := &nameFiltersFlagValue{}
+
+	c.Assert(flagValue.Get(), IsNil)
+}
+
+func (s *TestSuite) TestNameFilterTypeMapper(c *C) {
+	flagValue := &nameFiltersFlagValue{}
+	excludeFlag := newExcludeWildcardFilterFlag("exclude", "", flagValue)
+	includeFlag := newIncludeWildcardFilterFlag("include", "", flagValue)
+
+	optionsData := []struct {
+		pattern string
+		value   cli.Generic
+		filter  nameFilter
+	}{
+		{"pat1", excludeFlag.Value, excludeWildcardFilter{"pat1"}},
+		{"pat2", includeFlag.Value, includeWildcardFilter{"pat2"}},
+		{"pat3", excludeFlag.Value, excludeWildcardFilter{"pat3"}},
+	}
+
+	targetFilters := make([]nameFilter, len(optionsData))
+	for i, f := range optionsData {
+		err := f.value.Set(f.pattern)
+		c.Assert(err, IsNil)
+		targetFilters[i] = f.filter
+	}
+
+	nameFilters := flagValue.Get()
+	c.Assert(nameFilters, DeepEquals, targetFilters)
+}

--- a/cmd/name-filter.go
+++ b/cmd/name-filter.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/minio/pkg/wildcard"
+)
+
+// nameFilter is a general interface for implementing a simple filter,
+// such as filters for excluding or including names in a processing list.
+// For the reason, only name is available we can implement a few useful filters:
+// - the name is equal to a predefined value
+// - the name matches the wildcard pattern
+// - the name is in a predefined list
+// - the name matches a regular expression
+// - the name matches using a custom algorithm
+// and so on
+type nameFilter interface {
+	// name is a string, such as a file name
+	// included specifies the current state of file processing and helps optimize the matching
+	filter(name string, included bool) (includeAfter bool)
+}
+
+type nameFilterSlice []nameFilter
+
+// filter helps to process the name throughout the list
+func (f nameFilterSlice) filter(name string) (includeAfter bool) {
+	// We use the positive sense to avoid massive double negation operations
+	includeAfter = true
+	for _, filter := range f {
+		includeAfter = filter.filter(name, includeAfter)
+	}
+	return
+}
+
+// includeWildcardFilter implements a filter that includes a name if it matches a wildcard pattern
+type includeWildcardFilter struct {
+	pattern string
+}
+
+func (f includeWildcardFilter) filter(name string, included bool) (includeAfter bool) {
+	// 1. Do not perform matching is the name is already included
+	// 2. Include the name if it matches the pattern
+	return included || wildcard.Match(f.pattern, name)
+}
+
+// String returns a string representation for debugging purposes
+func (f includeWildcardFilter) String() string {
+	return fmt.Sprintf("{include \"%s\"}", f.pattern)
+}
+
+// excludeWildcardFilter implements a filter that excludes a name if it matches a wildcard pattern
+type excludeWildcardFilter struct {
+	pattern string
+}
+
+func (f excludeWildcardFilter) filter(name string, included bool) (includeAfter bool) {
+	// 1. Do not perform matching when the name is already excluded
+	// 2. Exclude the name when it not matches the pattern
+	return included && !wildcard.Match(f.pattern, name)
+}
+
+// String returns a string representation for debugging purposes
+func (f excludeWildcardFilter) String() string {
+	return fmt.Sprintf("{exclude \"%s\"}", f.pattern)
+}


### PR DESCRIPTION
This PR have the following points:
- `mc mirror` command now supports `--include=<wildcard>` flag that work similar to `--exclude`
- `--include` and `--exclude` work in combination and their order is important. For example:
`mc mirror --exclude="*" --include="*.json"` will mirror only json files
`mc mirror --exclude="*" --include="*.log" --exclude="ignore.log"` will mirror only log files except `ignore.log`
You can see other examples in the tests
- an abstract layer has been introduced for the future implementation of some other filters, for example `--exclude-regexp=` if needed. See cmd/name-filter.go

Please read the code. It contains a lot of details in the comments.
