### PR TITLE
mirror: Do not create remote bucket with --dry-run

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -946,6 +946,16 @@ func runMirror(ctx context.Context, cancelMirror context.CancelFunc, srcURL, dst
 						withLock = true
 					}
 				}
+
+				mj.status.PrintMsg(mirrorMessage{
+					Source: newSrcURL,
+					Target: newTgtURL,
+				})
+
+				if mj.opts.isFake {
+					continue
+				}
+
 				// Bucket only exists in the source, create the same bucket in the destination
 				if err := newDstClt.MakeBucket(ctx, cli.String("region"), false, withLock); err != nil {
 					errorIf(err, "Unable to create bucket at `"+newTgtURL+"`.")


### PR DESCRIPTION
In a site wide mirroring, non existing buckets in the destination site
are still created if --dry-run is passed. This commit will avoid this.

This commit also prints a mirror message of the newly created buckets
in a site wide mirroring.