### PR TITLE
mv: Fix regression when checking lock in target bucket

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -395,14 +395,8 @@ func doCopySession(ctx context.Context, cancelCopy context.CancelFunc, cli *cli.
 	sourceURLs := cli.Args()[:len(cli.Args())-1]
 	targetURL := cli.Args()[len(cli.Args())-1] // Last one is target
 
-	tgtClnt, err := newClient(targetURL)
-	fatalIf(err, "Unable to initialize `"+targetURL+"`.")
-
-	// Check if the target bucket has object locking enabled
-	var withLock bool
-	if _, _, _, _, err = tgtClnt.GetObjectLockConfig(ctx); err == nil {
-		withLock = true
-	}
+	// Check if the target path has object locking enabled
+	withLock, _ := isBucketLockEnabled(ctx, targetURL)
 
 	if session != nil {
 		// isCopied returns true if an object has been already copied

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -241,18 +241,12 @@ func mainMove(cliCtx *cli.Context) error {
 	// Check if source URLs does not have object locking enabled
 	// since we cannot move them (remove them from the source)
 	for _, urlStr := range cliCtx.Args()[:cliCtx.NArg()-1] {
-		client, err := newClient(urlStr)
+		enabled, err := isBucketLockEnabled(ctx, urlStr)
 		if err != nil {
-			fatalIf(err.Trace(), "Unable to parse the provided url.")
+			fatalIf(err.Trace(), "Unable to get bucket lock configuration of `%s`", urlStr)
 		}
-		if _, ok := client.(*S3Client); ok {
-			enabled, err := isBucketLockEnabled(ctx, urlStr)
-			if err != nil {
-				fatalIf(err.Trace(), "Unable to get bucket lock configuration of `%s`", urlStr)
-			}
-			if enabled {
-				fatalIf(errDummy().Trace(), fmt.Sprintf("Object lock configuration is enabled on the specified bucket in alias %v.", urlStr))
-			}
+		if enabled {
+			fatalIf(errDummy().Trace(), fmt.Sprintf("Object lock configuration is enabled on the specified bucket in alias %v.", urlStr))
 		}
 	}
 

--- a/cmd/retention-clear.go
+++ b/cmd/retention-clear.go
@@ -132,7 +132,7 @@ func mainRetentionClear(cliCtx *cli.Context) error {
 
 	target, versionID, rewind, withVersions, recursive, bucketMode := parseClearRetentionArgs(cliCtx)
 
-	checkObjectLockSupport(ctx, target)
+	fatalIfBucketLockNotEnabled(ctx, target)
 
 	if bucketMode {
 		return clearBucketLock(target)

--- a/cmd/retention-info.go
+++ b/cmd/retention-info.go
@@ -382,7 +382,7 @@ func mainRetentionInfo(cliCtx *cli.Context) error {
 
 	target, versionID, recursive, rewind, withVersions, bucketMode := parseInfoRetentionArgs(cliCtx)
 
-	checkObjectLockSupport(ctx, target)
+	fatalIfBucketLockNotEnabled(ctx, target)
 
 	if bucketMode {
 		return showBucketLock(target)

--- a/cmd/retention-set.go
+++ b/cmd/retention-set.go
@@ -147,7 +147,7 @@ func mainRetentionSet(cliCtx *cli.Context) error {
 
 	target, versionID, recursive, rewind, withVersions, mode, validity, unit, bypass, bucketMode := parseSetRetentionArgs(cliCtx)
 
-	checkObjectLockSupport(ctx, target)
+	fatalIfBucketLockNotEnabled(ctx, target)
 
 	if bucketMode {
 		return setBucketLock(target, mode, validity, unit)


### PR DESCRIPTION
A recent commit changed the behavior of client-s3.GetObjectLockConfig()
without properly checking the behavior of the callers introducing a bug
during mv command where the target is an S3 server.

Add some tests for mc mv command as well.

Fixes #4014 