### PR TITLE
svcacct: Show successful message after deletion

### DIFF
--- a/cmd/admin-user-svcacct-rm.go
+++ b/cmd/admin-user-svcacct-rm.go
@@ -18,8 +18,10 @@
 package cmd
 
 import (
+	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/console"
 )
 
 var adminUserSvcAcctRemoveCmd = cli.Command{
@@ -54,6 +56,8 @@ func checkAdminUserSvcAcctRemoveSyntax(ctx *cli.Context) {
 
 // mainAdminUserSvcAcctRemove is the handle for "mc admin user svcacct rm" command.
 func mainAdminUserSvcAcctRemove(ctx *cli.Context) error {
+	console.SetColor("SVCMessage", color.New(color.FgGreen))
+
 	checkAdminUserSvcAcctRemoveSyntax(ctx)
 
 	// Get the alias parameter from cli
@@ -69,7 +73,7 @@ func mainAdminUserSvcAcctRemove(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to remove a new service account")
 
 	printMsg(svcAcctMessage{
-		op:        "ls",
+		op:        "rm",
 		AccessKey: svcAccount,
 	})
 


### PR DESCRIPTION
Fix some typo which prevented the command to print a success message
when a service account is deleted.