### PR TITLE
sufficiently conlorize svacct command outputs

### DIFF
--- a/cmd/admin-policy-add.go
+++ b/cmd/admin-policy-add.go
@@ -88,8 +88,8 @@ func (u userPolicyMessage) accountType() string {
 func (u userPolicyMessage) String() string {
 	switch u.op {
 	case "info":
-		buf, err := json.MarshalIndent(u.PolicyInfo, "", " ")
-		fatalIf(probe.NewError(err), "Unable to marshal to JSON.")
+		buf, e := json.MarshalIndent(u.PolicyInfo, "", " ")
+		fatalIf(probe.NewError(e), "Unable to marshal to JSON.")
 		return string(buf)
 	case "list":
 		policyFieldMaxLen := 20

--- a/cmd/admin-user-svcacct-add.go
+++ b/cmd/admin-user-svcacct-add.go
@@ -75,8 +75,7 @@ EXAMPLES:
 // checkAdminUserSvcAcctAddSyntax - validate all the passed arguments
 func checkAdminUserSvcAcctAddSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
-			"Incorrect number of arguments for user svcacct add command.")
+		cli.ShowCommandHelpAndExit(ctx, "add", 1)
 	}
 }
 

--- a/cmd/admin-user-svcacct-disable.go
+++ b/cmd/admin-user-svcacct-disable.go
@@ -50,8 +50,7 @@ EXAMPLES:
 // checkAdminUserSvcAcctDisableSyntax - validate all the passed arguments
 func checkAdminUserSvcAcctDisableSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
-			"Incorrect number of arguments for user svcacct disable command.")
+		cli.ShowCommandHelpAndExit(ctx, "disable", 1)
 	}
 }
 

--- a/cmd/admin-user-svcacct-enable.go
+++ b/cmd/admin-user-svcacct-enable.go
@@ -50,8 +50,7 @@ EXAMPLES:
 // checkAdminUserSvcAcctEnableSyntax - validate all the passed arguments
 func checkAdminUserSvcAcctEnableSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
-			"Incorrect number of arguments for user svcacct enable command.")
+		cli.ShowCommandHelpAndExit(ctx, "enable", 1)
 	}
 }
 

--- a/cmd/admin-user-svcacct-list.go
+++ b/cmd/admin-user-svcacct-list.go
@@ -25,8 +25,8 @@ import (
 )
 
 var adminUserSvcAcctListCmd = cli.Command{
-	Name:         "list",
-	Aliases:      []string{"ls"},
+	Name:         "ls",
+	Aliases:      []string{"list"},
 	Usage:        "List services accounts",
 	Action:       mainAdminUserSvcAcctList,
 	OnUsageError: onUsageError,
@@ -53,8 +53,7 @@ EXAMPLES:
 // checkAdminUserSvcAcctListSyntax - validate all the passed arguments
 func checkAdminUserSvcAcctListSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
-			"Incorrect number of arguments for user svcacct ls command.")
+		cli.ShowCommandHelpAndExit(ctx, "ls", 1)
 	}
 }
 

--- a/cmd/admin-user-svcacct-rm.go
+++ b/cmd/admin-user-svcacct-rm.go
@@ -24,6 +24,7 @@ import (
 
 var adminUserSvcAcctRemoveCmd = cli.Command{
 	Name:         "rm",
+	Aliases:      []string{"remove"},
 	Usage:        "Remove a service account",
 	Action:       mainAdminUserSvcAcctRemove,
 	OnUsageError: onUsageError,
@@ -47,8 +48,7 @@ EXAMPLES:
 // checkAdminUserSvcAcctRemoveSyntax - validate all the passed arguments
 func checkAdminUserSvcAcctRemoveSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
-			"Incorrect number of arguments for user svcacct rm command.")
+		cli.ShowCommandHelpAndExit(ctx, "rm", 1)
 	}
 }
 

--- a/cmd/admin-user-svcacct-set.go
+++ b/cmd/admin-user-svcacct-set.go
@@ -37,7 +37,8 @@ var adminUserSvcAcctSetFlags = []cli.Flag{
 }
 
 var adminUserSvcAcctSetCmd = cli.Command{
-	Name:         "set",
+	Name:         "edit",
+	Aliases:      []string{"set"},
 	Usage:        "edit an existing service account",
 	Action:       mainAdminUserSvcAcctSet,
 	OnUsageError: onUsageError,
@@ -61,8 +62,7 @@ EXAMPLES:
 // checkAdminUserSvcAcctSetSyntax - validate all the passed arguments
 func checkAdminUserSvcAcctSetSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
-			"Incorrect number of arguments for user svcacct set command.")
+		cli.ShowCommandHelpAndExit(ctx, "edit", 1)
 	}
 }
 

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -348,8 +348,10 @@ var completeCmds = map[string]complete.Predictor{
 
 	"/admin/user/svcacct/add":     aliasCompleter,
 	"/admin/user/svcacct/list":    aliasCompleter,
+	"/admin/user/svcacct/ls":      aliasCompleter,
 	"/admin/user/svcacct/rm":      aliasCompleter,
 	"/admin/user/svcacct/info":    aliasCompleter,
+	"/admin/user/svcacct/edit":    aliasCompleter,
 	"/admin/user/svcacct/set":     aliasCompleter,
 	"/admin/user/svcacct/enable":  aliasCompleter,
 	"/admin/user/svcacct/disable": aliasCompleter,


### PR DESCRIPTION
also print help when no args passed, instead of asking
for `--help`

fixes #3803