### PR TITLE
Remove cli flag `subnet-proxy`

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -77,7 +77,7 @@ var (
 )
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
-func setGlobals(quiet, debug, json, noColor, insecure, devMode bool, subnetProxyURL *url.URL) {
+func setGlobals(quiet, debug, json, noColor, insecure, devMode bool) {
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
 	globalJSONLine = !isTerminal() && json
@@ -85,7 +85,6 @@ func setGlobals(quiet, debug, json, noColor, insecure, devMode bool, subnetProxy
 	globalNoColor = globalNoColor || noColor || globalJSONLine
 	globalInsecure = globalInsecure || insecure
 	globalDevMode = globalDevMode || devMode
-	globalSubnetProxyURL = subnetProxyURL
 
 	// Disable colorified messages if requested.
 	if globalNoColor || globalQuiet {
@@ -102,17 +101,6 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	insecure := ctx.IsSet("insecure") || ctx.GlobalIsSet("insecure")
 	devMode := ctx.IsSet("dev") || ctx.GlobalIsSet("dev")
 
-	subnetProxy := ctx.String("subnet-proxy")
-
-	var proxyURL *url.URL
-	var e error
-	if value := ctx.String("subnet-proxy"); value != "" {
-		proxyURL, e = url.Parse(subnetProxy)
-		if e != nil {
-			return e
-		}
-	}
-
-	setGlobals(quiet, debug, json, noColor, insecure, devMode, proxyURL)
+	setGlobals(quiet, debug, json, noColor, insecure, devMode)
 	return nil
 }

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -50,10 +50,6 @@ var subnetCommonFlags = []cli.Flag{
 		Name:  "name",
 		Usage: "Specify the name to associate to this MinIO cluster in SUBNET",
 	},
-	cli.StringFlag{
-		Name:  "subnet-proxy",
-		Usage: "Specify the HTTP(S) proxy URL to use for connecting to SUBNET",
-	},
 	cli.BoolFlag{
 		Name:  "airgap",
 		Usage: "Use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
@@ -243,7 +239,7 @@ func getSubnetAPIKeyFromConfig(alias string) string {
 
 func setSubnetProxyFromConfig(alias string) error {
 	if globalSubnetProxyURL != nil {
-		// proxy already set via command line arg.
+		// proxy already set
 		return nil
 	}
 

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -95,13 +95,10 @@ EXAMPLES:
   1. Upload MinIO diagnostics report for 'play' (https://play.min.io by default) to SUBNET
      {{.Prompt}} {{.HelpName}} play
 
-  2. Upload MinIO diagnostics report for alias 'play' (https://play.min.io by default) to SUBNET proxying via https://192.168.1.3:3128
-     {{.Prompt}} {{.HelpName}} play --subnet-proxy https://192.168.1.3:3128
-
-  3. Schedule periodic upload of MinIO diagnostics report for alias 'play' (https://play.min.io by default) to SUBNET every 2 days
+  2. Schedule periodic upload of MinIO diagnostics report for alias 'play' (https://play.min.io by default) to SUBNET every 2 days
      {{.Prompt}} {{.HelpName}} play --schedule 2
 
-  4. Generate MinIO diagnostics report for alias 'play' (https://play.min.io by default) save and upload to SUBNET manually
+  3. Generate MinIO diagnostics report for alias 'play' (https://play.min.io by default) save and upload to SUBNET manually
      {{.Prompt}} {{.HelpName}} play --airgap
 `,
 }

--- a/cmd/support-register.go
+++ b/cmd/support-register.go
@@ -51,9 +51,6 @@ EXAMPLES:
 
   2. Register MinIO cluster at alias 'play' on SUBNET, using the name "play-cluster".
      {{.Prompt}} {{.HelpName}} play --name play-cluster
-
-  3. Register MinIO cluster at alias 'play' on SUBNET, using the proxy https://192.168.1.3:3128
-     {{.Prompt}} {{.HelpName}} play --subnet-proxy https://192.168.1.3:3128
 `,
 }
 


### PR DESCRIPTION
System now supports setting the subnet proxy as a config, so the command
line flag is not required anymore.