### PR TITLE
Add remote zip support to mc ls/cp/cat

### DIFF
--- a/cmd/alias-set.go
+++ b/cmd/alias-set.go
@@ -61,10 +61,8 @@ var aliasSetCmd = cli.Command{
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
-
 USAGE:
   {{.HelpName}} ALIAS URL ACCESSKEY SECRETKEY
-
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
@@ -73,24 +71,20 @@ EXAMPLES:
      {{.DisableHistory}}
      {{.Prompt}} {{.HelpName}} myminio http://localhost:9000 minio minio123
      {{.EnableHistory}}
-
   2. Add MinIO service under "myminio" alias, to use dns style bucket lookup. For security reasons
      turn off bash history momentarily.
      {{.DisableHistory}}
      {{.Prompt}} {{.HelpName}} myminio http://localhost:9000 minio minio123 --api "s3v4" --path "off"
      {{.EnableHistory}}
-
   3. Add Amazon S3 storage service under "mys3" alias. For security reasons turn off bash history momentarily.
      {{.DisableHistory}}
      {{.Prompt}} {{.HelpName}} mys3 https://s3.amazonaws.com \
                  BKIKJAA5BMMU2RHO6IBB V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
      {{.EnableHistory}}
-
   4. Add Amazon S3 storage service under "mys3" alias, prompting for keys.
      {{.Prompt}} {{.HelpName}} mys3 https://s3.amazonaws.com --api "s3v4" --path "off"
      Enter Access Key: BKIKJAA5BMMU2RHO6IBB
      Enter Secret Key: V8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12
-
   5. Add Amazon S3 storage service under "mys3" alias using piped keys.
      {{.DisableHistory}}
      {{.Prompt}} echo -e "BKIKJAA5BMMU2RHO6IBB\nV8f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12" | \
@@ -103,6 +97,11 @@ EXAMPLES:
 func checkAliasSetSyntax(ctx *cli.Context, accessKey string, secretKey string, deprecated bool) {
 	args := ctx.Args()
 	argsNr := len(args)
+
+	if argsNr == 0 {
+		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+	}
+
 	if argsNr > 4 || argsNr < 2 {
 		fatalIf(errInvalidArgument().Trace(ctx.Args().Tail()...),
 			"Incorrect number of arguments for alias set command.")

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -186,7 +186,7 @@ func urlJoinPath(url1, url2 string) string {
 }
 
 // url2Stat returns stat info for URL.
-func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encKeyDB map[string][]prefixSSEPair, timeRef time.Time) (client Client, content *ClientContent, err *probe.Error) {
+func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encKeyDB map[string][]prefixSSEPair, timeRef time.Time, isZip bool) (client Client, content *ClientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
@@ -194,7 +194,7 @@ func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encK
 	alias, _ := url2Alias(urlStr)
 	sse := getSSE(urlStr, encKeyDB[alias])
 
-	content, err = client.Stat(ctx, StatOptions{preserve: fileAttr, sse: sse, timeRef: timeRef, versionID: versionID})
+	content, err = client.Stat(ctx, StatOptions{preserve: fileAttr, sse: sse, timeRef: timeRef, versionID: versionID, isZip: isZip})
 	if err != nil {
 		return nil, nil, err.Trace(urlStr)
 	}
@@ -202,12 +202,12 @@ func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encK
 }
 
 // firstURL2Stat returns the stat info of the first object having the specified prefix
-func firstURL2Stat(ctx context.Context, prefix string, timeRef time.Time) (client Client, content *ClientContent, err *probe.Error) {
+func firstURL2Stat(ctx context.Context, prefix string, timeRef time.Time, isZip bool) (client Client, content *ClientContent, err *probe.Error) {
 	client, err = newClient(prefix)
 	if err != nil {
 		return nil, nil, err.Trace(prefix)
 	}
-	content = <-client.List(ctx, ListOptions{Recursive: true, TimeRef: timeRef, Count: 1})
+	content = <-client.List(ctx, ListOptions{Recursive: true, TimeRef: timeRef, Count: 1, ListZip: isZip})
 	if content == nil {
 		return nil, nil, probe.NewError(ObjectMissing{timeRef: timeRef}).Trace(prefix)
 	}

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/minio/mc/pkg/probe"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
 	"github.com/minio/minio-go/v7/pkg/replication"
@@ -47,6 +47,7 @@ const (
 type GetOptions struct {
 	SSE       encrypt.ServerSide
 	VersionID string
+	Zip       bool
 }
 
 // PutOptions holds options for PUT operation
@@ -67,6 +68,7 @@ type StatOptions struct {
 	sse        encrypt.ServerSide
 	timeRef    time.Time
 	versionID  string
+	isZip      bool
 }
 
 // ListOptions holds options for listing operation
@@ -76,6 +78,7 @@ type ListOptions struct {
 	WithMetadata      bool
 	WithOlderVersions bool
 	WithDeleteMarkers bool
+	ListZip           bool
 	TimeRef           time.Time
 	ShowDir           DirOpt
 	Count             int

--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -53,6 +53,10 @@ func checkCopySyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 		fatalIf(errDummy().Trace(cliCtx.Args()...), "Unable to pass --version flag with multiple copy sources arguments.")
 	}
 
+	if isZip && cliCtx.String("rewind") != "" {
+		fatalIf(errDummy().Trace(cliCtx.Args()...), "--zip and --rewind cannot be used together")
+	}
+
 	// Verify if source(s) exists.
 	for _, srcURL := range srcURLs {
 		var err *probe.Error

--- a/cmd/diff-main.go
+++ b/cmd/diff-main.go
@@ -130,7 +130,7 @@ func checkDiffSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 	// Diff only works between two directories, verify them below.
 
 	// Verify if firstURL is accessible.
-	_, firstContent, err := url2Stat(ctx, firstURL, "", false, encKeyDB, time.Time{})
+	_, firstContent, err := url2Stat(ctx, firstURL, "", false, encKeyDB, time.Time{}, false)
 	if err != nil {
 		fatalIf(err.Trace(firstURL), fmt.Sprintf("Unable to stat '%s'.", firstURL))
 	}
@@ -141,7 +141,7 @@ func checkDiffSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 	}
 
 	// Verify if secondURL is accessible.
-	_, secondContent, err := url2Stat(ctx, secondURL, "", false, encKeyDB, time.Time{})
+	_, secondContent, err := url2Stat(ctx, secondURL, "", false, encKeyDB, time.Time{}, false)
 	if err != nil {
 		// Destination doesn't exist is okay.
 		if _, ok := err.ToGoError().(ObjectMissing); !ok {

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -174,7 +174,7 @@ func checkFindSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 
 	// Extract input URLs and validate.
 	for _, url := range args {
-		_, _, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{})
+		_, _, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{}, false)
 		if err != nil && !isURLPrefixExists(url, false) {
 			// Bucket name empty is a valid error for 'find myminio' unless we are using watch, treat it as such.
 			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !cliCtx.Bool("watch") {

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -180,9 +180,6 @@ func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, doList
 		timeRef = time.Now().UTC()
 	}
 
-	if listZip && withOlderVersions {
-		fatalIf(errInvalidArgument().Trace(args...), "Zip file listing can only be performed on the latest version")
-	}
 	if listZip && (withOlderVersions || !timeRef.IsZero()) {
 		fatalIf(errInvalidArgument().Trace(args...), "Zip file listing can only be performed on the latest version")
 	}

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -180,7 +180,7 @@ func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, doList
 		timeRef = time.Now().UTC()
 	}
 
-	if listZip && withOlderVersions {
+	if listZip && (withOlderVersions || !timeRef.IsZero()) {
 		fatalIf(errInvalidArgument().Trace(args...), "Zip file listing can only be performed on the latest version")
 	}
 	storageClasss := cliCtx.String("storage-class")

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -57,6 +57,10 @@ var (
 			Name:  "storage-class, sc",
 			Usage: "filter to specified storage class",
 		},
+		cli.BoolFlag{
+			Name:  "zip",
+			Usage: "list files inside zip archive (MinIO servers only)",
+		},
 	}
 )
 
@@ -154,7 +158,7 @@ func parseRewindFlag(rewind string) (timeRef time.Time) {
 }
 
 // checkListSyntax - validate all the passed arguments
-func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, bool, bool, bool, time.Time, bool, string) {
+func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, doListOptions) {
 	args := cliCtx.Args()
 	if !cliCtx.Args().Present() {
 		args = []string{"."}
@@ -169,15 +173,27 @@ func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, bool, 
 	isIncomplete := cliCtx.Bool("incomplete")
 	withOlderVersions := cliCtx.Bool("versions")
 	isSummary := cliCtx.Bool("summarize")
+	listZip := cliCtx.Bool("zip")
 
 	timeRef := parseRewindFlag(cliCtx.String("rewind"))
 	if timeRef.IsZero() && withOlderVersions {
 		timeRef = time.Now().UTC()
 	}
 
+	if listZip && withOlderVersions {
+		fatalIf(errInvalidArgument().Trace(args...), "Zip file listing can only be performed on the latest version")
+	}
 	storageClasss := cliCtx.String("storage-class")
-
-	return args, isRecursive, isIncomplete, isSummary, timeRef, withOlderVersions, storageClasss
+	opts := doListOptions{
+		timeRef:           timeRef,
+		isRecursive:       isRecursive,
+		isIncomplete:      isIncomplete,
+		isSummary:         isSummary,
+		withOlderVersions: withOlderVersions,
+		listZip:           listZip,
+		filter:            storageClasss,
+	}
+	return args, opts
 }
 
 // mainList - is a handler for mc ls command
@@ -198,7 +214,7 @@ func mainList(cliCtx *cli.Context) error {
 	console.SetColor("SC", color.New(color.FgBlue))
 
 	// check 'ls' cliCtx arguments.
-	args, isRecursive, isIncomplete, isSummary, timeRef, withOlderVersions, storageClassFilter := checkListSyntax(ctx, cliCtx)
+	args, opts := checkListSyntax(ctx, cliCtx)
 
 	var cErr error
 	for _, targetURL := range args {
@@ -206,14 +222,14 @@ func mainList(cliCtx *cli.Context) error {
 		fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
 		if !strings.HasSuffix(targetURL, string(clnt.GetURL().Separator)) {
 			var st *ClientContent
-			st, err = clnt.Stat(ctx, StatOptions{incomplete: isIncomplete})
+			st, err = clnt.Stat(ctx, StatOptions{incomplete: opts.isIncomplete})
 			if st != nil && err == nil && st.Type.IsDir() {
 				targetURL = targetURL + string(clnt.GetURL().Separator)
 				clnt, err = newClient(targetURL)
 				fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
 			}
 		}
-		if e := doList(ctx, clnt, isRecursive, isIncomplete, isSummary, timeRef, withOlderVersions, storageClassFilter); e != nil {
+		if e := doList(ctx, clnt, opts); e != nil {
 			cErr = e
 		}
 	}

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -463,7 +463,7 @@ func (mj *mirrorJob) doMirror(ctx context.Context, sURLs URLs) URLs {
 	sURLs.DisableMultipart = mj.opts.disableMultipart
 
 	now := time.Now()
-	ret := uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.opts.encKeyDB, mj.opts.isMetadata)
+	ret := uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.opts.encKeyDB, mj.opts.isMetadata, false)
 	if ret.Error == nil {
 		durationMs := time.Since(now) / time.Millisecond
 		mirrorReplicationDurations.With(prometheus.Labels{"object_size": convertSizeToTag(sURLs.SourceContent.Size)}).Observe(float64(durationMs))

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -66,7 +66,7 @@ func checkMirrorSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[st
 
 	/****** Generic rules *******/
 	if !cliCtx.Bool("watch") && !cliCtx.Bool("active-active") && !cliCtx.Bool("multi-master") {
-		_, srcContent, err := url2Stat(ctx, srcURL, "", false, encKeyDB, time.Time{})
+		_, srcContent, err := url2Stat(ctx, srcURL, "", false, encKeyDB, time.Time{}, false)
 		if err != nil {
 			fatalIf(err.Trace(srcURL), "Unable to stat source `"+srcURL+"`.")
 		}

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -272,7 +272,7 @@ func removeSingle(url, versionID string, isIncomplete, isFake, isForce, isBypass
 		modTime time.Time
 	)
 
-	_, content, pErr := url2Stat(ctx, url, versionID, false, encKeyDB, time.Time{})
+	_, content, pErr := url2Stat(ctx, url, versionID, false, encKeyDB, time.Time{}, false)
 	if pErr != nil {
 		switch minio.ToErrorResponse(pErr.ToGoError()).StatusCode {
 		case http.StatusBadRequest, http.StatusMethodNotAllowed:

--- a/cmd/share-download-main.go
+++ b/cmd/share-download-main.go
@@ -104,7 +104,7 @@ func checkShareDownloadSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB
 	// Validate if object exists only if the `--recursive` flag was NOT specified
 	if !isRecursive {
 		for _, url := range cliCtx.Args() {
-			_, _, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{})
+			_, _, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{}, false)
 			if err != nil {
 				fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 			}

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -454,7 +454,7 @@ func mainSQL(cliCtx *cli.Context) error {
 	URLs := cliCtx.Args()
 	writeHdr := true
 	for _, url := range URLs {
-		if _, targetContent, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{}); err != nil {
+		if _, targetContent, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{}, false); err != nil {
 			errorIf(err.Trace(url), "Unable to run sql for "+url+".")
 			continue
 		} else if !targetContent.Type.IsDir() {

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -125,7 +125,7 @@ func parseAndCheckStatSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB 
 	}
 
 	for _, url := range URLs {
-		_, _, err := url2Stat(ctx, url, versionID, false, encKeyDB, rewind)
+		_, _, err := url2Stat(ctx, url, versionID, false, encKeyDB, rewind, false)
 		if err != nil && !isURLPrefixExists(url, isIncomplete) {
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 		}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -229,7 +229,7 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 				continue
 			}
 		}
-		clnt, stat, err := url2Stat(ctx, url, content.VersionID, true, encKeyDB, timeRef)
+		clnt, stat, err := url2Stat(ctx, url, content.VersionID, true, encKeyDB, timeRef, false)
 		if err != nil {
 			continue
 		}

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -131,7 +131,7 @@ func parseTreeSyntax(ctx context.Context, cliCtx *cli.Context) (args []string, d
 	}
 
 	for _, url := range args {
-		if _, _, err := url2Stat(ctx, url, "", false, nil, timeRef); err != nil && !isURLPrefixExists(url, false) {
+		if _, _, err := url2Stat(ctx, url, "", false, nil, timeRef, false); err != nil && !isURLPrefixExists(url, false) {
 			fatalIf(err.Trace(url), "Unable to tree `"+url+"`.")
 		}
 	}
@@ -284,7 +284,16 @@ func mainTree(cliCtx *cli.Context) error {
 			}
 			clnt, err := newClientFromAlias(targetAlias, targetURL)
 			fatalIf(err.Trace(targetURL), "Unable to initialize target `"+targetURL+"`.")
-			if e := doList(ctx, clnt, true, false, false, timeRef, false, "*"); e != nil {
+			opts := doListOptions{
+				timeRef:           timeRef,
+				isRecursive:       true,
+				isIncomplete:      false,
+				isSummary:         false,
+				withOlderVersions: false,
+				listZip:           false,
+				filter:            "*",
+			}
+			if e := doList(ctx, clnt, opts); e != nil {
 				cErr = e
 			}
 		}


### PR DESCRIPTION
All remote zip support for mc operations.

```
λ mc ls --zip play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/bytes.go/
[2022-02-09 16:38:59 CET]  14KiB STANDARD part.1
[2022-02-09 16:38:59 CET] 1.1KiB STANDARD xl.meta

λ mc cat --zip play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/bytes.go/xl.meta
{"version":"1.0.1 ...

λ mc cp --zip play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/bytes.go/xl.meta .
.../xl1/src3/src2/bytes/bytes.go/xl.meta:  1.06 KiB / 1.06 KiB [========================================] 1.21 KiB/s 0s

λ mc cp --recursive --json --zip play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/bytes.go/ .
{
 "status": "success",
 "source": "play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/bytes.go/part.1",
 "target": "part.1",
 "size": 14625,
 "totalCount": 2,
 "totalSize": 0
}
{
 "status": "success",
 "source": "play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/bytes.go/xl.meta",
 "target": "xl.meta",
 "size": 1084,
 "totalCount": 2,
 "totalSize": 0
}

λ mc ls --recursive --zip play/test/repro-pack.zip/data/mindev/data2/xl1/src3/src2/bytes/
[2022-02-09 16:38:59 CET] 1.1KiB STANDARD boundary_test.go/part.1
[2022-02-09 16:38:59 CET] 1.1KiB STANDARD boundary_test.go/xl.meta
[2022-02-09 16:38:59 CET] 7.2KiB STANDARD buffer.go/part.1
[2022-02-09 16:38:59 CET] 1.1KiB STANDARD buffer.go/xl.meta
...
```