### PR TITLE
Load proxy config when probing for server TLS certificate

### DIFF
--- a/cmd/alias-set.go
+++ b/cmd/alias-set.go
@@ -378,6 +378,7 @@ func promptTrustSelfSignedCert(ctx context.Context, endpoint, alias string) (*x5
 
 	client := http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: globalRootCAs, // make sure to use loaded certs before probing
 			},


### PR DESCRIPTION
mc alias set recently started to probe the TLS certificate for
the remote server, however it should load the proxy environment
configuration if any.