### PR TITLE
tags: Show how to assign two tags to an object

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -88,7 +88,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "tags",
-			Usage: "apply tags to the uploaded objects",
+			Usage: "apply one or more tags to the uploaded objects",
 		},
 		cli.StringFlag{
 			Name:  rmFlag,
@@ -193,7 +193,7 @@ EXAMPLES:
       {{.Prompt}} {{.HelpName}} --rewind 10d -r play/mybucket/ /tmp/dest/
 
   20. Set tags to the uploaded objects
-      {{.Prompt}} {{.HelpName}} -r --tags "category=prod" ./data/ play/another-bucket/
+      {{.Prompt}} {{.HelpName}} -r --tags "category=prod&type=backup" ./data/ play/another-bucket/
 
 `,
 }

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -41,7 +41,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:  "tags",
-			Usage: "apply tags to the uploaded objects",
+			Usage: "apply one or more tags to the uploaded objects",
 		},
 	}
 )
@@ -87,7 +87,7 @@ EXAMPLES:
       {{.Prompt}} cat music.mp3 | {{.HelpName}} --attr "Cache-Control=max-age=90000,min-fresh=9000;Artist=Unknown" play/mybucket/music.mp3
 
   7. Set tags to the uploaded objects
-      {{.Prompt}} tar cvf - . | {{.HelpName}} --tags "category=backup" play/mybucket/backup.tar
+      {{.Prompt}} tar cvf - . | {{.HelpName}} --tags "category=prod&type=backup" play/mybucket/backup.tar
 `,
 }
 


### PR DESCRIPTION
mc cp --tags is able to assign more than one tag to an object, enhance
the example to show that.