### PR TITLE
Error handling for remove alias request if alias not found 

### DIFF
--- a/cmd/alias-remove.go
+++ b/cmd/alias-remove.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"github.com/fatih/color"
 	"github.com/minio/cli"
-	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/pkg/console"
 )
 
@@ -81,13 +80,13 @@ func mainAliasRemove(ctx *cli.Context, deprecated bool) error {
 	return nil
 }
 
-// isAliasIn is a helper function that checks if a given alias is present in Aliases array, returns error if not found
-func isAliasIn(alias string) *probe.Error {
+// aliasMustExist confirms that a given alias is present in Aliases array, returns error if not found
+
+func aliasMustExist(alias string) {
 	hostConfig := mustGetHostConfig(alias)
 	if hostConfig == nil {
 		fatalIf(errInvalidAliasedURL(alias), "No such alias `"+alias+"` found.")
 	}
-	return nil
 }
 
 // removeAlias - removes an alias.
@@ -96,9 +95,8 @@ func removeAlias(alias string) aliasMessage {
 	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config version `"+globalMCConfigVersion+"`.")
 
 	// check if alias is valid
-	err = isAliasIn(alias)
+	aliasMustExist(alias)
 
-	fatalIf(err.Trace(alias), alias+" not found in the configuration file. Please confirm the alias name you are trying to remove. You can use mc alias list to view a list of all aliases configured.")
 	// Remove the alias from the config.
 	delete(conf.Aliases, alias)
 

--- a/cmd/alias-remove.go
+++ b/cmd/alias-remove.go
@@ -97,7 +97,7 @@ func removeAlias(alias string) aliasMessage {
 	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config version `"+globalMCConfigVersion+"`.")
 
 	err = isAliasIn(alias, conf.Aliases)
-	fatalIf(err.Trace(alias), alias+"not found in this instances configuration file. Please confirm the alias name you are trying to remove. You can use mc alias list to view a list of all aliases configured on this instance.")
+	fatalIf(err.Trace(alias), alias+" not found in the configuration file. Please confirm the alias name you are trying to remove. You can use mc alias list to view a list of all aliases configured.")
 	// Remove the alias from the config.
 	delete(conf.Aliases, alias)
 

--- a/cmd/alias-remove.go
+++ b/cmd/alias-remove.go
@@ -83,13 +83,12 @@ func mainAliasRemove(ctx *cli.Context, deprecated bool) error {
 	return nil
 }
 
-//isAliasIn is a helper function that checks if a given alias is present in Aliases array, returns error if not found
+// isAliasIn is a helper function that checks if a given alias is present in Aliases array, returns error if not found
 func isAliasIn(alias string, aliasMap map[string]aliasConfigV10) *probe.Error {
 	if _, ok := aliasMap[alias]; ok {
 		return nil
-	} else {
-		return probe.NewError(errors.New("Alias not found in alias list"))
 	}
+	return probe.NewError(errors.New("Alias not found in alias list"))
 }
 
 // removeAlias - removes an alias.

--- a/cmd/alias-remove.go
+++ b/cmd/alias-remove.go
@@ -96,7 +96,7 @@ func removeAlias(alias string) aliasMessage {
 	conf, err := loadMcConfig()
 	fatalIf(err.Trace(globalMCConfigVersion), "Unable to load config version `"+globalMCConfigVersion+"`.")
 
-	//check if alias is valid
+	// check if alias is valid
 	err = isAliasIn(alias)
 
 	fatalIf(err.Trace(alias), alias+" not found in the configuration file. Please confirm the alias name you are trying to remove. You can use mc alias list to view a list of all aliases configured.")

--- a/cmd/alias-remove.go
+++ b/cmd/alias-remove.go
@@ -86,7 +86,6 @@ func isAliasIn(alias string) *probe.Error {
 	hostConfig := mustGetHostConfig(alias)
 	if hostConfig == nil {
 		fatalIf(errInvalidAliasedURL(alias), "No such alias `"+alias+"` found.")
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, `mc alias remove thisalias` would return a success message even if `thisalias` was not an existing alias. This checks if the requested alias is present in the configuration file, and if not, throws an appropriate error message.  