### PR TITLE
Use latest version of madmin-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.1.14
+	github.com/minio/madmin-go v1.1.15
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df
 	github.com/minio/pkg v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1
+	github.com/minio/madmin-go v1.1.14
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df
 	github.com/minio/pkg v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.1.13
+	github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df
 	github.com/minio/pkg v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -275,10 +275,6 @@ github.com/minio/colorjson v1.0.1/go.mod h1:oPM3zQQY8Gz9NGtgvuBEjQ+gPZLKAGc7T+kj
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.0.12/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
-github.com/minio/madmin-go v1.1.13 h1:uIY5q88TGOx10iDsLvPT4ylTe8Nw8vctn9hRvk9z91A=
-github.com/minio/madmin-go v1.1.13/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
-github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1 h1:97beaW7haUHGBKzKWv0oUQa/aLo/xyZzFTCbi+AseBY=
-github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/madmin-go v1.1.14 h1:37tVKZQ6tR6PrTdfaggd8khrGNA/qKHJ+obeyK3H9Ro=
 github.com/minio/madmin-go v1.1.14/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/minio/colorjson v1.0.1/go.mod h1:oPM3zQQY8Gz9NGtgvuBEjQ+gPZLKAGc7T+kj
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.0.12/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
-github.com/minio/madmin-go v1.1.14 h1:37tVKZQ6tR6PrTdfaggd8khrGNA/qKHJ+obeyK3H9Ro=
-github.com/minio/madmin-go v1.1.14/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
+github.com/minio/madmin-go v1.1.15 h1:iRfHD3xTMGjJ6EZvLQbcxog2nfXUXZ1yp283xGvuvbM=
+github.com/minio/madmin-go v1.1.15/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/minio/madmin-go v1.1.13 h1:uIY5q88TGOx10iDsLvPT4ylTe8Nw8vctn9hRvk9z91
 github.com/minio/madmin-go v1.1.13/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1 h1:97beaW7haUHGBKzKWv0oUQa/aLo/xyZzFTCbi+AseBY=
 github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
+github.com/minio/madmin-go v1.1.14 h1:37tVKZQ6tR6PrTdfaggd8khrGNA/qKHJ+obeyK3H9Ro=
+github.com/minio/madmin-go v1.1.14/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEX
 github.com/minio/madmin-go v1.0.12/go.mod h1:BK+z4XRx7Y1v8SFWXsuLNqQqnq5BO/axJ8IDJfgyvfs=
 github.com/minio/madmin-go v1.1.13 h1:uIY5q88TGOx10iDsLvPT4ylTe8Nw8vctn9hRvk9z91A=
 github.com/minio/madmin-go v1.1.13/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
+github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1 h1:97beaW7haUHGBKzKWv0oUQa/aLo/xyZzFTCbi+AseBY=
+github.com/minio/madmin-go v1.1.14-0.20211112204931-d450d5fdd7e1/go.mod h1:Iu0OnrMWNBYx1lqJTW+BFjBMx0Hi0wjw8VmqhiOs2Jo=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=


### PR DESCRIPTION
It changes the field `TLS` to pointer, so will be empty in the health report
when TLS info is not available, and will be nil after de-serialization, thus
allowing `health-analyzer` to reliably skip TLS related checks.