### PR TITLE
du: Fix double counting of objects

### DIFF
--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
@@ -151,7 +151,7 @@ func du(ctx context.Context, urlStr string, timeRef time.Time, withVersions bool
 			continue
 		}
 
-		if content.Type.IsDir() {
+		if content.Type.IsDir() && !recursive {
 			depth := depth
 			if depth > 0 {
 				depth--


### PR DESCRIPTION
`mc du play` would count objects twice since it was doing a recursive listing AND traversing into folders.

Compare total to `mc du play --depth=2` and `mc du play --recursive`.