### PR TITLE
Fix health upload to subnet failing

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -347,10 +347,10 @@ func subnetUploadReq(url string, filename string) (*http.Request, error) {
 	if e != nil {
 		return nil, e
 	}
-	defer writer.Close()
 	if _, e = io.Copy(part, file); e != nil {
 		return nil, e
 	}
+	writer.Close()
 
 	r, e := http.NewRequest(http.MethodPost, url, &body)
 	if e != nil {


### PR DESCRIPTION
The writer needs to be closed before creating the request. Otherwise the
call to subnet api fails with error like:

HTTP/1.x transport connection broken: http: ContentLength=6235 with Body length 6303.