### PR TITLE
Allow remote target endpoint to point to different host

### DIFF
--- a/cmd/admin-bucket-remote-edit.go
+++ b/cmd/admin-bucket-remote-edit.go
@@ -177,9 +177,6 @@ func modifyRemoteTarget(cli *cli.Context, targets []madmin.BucketTarget) (*madmi
 		}
 		console.SetColor(cred, color.New(color.FgYellow, color.Italic))
 		creds := &madmin.Credentials{AccessKey: accessKey, SecretKey: secretKey}
-		if host != bktTarget.Endpoint {
-			fatalIf(errInvalidArgument().Trace(args...), "configured Endpoint `"+host+"` does not match "+bktTarget.Endpoint+"` for this ARN `"+bktTarget.Arn+"`")
-		}
 		if tgtBucket != bktTarget.TargetBucket {
 			fatalIf(errInvalidArgument().Trace(args...), "configured remote target bucket `"+tgtBucket+"` does not match "+bktTarget.TargetBucket+"` for this ARN `"+bktTarget.Arn+"`")
 		}


### PR DESCRIPTION
Loosen validation in `mc admin bucket remote edit` in order to retain same ARN for replication when host name is changed e.g. from LB endpoint to cluster DNS.