### PR TITLE
Fix mc ilm restore --help

### DIFF
--- a/cmd/ilm-restore.go
+++ b/cmd/ilm-restore.go
@@ -65,7 +65,12 @@ USAGE:
   {{.HelpName}} TARGET
 
 DESCRIPTION:
-  Create a restored copy of one or more archived objects.
+  Create a restored copy of one or more objects archived on a remote tier. The copy automatically expires 
+  after the specified number of days (Default 1 day). 
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
 
 EXAMPLES:
   1. Restore one specific object


### PR DESCRIPTION
Minor fix-up to the help text for `mc ilm restore --help`. No changes to actual code, so hopefully this is a small fix