### PR TITLE
Use subnet proxy from minio config if available

### DIFF
--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -316,6 +316,11 @@ func prepareDiagUploadURL(alias string, clusterName string, filename string, lic
 }
 
 func uploadDiagReport(alias string, filename string, reqURL string, headers map[string]string) error {
+	e := setSubnetProxyFromConfig(alias)
+	if e != nil {
+		return e
+	}
+
 	req, e := subnetUploadReq(reqURL, filename)
 	if e != nil {
 		return e


### PR DESCRIPTION
minio now supports storing the proxy to be used for connecting to subnet
in the `subnet proxy` config. So mc can use it if available when
communicating with subnet during cluster registration or diagnostics
upload.