### PR TITLE
Updating the "rb" warning to be more obvious

### DIFF
--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -110,7 +110,7 @@ func checkRbSyntax(ctx context.Context, cliCtx *cli.Context) {
 				continue
 			}
 			fatalIf(errDummy().Trace(),
-				"This operation results in **site-wide** removal of buckets. If you are really sure, retry this command with ‘--force’ and ‘--dangerous’ flags.")
+				"This operation results in the *permanent deletion of ALL BUCKETS* in this account! If you are really sure, retry this command with ‘--force’ and ‘--dangerous’ flags.")
 		}
 	}
 }


### PR DESCRIPTION
When I read this the first time, I thought it was saying it would remove all objects in the bucket and the bucket itself ("remove bucket"). I did NOT understand it to mean that it would remove ALL buckets in the account and so cheerfully added the force and dangerous flags!!

Fortunately, they were all test buckets, but can you imagine if I had run this on a production account? Yikes! So this is a simple patch to just change the language a little bit to make it more obvious. If a non-native English speaker can think of a simpler way to word this, even better.

(thank you for mc, great tool!)