### PR TITLE
Fix mirror with relative fs path

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -70,8 +70,18 @@ func fsNew(path string) (Client, *probe.Error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, probe.NewError(EmptyPath{})
 	}
+	absPath, e := filepath.Abs(path)
+	if e != nil {
+		return nil, probe.NewError(e)
+	}
+	// filepath.Abs removes the trailing slash in a path
+	// but we still need it because fsClient.List() does not
+	// traverse a directory without a trailing slash in the name
+	if path[len(path)-1] == filepath.Separator {
+		absPath += string(filepath.Separator)
+	}
 	return &fsClient{
-		PathURL: newClientURL(normalizePath(path)),
+		PathURL: newClientURL(normalizePath(absPath)),
 	}, nil
 }
 

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -184,7 +184,7 @@ func doDiffMain(ctx context.Context, firstURL, secondURL string) error {
 	}
 
 	// Diff first and second urls.
-	for diffMsg := range objectDifference(ctx, firstClient, secondClient, firstURL, secondURL, true) {
+	for diffMsg := range objectDifference(ctx, firstClient, secondClient, true) {
 		if diffMsg.Error != nil {
 			errorIf(diffMsg.Error, "Unable to calculate objects difference.")
 			// Ignore error and proceed to next object.

--- a/cmd/difference.go
+++ b/cmd/difference.go
@@ -160,15 +160,15 @@ func metadataEqual(m1, m2 map[string]string) bool {
 	return true
 }
 
-func objectDifference(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, targetURL string, isMetadata bool) (diffCh chan diffMessage) {
-	return difference(ctx, sourceClnt, targetClnt, sourceURL, targetURL, isMetadata, true, false, DirNone)
+func objectDifference(ctx context.Context, sourceClnt, targetClnt Client, isMetadata bool) (diffCh chan diffMessage) {
+	return difference(ctx, sourceClnt, targetClnt, isMetadata, true, false, DirNone)
 }
 
-func dirDifference(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, targetURL string) (diffCh chan diffMessage) {
-	return difference(ctx, sourceClnt, targetClnt, sourceURL, targetURL, false, false, true, DirFirst)
+func dirDifference(ctx context.Context, sourceClnt, targetClnt Client) (diffCh chan diffMessage) {
+	return difference(ctx, sourceClnt, targetClnt, false, false, true, DirFirst)
 }
 
-func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, targetURL string, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt, diffCh chan<- diffMessage) *probe.Error {
+func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt, diffCh chan<- diffMessage) *probe.Error {
 	// Set default values for listing.
 	srcCh := sourceClnt.List(ctx, ListOptions{Recursive: isRecursive, WithMetadata: isMetadata, ShowDir: dirOpt})
 	tgtCh := targetClnt.List(ctx, ListOptions{Recursive: isRecursive, WithMetadata: isMetadata, ShowDir: dirOpt})
@@ -188,11 +188,11 @@ func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, sour
 		}
 
 		if !srcEOF && srcCtnt.Err != nil {
-			return srcCtnt.Err.Trace(sourceURL, targetURL)
+			return srcCtnt.Err.Trace(sourceClnt.GetURL().String(), targetClnt.GetURL().String())
 		}
 
 		if !tgtEOF && tgtCtnt.Err != nil {
-			return tgtCtnt.Err.Trace(sourceURL, targetURL)
+			return tgtCtnt.Err.Trace(sourceClnt.GetURL().String(), targetClnt.GetURL().String())
 		}
 
 		// If source doesn't have objects anymore, comparison becomes obvious
@@ -217,11 +217,11 @@ func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, sour
 			continue
 		}
 
-		srcSuffix := strings.TrimPrefix(srcCtnt.URL.String(), sourceURL)
-		tgtSuffix := strings.TrimPrefix(tgtCtnt.URL.String(), targetURL)
+		srcSuffix := strings.TrimPrefix(srcCtnt.URL.String(), sourceClnt.GetURL().String())
+		tgtSuffix := strings.TrimPrefix(tgtCtnt.URL.String(), targetClnt.GetURL().String())
 
-		current := urlJoinPath(targetURL, srcSuffix)
-		expected := urlJoinPath(targetURL, tgtSuffix)
+		current := urlJoinPath(targetClnt.GetURL().String(), srcSuffix)
+		expected := urlJoinPath(targetClnt.GetURL().String(), tgtSuffix)
 
 		if !utf8.ValidString(srcSuffix) {
 			// Error. Keys must be valid UTF-8.
@@ -326,14 +326,13 @@ func differenceInternal(ctx context.Context, sourceClnt, targetClnt Client, sour
 
 // objectDifference function finds the difference between all objects
 // recursively in sorted order from source and target.
-func difference(ctx context.Context, sourceClnt, targetClnt Client, sourceURL, targetURL string, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt) (diffCh chan diffMessage) {
+func difference(ctx context.Context, sourceClnt, targetClnt Client, isMetadata bool, isRecursive, returnSimilar bool, dirOpt DirOpt) (diffCh chan diffMessage) {
 	diffCh = make(chan diffMessage, 10000)
 
 	go func() {
 		defer close(diffCh)
 
-		err := differenceInternal(ctx, sourceClnt, targetClnt, sourceURL, targetURL,
-			isMetadata, isRecursive, returnSimilar, dirOpt, diffCh)
+		err := differenceInternal(ctx, sourceClnt, targetClnt, isMetadata, isRecursive, returnSimilar, dirOpt, diffCh)
 		if err != nil {
 			// handle this specifically for filesystem related errors.
 			switch err.ToGoError().(type) {

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -907,7 +907,7 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 
 	if mirrorSrcBuckets || createDstBuckets {
 		// Synchronize buckets using dirDifference function
-		for d := range dirDifference(ctx, srcClt, dstClt, srcURL, dstURL) {
+		for d := range dirDifference(ctx, srcClt, dstClt) {
 			if d.Error != nil {
 				if mj.opts.activeActive {
 					errorIf(d.Error, "Failed to start mirroring.. retrying")

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -128,7 +128,7 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 	}
 
 	// List both source and target, compare and return values through channel.
-	for diffMsg := range objectDifference(ctx, sourceClnt, targetClnt, sourceURL, targetURL, opts.isMetadata) {
+	for diffMsg := range objectDifference(ctx, sourceClnt, targetClnt, opts.isMetadata) {
 		if diffMsg.Error != nil {
 			// Send all errors through the channel
 			URLsCh <- URLs{Error: diffMsg.Error, ErrorCond: differInUnknown}


### PR DESCRIPTION
`mc diff <alias>/<bucket>/ ./dir/` is not calculated correctly because the
difference code relies on the format of the argument, for example,
whether it is dir/ or ./dir/ or ../my/dir/.

This commit will calculate the absolute path of the passed argument if
it is a filesystem path and use it through the code.

Fixes https://github.com/minio/mc/issues/3924