### PR TITLE
Fix arm FreeBSD build

### DIFF
--- a/pkg/disk/stat_freebsd.go
+++ b/pkg/disk/stat_freebsd.go
@@ -35,7 +35,8 @@ func GetFileSystemAttrs(file string) (string, error) {
 
 	var fileAttr strings.Builder
 	fileAttr.WriteString("atime:")
-	fileAttr.WriteString(strconv.FormatInt(st.Atimespec.Sec, 10) + "#" + strconv.FormatInt(st.Atimespec.Nsec, 10))
+	// NOTE: Keep int64 casts. See https://github.com/minio/mc/issues/4005
+	fileAttr.WriteString(strconv.FormatInt(int64(st.Atimespec.Sec), 10) + "#" + strconv.FormatInt(int64(st.Atimespec.Nsec), 10))
 	fileAttr.WriteString("/gid:")
 	fileAttr.WriteString(strconv.Itoa(int(st.Gid)))
 
@@ -48,7 +49,8 @@ func GetFileSystemAttrs(file string) (string, error) {
 	fileAttr.WriteString("/mode:")
 	fileAttr.WriteString(strconv.Itoa(int(st.Mode)))
 	fileAttr.WriteString("/mtime:")
-	fileAttr.WriteString(strconv.FormatInt(st.Mtimespec.Sec, 10) + "#" + strconv.FormatInt(st.Mtimespec.Nsec, 10))
+	// NOTE: Keep int64 casts. See https://github.com/minio/mc/issues/4005
+	fileAttr.WriteString(strconv.FormatInt(int64(st.Mtimespec.Sec), 10) + "#" + strconv.FormatInt(int64(st.Mtimespec.Nsec), 10))
 	fileAttr.WriteString("/uid:")
 	fileAttr.WriteString(strconv.Itoa(int(st.Uid)))
 


### PR DESCRIPTION
Fixes #4005

Tested with `GOOS=freebsd GOARCH=arm go build .`.