### PR TITLE
More validation for retention commands

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -2250,7 +2250,11 @@ func (c *S3Client) ShareUpload(ctx context.Context, isRecursive bool, expires ti
 
 // SetObjectLockConfig - Set object lock configurataion of bucket.
 func (c *S3Client) SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error {
-	bucket, _ := c.url2BucketAndObject()
+	bucket, object := c.url2BucketAndObject()
+
+	if bucket == "" || object != "" {
+		return errInvalidArgument().Trace(bucket, object)
+	}
 
 	// FIXME: This is too ugly, fix minio-go
 	vuint := (uint)(validity)
@@ -2366,7 +2370,11 @@ func (c *S3Client) GetObjectLegalHold(ctx context.Context, versionID string) (mi
 
 // GetObjectLockConfig - Get object lock configuration of bucket.
 func (c *S3Client) GetObjectLockConfig(ctx context.Context) (string, minio.RetentionMode, uint64, minio.ValidityUnit, *probe.Error) {
-	bucket, _ := c.url2BucketAndObject()
+	bucket, object := c.url2BucketAndObject()
+
+	if bucket == "" || object != "" {
+		return "", "", 0, "", errInvalidArgument().Trace(bucket, object)
+	}
 
 	status, mode, validity, unit, e := c.api.GetObjectLockConfig(ctx, bucket)
 	if e != nil {

--- a/cmd/retention-clear.go
+++ b/cmd/retention-clear.go
@@ -90,6 +90,11 @@ EXAMPLES:
 
 func parseClearRetentionArgs(cliCtx *cli.Context) (target, versionID string, timeRef time.Time, withVersions, recursive, bucketMode bool) {
 	args := cliCtx.Args()
+
+	if len(args) != 1 {
+		cli.ShowCommandHelpAndExit(cliCtx, "clear", 1)
+	}
+
 	target = args[0]
 	if target == "" {
 		fatalIf(errInvalidArgument().Trace(), "invalid target url '%v'", target)
@@ -100,6 +105,11 @@ func parseClearRetentionArgs(cliCtx *cli.Context) (target, versionID string, tim
 	withVersions = cliCtx.Bool("versions")
 	recursive = cliCtx.Bool("recursive")
 	bucketMode = cliCtx.Bool("default")
+
+	if bucketMode && (versionID != "" || !timeRef.IsZero() || withVersions || recursive) {
+		fatalIf(errDummy(), "--default cannot be specified with any of --version-id, --rewind, --versions or --recursive.")
+	}
+
 	return
 }
 
@@ -119,10 +129,6 @@ func mainRetentionClear(cliCtx *cli.Context) error {
 
 	console.SetColor("RetentionSuccess", color.New(color.FgGreen, color.Bold))
 	console.SetColor("RetentionFailure", color.New(color.FgYellow))
-
-	if len(cliCtx.Args()) != 1 {
-		cli.ShowCommandHelpAndExit(cliCtx, "clear", 1)
-	}
 
 	target, versionID, rewind, withVersions, recursive, bucketMode := parseClearRetentionArgs(cliCtx)
 

--- a/cmd/retention-info.go
+++ b/cmd/retention-info.go
@@ -92,6 +92,10 @@ EXAMPLES:
 func parseInfoRetentionArgs(cliCtx *cli.Context) (target, versionID string, recursive bool, timeRef time.Time, withVersions, defaultMode bool) {
 	args := cliCtx.Args()
 
+	if len(args) != 1 {
+		cli.ShowCommandHelpAndExit(cliCtx, "info", 1)
+	}
+
 	target = args[0]
 	if target == "" {
 		fatalIf(errInvalidArgument().Trace(), "invalid target url '%v'", target)
@@ -102,6 +106,11 @@ func parseInfoRetentionArgs(cliCtx *cli.Context) (target, versionID string, recu
 	withVersions = cliCtx.Bool("versions")
 	recursive = cliCtx.Bool("recursive")
 	defaultMode = cliCtx.Bool("default")
+
+	if defaultMode && (versionID != "" || !timeRef.IsZero() || withVersions || recursive) {
+		fatalIf(errDummy(), "--default flag cannot be specified with any of --version-id, --rewind, --versions, --recursive.")
+	}
+
 	return
 }
 
@@ -370,10 +379,6 @@ func mainRetentionInfo(cliCtx *cli.Context) error {
 	console.SetColor("RetentionVersionID", color.New(color.FgGreen))
 	console.SetColor("RetentionExpired", color.New(color.FgRed, color.Bold))
 	console.SetColor("RetentionFailure", color.New(color.FgYellow))
-
-	if len(cliCtx.Args()) != 1 {
-		cli.ShowCommandHelpAndExit(cliCtx, "info", 1)
-	}
 
 	target, versionID, recursive, rewind, withVersions, bucketMode := parseInfoRetentionArgs(cliCtx)
 


### PR DESCRIPTION
1. Print an error when --default with specified with any other flags, such as --version-id, --recursive, etc..
2. Print an error when --default is passed with object name in the aliased path