### PR TITLE
typo: Error out if the policy is already set in policy update cmd

### DIFF
--- a/cmd/admin-policy-update.go
+++ b/cmd/admin-policy-update.go
@@ -51,7 +51,7 @@ EXAMPLES:
   1. Add the "diagnostics" policy for user "james".
      {{.Prompt}} {{.HelpName}} myminio diagnostics user=james
 
-  2. add the "diagnostics" policy for group "auditors".
+  2. Add the "diagnostics" policy for group "auditors".
      {{.Prompt}} {{.HelpName}} myminio diagnostics group=auditors
 `,
 }
@@ -123,7 +123,7 @@ func mainAdminPolicyUpdate(ctx *cli.Context) error {
 	}
 
 	updatedPolicies, e := updateCannedPolicies(existingPolicies, policiesToAdd)
-	if err != nil {
+	if e != nil {
 		fatalIf(probe.NewError(e).Trace(args...), "Unable to update the policy")
 	}
 


### PR DESCRIPTION
Fix a typo when checking if a policy is already set to a user or a
group.

Fixes https://github.com/minio/mc/issues/3930