### PR TITLE
Compute bucket/object correctly for some endpoints

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -514,7 +514,7 @@ func (f *fsClient) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 			}
 			e := deleteFile(f.PathURL.Path, name)
 			if e == nil {
-				_, objectName := url2BucketAndObject(&content.URL, false)
+				_, objectName := url2BucketAndObject(&content.URL)
 				res := RemoveResult{}
 				res.ObjectName = objectName
 				resultCh <- res

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1650,37 +1650,14 @@ func isVirtualHostStyle(host string, lookup minio.BucketLookupType) bool {
 	return isAmazon(host) && !isAmazonChina(host) || isGoogle(host) || isAmazonAccelerated(host)
 }
 
-func url2BucketAndObject(u *ClientURL, virtualStyle bool) (bucketName, objectName string) {
-	path := u.Path
-	// Convert any virtual host styled requests.
-	//
-	// For the time being this check is introduced for S3,
-	// If you have custom virtual styled hosts please.
-	// List them below.
-	if virtualStyle {
-		var bucket string
-		hostIndex := strings.Index(u.Host, "s3")
-		if hostIndex != -1 && !matchS3InHost(u.Host) {
-			hostIndex = -1
-		}
-		if hostIndex == -1 {
-			hostIndex = strings.Index(u.Host, "s3-accelerate")
-		}
-		if hostIndex == -1 {
-			hostIndex = strings.Index(u.Host, "storage.googleapis")
-		}
-		if hostIndex > 0 {
-			bucket = u.Host[:hostIndex-1]
-			path = string(u.Separator) + bucket + u.Path
-		}
-	}
-	tokens := splitStr(path, string(u.Separator), 3)
+func url2BucketAndObject(u *ClientURL) (bucketName, objectName string) {
+	tokens := splitStr(u.Path, string(u.Separator), 3)
 	return tokens[1], tokens[2]
 }
 
 // url2BucketAndObject gives bucketName and objectName from URL path.
 func (c *S3Client) url2BucketAndObject() (bucketName, objectName string) {
-	return url2BucketAndObject(c.targetURL, c.virtualStyle)
+	return url2BucketAndObject(c.targetURL)
 }
 
 // splitPath split path into bucket and object.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -405,23 +404,6 @@ func parseAttribute(meta map[string]string) (map[string]string, error) {
 	}
 
 	return attribute, nil
-}
-
-// Returns true if "s3" is entirely in sub-domain and false otherwise.
-// true for s3.amazonaws.com, false for ams3.digitaloceanspaces.com, 192.168.1.12
-func matchS3InHost(urlHost string) bool {
-	if strings.Contains(urlHost, ":") {
-		if host, _, err := net.SplitHostPort(urlHost); err == nil {
-			urlHost = host
-		}
-	}
-	fqdnParts := strings.Split(urlHost, ".")
-	for _, fqdn := range fqdnParts {
-		if fqdn == "s3" {
-			return true
-		}
-	}
-	return false
 }
 
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"


### PR DESCRIPTION
Removing an old code that calculates incorrectly the bucket and object
from the client-s3.targetURL. The old code assumed that
client-s3.targetURL can have this style
http://bucket.endpoint/prefix/object but this is not true.

client-s3.targetURL will always have this endpoint style
https://endpoint/bucket/object whenever vhost is enabled or not for a
given alias.

Fixes #4036 