### PR TITLE
Allow storageclass to be specified on mc ls

### DIFF
--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -106,12 +106,9 @@ EXAMPLES:
 
   9. List all objects on mybucket, summarize the number of objects and total size.
      {{.Prompt}} {{.HelpName}} --summarize s3/mybucket/
-
-  10. List all objects on mybucket, for all storageClass
-     {{.Prompt}} {{.HelpName}} --storage-classes '*' s3/mybucket
   
-  11. List all objects on mybucket, for the GLACIER storage class
-     {{.Prompt}} {{.HelpName}} --storage-classes 'GLACIER' s3/mybucket 
+  10. List all objects on mybucket, for the GLACIER storage class
+     {{.Prompt}} {{.HelpName}} --storage-class 'GLACIER' s3/mybucket 
 `,
 }
 

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -179,9 +179,6 @@ func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, bool, 
 	}
 
 	storageClasss := cliCtx.String("storage-class")
-	if len(storageClasss) == 0 {
-		storageClasss = "STANDARD"
-	}
 
 	return args, isRecursive, isIncomplete, isSummary, timeRef, withOlderVersions, storageClasss
 }

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -284,7 +284,7 @@ func mainTree(cliCtx *cli.Context) error {
 			}
 			clnt, err := newClientFromAlias(targetAlias, targetURL)
 			fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
-			if e := doList(ctx, clnt, true, false, false, timeRef, false); e != nil {
+			if e := doList(ctx, clnt, true, false, false, timeRef, false, "*"); e != nil {
 				cErr = e
 			}
 		}


### PR DESCRIPTION
The current version of the ls command omits GLACIER objects. 
Sometimes you need to get a list of those files that are located under another storage class. 

This commit allows filtering a given storage class and only list this class, or list all objects in all storage classes. The default value is STANDARD. 

Usage example: 
* List only GLACIER objects: `mc ls -r -sc GLACIER myAlias/ `
* List only STANDARD objects (default): `mc ls -r myAlias/ `
* List all objects in all storage classes: `mc ls -r -sc '*' myAlias/ `

output example:
```
[2022-01-05 21:17:32 CET] 237KiB STANDARD gu-952f-8404d1f1a068/bl78af97a0f4de9155e56d709e70e81db820eb90f397b39d547f9f9fa0ff84b.blk
[2022-01-05 21:17:49 CET]  19KiB STANDARD gu-952f-8404d1f1a068/bla1889f63d333c93f14f9930dd52526db68ea0073a8336316f24ac2486f98d.blk
[2022-01-05 21:18:06 CET] 160KiB STANDARD gu-952f-8404d1f1a068/bla05d10933062879e669c465f57e5445fbec4f7ed8a4c9690d139c89a05867.blk
[2022-01-08 10:26:41 CET]   635B STANDARD gu-952f-8404d1f1a068/data.cfg
[2022-01-08 10:45:40 CET]  15MiB GLACIER  gu-952f-8404d1f1a068/bkp.blk
```