### PR TITLE
Update go.mod to include NewerNoncurrentVersions support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/minio/colorjson v1.0.1
 	github.com/minio/filepath v1.0.0
 	github.com/minio/madmin-go v1.1.17
-	github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df
+	github.com/minio/minio-go/v7 v7.0.18
 	github.com/minio/pkg v1.1.3
 	github.com/minio/selfupdate v0.3.1
 	github.com/minio/sha256-simd v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77Z
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.11-0.20210302210017-6ae69c73ce78/go.mod h1:mTh2uJuAbEqdhMVl6CMIIZLUeiMiWtJR4JB8/5g2skw=
-github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df h1:7BfpVODGh5reCjIx2lUqE7CxRMjo58XJw7ZjKKNW/vc=
-github.com/minio/minio-go/v7 v7.0.16-0.20211108161804-a7a36ee131df/go.mod h1:pUV0Pc+hPd1nccgmzQF/EXh48l/Z/yps6QPF1aaie4g=
+github.com/minio/minio-go/v7 v7.0.18 h1:fncn6iacnK+i2uYfNc5aVPG7bEqQH0nU4yAGMSunY0w=
+github.com/minio/minio-go/v7 v7.0.18/go.mod h1:SyQ1IFeJuaa+eV5yEDxW7hYE1s5VVq5sgImDe27R+zg=
 github.com/minio/pkg v1.0.3/go.mod h1:obU54TZ9QlMv0TRaDgQ/JTzf11ZSXxnSfLrm4tMtBP8=
 github.com/minio/pkg v1.1.3 h1:J4vGnlNSxc/o9gDOQMZ3k0L3koA7ZgBQ7GRMrUpt/OY=
 github.com/minio/pkg v1.1.3/go.mod h1:32x/3OmGB0EOi1N+3ggnp+B5VFkSBBB9svPMVfpnf14=


### PR DESCRIPTION
With this `mc ilm import` accepts NewerNoncurrentVersions tag.