### PR TITLE
watch: Clean up watch when restarting mirror after an error

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -181,6 +181,9 @@ func (f *fsClient) Watch(ctx context.Context, options WatchOptions) (*WatchObjec
 		close(eventChan)
 		close(errorChan)
 		notify.Stop(in)
+		// At this point, notify is guaranteed to not write
+		// in 'in' channel so we can close it.
+		close(in)
 	}()
 
 	timeFormatFS := "2006-01-02T15:04:05.000Z"

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -645,6 +645,8 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 
 // this goroutine will watch for notifications, and add modified objects to the queue
 func (mj *mirrorJob) watchMirror(ctx context.Context) {
+	defer mj.watcher.Stop()
+
 	for {
 		select {
 		case events, ok := <-mj.watcher.Events():

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -103,13 +103,11 @@ func (w *Watcher) Events() chan []EventInfo {
 	return w.EventInfoChan
 }
 
-// Watching returns if the watcher is watching for notifications
-func (w *Watcher) Watching() bool {
-	return (len(w.o) > 0)
-}
-
-// Wait for watcher to wait
-func (w *Watcher) Wait() {
+// Stop all watchers
+func (w *Watcher) Stop() {
+	for _, w := range w.o {
+		close(w.DoneChan)
+	}
 	w.wg.Wait()
 }
 
@@ -135,6 +133,8 @@ func (w *Watcher) Join(ctx context.Context, client Client, recursive bool) *prob
 
 		for {
 			select {
+			case <-wo.DoneChan:
+				return
 			case events, ok := <-wo.Events():
 				if !ok {
 					return


### PR DESCRIPTION
Add cleanup for watch code when it exits and mirroring is restarted.