### PR TITLE
Rewind mode list directory bug fix

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1699,11 +1699,9 @@ func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 // it falls back to the regular listing if not.
 func (c *S3Client) versionedList(ctx context.Context, contentCh chan *ClientContent, opts ListOptions) {
 	b, o := c.url2BucketAndObject()
-
 	if opts.IsDir {
 		o += "/"
 	}
-	
 	switch {
 	case b == "" && o == "":
 		buckets, err := c.api.ListBuckets(ctx)

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1699,6 +1699,11 @@ func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientCon
 // it falls back to the regular listing if not.
 func (c *S3Client) versionedList(ctx context.Context, contentCh chan *ClientContent, opts ListOptions) {
 	b, o := c.url2BucketAndObject()
+
+	if opts.IsDir {
+		o += "/"
+	}
+	
 	switch {
 	case b == "" && o == "":
 		buckets, err := c.api.ListBuckets(ctx)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -76,6 +76,7 @@ type ListOptions struct {
 	WithMetadata      bool
 	WithOlderVersions bool
 	WithDeleteMarkers bool
+	IsDir             bool
 	TimeRef           time.Time
 	ShowDir           DirOpt
 	Count             int


### PR DESCRIPTION
Adds an extra parameter, IsDir to ListObjects, because folders would never end with '/' in rewind mode, causing them to be misinterpreted as files.