### PR TITLE
Fix cluster registration failing when proxy not set

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -249,7 +249,7 @@ func setSubnetProxyFromConfig(alias string) error {
 
 	// get the subnet proxy config from MinIO if available
 	supported, proxy := getSubnetKeyFromMinIOConfig(alias, "proxy")
-	if supported {
+	if supported && len(proxy) > 0 {
 		proxyURL, e := url.Parse(proxy)
 		if e != nil {
 			return e


### PR DESCRIPTION
Global proxy variable was getting set even when the subnet proxy config is empty,
resulting in error in the `mc support register command`. Fixed by setting it only when
the configured proxy is non-empty.