### PR TITLE
[WIP] Add --check-etag in cat command

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -809,6 +809,7 @@ func (c *S3Client) Get(ctx context.Context, opts GetOptions) (io.ReadCloser, *pr
 		minio.GetObjectOptions{
 			ServerSideEncryption: opts.SSE,
 			VersionID:            opts.VersionID,
+			PartNumber:           opts.PartNumber,
 		})
 	if e != nil {
 		errResponse := minio.ToErrorResponse(e)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -45,8 +45,9 @@ const (
 
 // GetOptions holds options of the GET operation
 type GetOptions struct {
-	SSE       encrypt.ServerSide
-	VersionID string
+	SSE        encrypt.ServerSide
+	VersionID  string
+	PartNumber int
 }
 
 // PutOptions holds options for PUT operation

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -447,6 +447,7 @@ var appCmds = []cli.Command{
 	tagCmd,
 	replicateCmd,
 	adminCmd,
+	verifyCmd,
 	configCmd,
 	updateCmd,
 }

--- a/cmd/verify-main.go
+++ b/cmd/verify-main.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2015-2021 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/console"
+)
+
+// verify specific flags.
+var (
+	verifyFlags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "versions",
+			Usage: "list all versions",
+		},
+		cli.BoolFlag{
+			Name:  "recursive, r",
+			Usage: "list recursively",
+		},
+	}
+)
+
+// Verify files and versions
+var verifyCmd = cli.Command{
+	Name:         "verify",
+	Usage:        "Check the etag of objects",
+	Action:       mainVerify,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        append(verifyFlags, globalFlags...),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS] TARGET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Verify the ETag of all objects in 'myminio'
+     {{.Prompt}} {{.HelpName}} myminio
+`,
+}
+
+// checkVerifySyntax - validate all the passed arguments
+func checkVerifySyntax(ctx context.Context, cliCtx *cli.Context) (string, bool, bool) {
+	args := cliCtx.Args()
+	if !cliCtx.Args().Present() {
+		args = []string{"."}
+	}
+
+	if len(args) != 1 {
+		fatalIf(errInvalidArgument().Trace(args...), "Unable to process multiple arguments.")
+	}
+
+	arg := args[0]
+
+	if strings.TrimSpace(arg) == "" {
+		fatalIf(errInvalidArgument().Trace(args...), "Unable to validate empty argument.")
+	}
+
+	isRecursive := cliCtx.Bool("recursive")
+	withOlderVersions := cliCtx.Bool("versions")
+
+	return arg, isRecursive, withOlderVersions
+}
+
+// getMD5Sum returns MD5 sum of given data.
+func getMD5Sum(data []byte) []byte {
+	hash := md5.New()
+	hash.Write(data)
+	return hash.Sum(nil)
+}
+
+// getMD5Hash returns MD5 hash in hex encoding of given data.
+func getMD5Hash(data []byte) string {
+	return hex.EncodeToString(getMD5Sum(data))
+}
+
+func downloadAndCheckETag(ctx context.Context, alias, url, versionID string) (bool, *probe.Error) {
+	clnt, err := newClientFromAlias(alias, url)
+	if err != nil {
+		return false, err
+	}
+
+	st, err := clnt.Stat(ctx, StatOptions{versionID: versionID})
+	if err != nil {
+		return false, err
+	}
+
+	parts := 1
+	s := strings.Split(st.ETag, "-")
+	if len(s) > 1 {
+		if p, err := strconv.Atoi(s[1]); err == nil {
+			parts = p
+		} else {
+			return false, probe.NewError(errors.New("unrecognized ETag format"))
+		}
+	}
+
+	var partsMD5Sum [][]byte
+
+	for p := 1; p <= parts; p++ {
+		rd, err := clnt.Get(context.Background(), GetOptions{VersionID: versionID, PartNumber: p})
+		if err != nil {
+			return false, err
+		}
+		h := md5.New()
+		if _, err := io.Copy(h, rd); err != nil {
+			return false, probe.NewError(err)
+		}
+		partsMD5Sum = append(partsMD5Sum, h.Sum(nil))
+	}
+
+	corrupted := false
+
+	switch len(partsMD5Sum) {
+	case 1:
+		md5sum := fmt.Sprintf("%x", partsMD5Sum[0])
+		if md5sum != st.ETag {
+			corrupted = true
+		}
+	default:
+		var totalMD5SumBytes []byte
+		for _, sum := range partsMD5Sum {
+			totalMD5SumBytes = append(totalMD5SumBytes, sum...)
+		}
+		s3MD5 := fmt.Sprintf("%s-%d", getMD5Hash(totalMD5SumBytes), len(partsMD5Sum))
+		if s3MD5 != st.ETag {
+			corrupted = true
+		}
+	}
+
+	return corrupted, nil
+}
+
+// mainVerify - is a handler for mc verify command
+func mainVerify(cliCtx *cli.Context) error {
+	ctx, cancelVerify := context.WithCancel(globalContext)
+	defer cancelVerify()
+
+	// Additional command specific theme customization.
+	console.SetColor("ETagMismatch", color.New(color.Bold))
+
+	// check 'verify' cliCtx arguments.
+	targetURL, isRecursive, olderVersions := checkVerifySyntax(ctx, cliCtx)
+
+	clnt, err := newClient(targetURL)
+	fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
+
+	alias, _, _, _ := expandAlias(targetURL)
+
+	if clnt.GetURL().Type != objectStorage {
+		fatalIf(errInvalidArgument().Trace(targetURL), "The path `"+targetURL+"` does not support verifying objects hashes.")
+	}
+
+	// Capture last error
+	var cErr error
+
+	for content := range clnt.List(ctx, ListOptions{
+		Recursive:         isRecursive,
+		WithOlderVersions: olderVersions,
+		ShowDir:           DirNone,
+	}) {
+		if content.Err != nil {
+			errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to verify object/folder.")
+			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
+			continue
+		}
+
+		if content.StorageClass == s3StorageClassGlacier {
+			continue
+		}
+
+		corrupted, err := downloadAndCheckETag(ctx, alias, content.URL.String(), content.VersionID)
+		fatalIf(err, "Unable to check")
+
+		if corrupted {
+			errorIf(errDummy(), "Corrupted object/version detected", content.URL.String())
+		} else {
+			fmt.Println(content.URL.String(), "is fine")
+		}
+	}
+
+	return cErr
+}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/minio/filepath v1.0.0
 	github.com/minio/madmin-go v1.1.15
 	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df
+	github.com/minio/minio-go/v7 v7.0.17
 	github.com/minio/pkg v1.1.3
 	github.com/minio/selfupdate v0.3.1
 	github.com/minio/sha256-simd v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEp
 github.com/minio/minio-go/v7 v7.0.11-0.20210302210017-6ae69c73ce78/go.mod h1:mTh2uJuAbEqdhMVl6CMIIZLUeiMiWtJR4JB8/5g2skw=
 github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df h1:7BfpVODGh5reCjIx2lUqE7CxRMjo58XJw7ZjKKNW/vc=
 github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df/go.mod h1:pUV0Pc+hPd1nccgmzQF/EXh48l/Z/yps6QPF1aaie4g=
+github.com/minio/minio-go/v7 v7.0.17 h1:5SiS3pqiQDbNhmXMxtqn2HzAInbN5cbHT7ip9F0F07E=
+github.com/minio/minio-go/v7 v7.0.17/go.mod h1:SyQ1IFeJuaa+eV5yEDxW7hYE1s5VVq5sgImDe27R+zg=
 github.com/minio/pkg v1.0.3/go.mod h1:obU54TZ9QlMv0TRaDgQ/JTzf11ZSXxnSfLrm4tMtBP8=
 github.com/minio/pkg v1.1.3 h1:J4vGnlNSxc/o9gDOQMZ3k0L3koA7ZgBQ7GRMrUpt/OY=
 github.com/minio/pkg v1.1.3/go.mod h1:32x/3OmGB0EOi1N+3ggnp+B5VFkSBBB9svPMVfpnf14=


### PR DESCRIPTION
Waiting for the command approval.

This doesn't work with server encrypted objects since ETag is not close to the md5sum here.