### PR TITLE
mirror: Do not exit upon errors when --watch is passed

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -510,11 +510,13 @@ func (mj *mirrorJob) monitorMirrorStatus(cancel context.CancelFunc) (errDuringMi
 				errDuringMirror = true
 			}
 
-			if mj.opts.activeActive {
+			// Do not quit mirroring if we are in --watch or --active-active mode
+			if !mj.opts.activeActive && !mj.opts.isWatch {
 				cancel()
 				cancelInProgress = true
-				continue
 			}
+
+			continue
 		}
 
 		if sURLs.SourceContent != nil {


### PR DESCRIPTION
Currently, when mirror is not able to copy an object (e.g. corrupted)
and watch is specified, mirror will restart mirroring again to stop
again at the same problematic object.

This commit will not abort mirroring when --watch is specified, to
continue mirroring the rest of the object. An error message will still
be printed.