### PR TITLE
Add mutex, threads and cpuio as default in profiling

### DIFF
--- a/cmd/support-profile-start.go
+++ b/cmd/support-profile-start.go
@@ -31,7 +31,7 @@ var supportProfileStartFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "type",
 		Usage: "start profiler type, possible values are 'cpu', 'cpuio' 'mem', 'block', 'mutex', 'trace', 'threads' and 'goroutines'",
-		Value: "cpu,mem,block,goroutines",
+		Value: "cpu,cpuio,mem,block,mutex,threads,goroutines",
 	},
 }
 


### PR DESCRIPTION
The default values for profiling were `cpu,mem,block,goroutines` , with this PR `mutex, threads and cpuio` are also added as default . 

**Steps 1.**
Run minio in distributed mode 
```
export MINIO_CI_CD=1
./minio  server /tmp/{1...4}
Automatically configured API requests per node based on available memory on the system: 313
Status:         4 Online, 0 Offline. 
API: http://192.168.1.12:9000  http://172.17.0.1:9000  http://192.168.122.1:9000  http://127.0.0.1:9000     
RootUser: minioadmin 
RootPass: minioadmin 

Console: http://192.168.1.12:42025 http://172.17.0.1:42025 http://192.168.122.1:42025 http://127.0.0.1:42025   
RootUser: minioadmin 
RootPass: minioadmin 

Command-line: https://docs.min.io/docs/minio-client-quickstart-guide
   $ mc alias set myminio http://192.168.1.12:9000 minioadmin minioadmin

Documentation: https://docs.min.io
```
**Step 2**
Check the zip folder after the profile is downloaded using the command 
``` 
./mc support profile start myminio &&  sleep 10 && ./mc support profile stop myminio
```
**Step 3**
After unzipping 
```
ashish@ashish:~/code/go/src/github/minio/minio$ ls ~/Desktop/profile
 profile-127.0.0.1:9000-block.pprof
 profile-127.0.0.1:9000-cpu.pprof
'profile-127.0.0.1:9000-goroutines-before,debug=2.txt'
 profile-127.0.0.1:9000-goroutines-before.txt
 profile-127.0.0.1:9000-goroutines.txt
 profile-127.0.0.1:9000-mem-before.pprof
 profile-127.0.0.1:9000-mem.pprof
 profile-127.0.0.1:9000-mutex-before.pprof
 profile-127.0.0.1:9000-mutex.pprof
 profile-127.0.0.1:9000-threads-before.pprof
 profile-127.0.0.1:9000-threads.pprof
```

Debug o/p 
```
./mc support profile start myminio  --debug
mc: <DEBUG> POST /minio/admin/v3/profiling/start?profilerType=cpu%2Ccpuio%2Cmem%2Cblock%2Cmutex%2Cthreads%2Cgoroutines HTTP/1.1
Host: 192.168.1.12:9000
User-Agent: MinIO (linux; amd64) madmin-go/0.0.1 mc/DEVELOPMENT.2022-04-12T05-36-58Z
Transfer-Encoding: chunked
Authorization: AWS4-HMAC-SHA256 Credential=minioadmin/20220412//s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=**REDACTED**
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20220412T053901Z
Accept-Encoding: gzip

mc: <DEBUG> HTTP/1.1 200 OK
Content-Length: 422
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Content-Type: application/json
Date: Tue, 12 Apr 2022 05:39:01 GMT
Server: MinIO
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin
Vary: Accept-Encoding
X-Amz-Request-Id: 16E50F8E17EBE58B
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block

mc: <DEBUG> Response Time:  272.187654ms

mc: Profile data successfully started.
```