### PR TITLE
mirror: Sort bucket names with slash for site wide scenarios

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -33,6 +33,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1708,7 +1709,9 @@ func (c *S3Client) versionedList(ctx context.Context, contentCh chan *ClientCont
 			}
 			return
 		}
-
+		if opts.Recursive {
+			sortBucketsNameWithSlash(buckets)
+		}
 		for _, bucket := range buckets {
 			if opts.ShowDir != DirLast {
 				contentCh <- c.bucketInfo2ClientContent(bucket)
@@ -1855,6 +1858,7 @@ func (c *S3Client) listIncompleteRecursiveInRoutine(ctx context.Context, content
 			}
 			return
 		}
+		sortBucketsNameWithSlash(buckets)
 		isRecursive := true
 		for _, bucket := range buckets {
 			if opts.ShowDir != DirLast {
@@ -2049,6 +2053,15 @@ const (
 	s3StorageClassGlacier = "GLACIER"
 )
 
+// Sorting buckets name with an additional '/' to make sure that a
+// site-wide listing returns sorted output. This is crucial for
+// correct diff/mirror calculation.
+func sortBucketsNameWithSlash(bucketsInfo []minio.BucketInfo) {
+	sort.Slice(bucketsInfo, func(i, j int) bool {
+		return bucketsInfo[i].Name+"/" < bucketsInfo[j].Name+"/"
+	})
+}
+
 func (c *S3Client) listRecursiveInRoutine(ctx context.Context, contentCh chan *ClientContent, opts ListOptions) {
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
@@ -2061,6 +2074,7 @@ func (c *S3Client) listRecursiveInRoutine(ctx context.Context, contentCh chan *C
 			}
 			return
 		}
+		sortBucketsNameWithSlash(buckets)
 		for _, bucket := range buckets {
 			if opts.ShowDir == DirFirst {
 				contentCh <- c.bucketInfo2ClientContent(bucket)


### PR DESCRIPTION
mc diff/mirror command fails to compare source & target when doing
an S3 site-wide listing.

The reason is that client-s3.List(), when doing a site wide listing,
lists buckets first and list objects inside each bucket with the order
returned by S3 ListBuckets API.

However this can produce a non properly sorted listing output,
e.g.:

```
$ mc ls -r myminio/
[2021-12-14 15:58:27 CET] 227KiB bucketname/object1
[2021-12-14 15:58:24 CET] 227KiB bucketname-0/object2
```

Though it should be
```
$ mc ls -r myminio/
[2021-12-14 15:58:24 CET] 227KiB bucketname-0/object2
[2021-12-14 15:58:27 CET] 227KiB bucketname/object1
```

because '/' has a higher ASCII value than '-'

This commit fixes the behavior by always sorting bucket names with
a fake trailing slash when doing a site wide recursive listing.