### PR TITLE
docs: add example instructions for IBM cloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Get your AccessKeyID and SecretAccessKey by following [Google Credentials Guide]
 mc alias set gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
 ```
 
+### Example - IBM Cloud Object Storage
+See [the complete guide](docs/minio-client-complete-guide.md) for IBM instructions.
+
 ## Test Your Setup
 `mc` is pre-configured with https://play.min.io, aliased as "play". It is a hosted MinIO server for testing and development purpose.  To test Amazon S3, simply replace "play" with "s3" or the alias you used at the time of setup.
 

--- a/docs/minio-client-complete-guide.md
+++ b/docs/minio-client-complete-guide.md
@@ -155,6 +155,17 @@ Get your AccessKeyID and SecretAccessKey by following [Google Credentials Guide]
 mc alias set gcs  https://storage.googleapis.com BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
 ```
 
+### Example - IBM Cloud Object Storage
+Get your AccessKeyID and SecretAccessKey by creating a service account [with HMAC credentials](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-uhc-hmac-credentials-main).  This option is only available from **Resources > Cloud Object Storage > Service credentials** (not from Manage > Access (IAM) > Service IDs). Once created, the values you will use for `accessKey` and `secretKey` are found in the `cos_hmac_keys` field of the service credentials.
+
+Finally, the url will be the **public endpoint specific to the region/resiliency** that you chose when setting up your bucket. There is no single, global url for all buckets. Find your bucket's URL in the console by going to Cloud Object Storage > Buckets > [your-bucket] > Configuration > Endpoints > public. Remember to prepend `https://` to the URL provided.
+
+```
+mc alias set ibm https://s3.us-east.cloud-object-storage.appdomain.cloud BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12 --api s3v4
+```
+
+**Note**: The service ID you create must have an access policy granting it access to your Object Storage instance(s). 
+
 ### Example - Specify keys using standard input
 
 #### Prompt

--- a/docs/minio-client-configuration-files.md
+++ b/docs/minio-client-configuration-files.md
@@ -62,6 +62,13 @@ cat config.json
 			"secretKey": "YOUR-SECRET-KEY-HERE",
 			"api": "S3v4",
                         "path": "auto"
+		},
+		"ibm": {
+			"url": "https://s3.YOUR-REGION.cloud-object-storage.appdomain.cloud",
+			"accessKey": "YOUR-HMAC-ACCESS-KEY-ID",
+			"secretKey": "YOUR-HMAC-SECRET-ACCESS-KEY",
+			"api": "S3v4", 
+			"path": "auto" 
 		}
 	}
 }


### PR DESCRIPTION
It took me a while to figure out where the access and secret keys came from to connect this, all the while using the wrong endpoint. Hoping to save someone the trial-and-error I went through. 