### PR TITLE
Error out from `support diag` if cluster not registered

### DIFF
--- a/cmd/support-callhome-set.go
+++ b/cmd/support-callhome-set.go
@@ -113,7 +113,7 @@ func configureSubnetWebhook(aliasedURL string, enable bool) {
 
 	apiKey := getSubnetAPIKeyFromConfig(alias)
 	if len(apiKey) == 0 {
-		e := fmt.Errorf("Please register the cluster first by running 'mc admin subnet register %s'", alias)
+		e := fmt.Errorf("Please register the cluster first by running 'mc support register %s'", alias)
 		fatalIf(probe.NewError(e), "Cluster not registered.")
 	}
 

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -299,6 +299,11 @@ func prepareDiagUploadURL(alias string, clusterName string, filename string, lic
 
 		if len(apiKey) == 0 {
 			license = getSubnetLicenseFromConfig(alias)
+			if len(license) == 0 {
+				// Both api key and license not available. Ask user to register the cluster first
+				e := fmt.Errorf("Please register the cluster first by running 'mc support register %s', or use --airgap flag", alias)
+				fatalIf(probe.NewError(e), "Cluster not registered.")
+			}
 		}
 	}
 


### PR DESCRIPTION
If user tries to run `mc support diag` for a cluster that is not yet
registered, error out asking the user to register the cluster first.