### PR TITLE
Error message when update failing due to permissions

### DIFF
--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -463,8 +463,8 @@ func doUpdate(sha256Hex string, latestReleaseTime time.Time, ok bool) (updateSta
 		opts.Verifier = v
 	}
 
-	if err := opts.CheckPermissions(); err != nil {
-		permErrMsg := fmt.Sprintf(" failed with: %s", err)
+	if e := opts.CheckPermissions(); e != nil {
+		permErrMsg := fmt.Sprintf(" failed with: %s", e)
 		updateStatusMsg = colorYellowBold("mc update to version RELEASE.%s %s.",
 			fmtReleaseTime, permErrMsg)
 		return updateStatusMsg, nil

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -484,10 +484,11 @@ func doUpdate(sha256Hex string, latestReleaseTime time.Time, ok bool) (updateSta
 				fmtReleaseTime, pathErrMsg)
 			return updateStatusMsg, nil
 		}
+
+		return colorYellowBold(fmt.Sprintf("Error in mc update to version RELEASE.%s %v.", fmtReleaseTime, e)), nil
 	}
 
-	return colorGreenBold("mc updated to version RELEASE.%s successfully.",
-		fmtReleaseTime), nil
+	return colorGreenBold("mc updated to version RELEASE.%s successfully.", fmtReleaseTime), nil
 }
 
 type updateMessage struct {


### PR DESCRIPTION
Error message when update failing due to permissions

Local build/test reference PR : `https://github.com/minio/mc/pull/3782`

Build this PR for an older date:

```
GO111MODULE=on CGO_ENABLED=0 go build -trimpath -tags kqueue --ldflags '-s -w -X github.com/minio/mc/cmd.Version=2022-02-20T11:30:12Z -X github.com/minio/mc/cmd.ReleaseTag=DEVELOPMENT.2022-02-20T11:30:12Z -X github.com/minio/mc/cmd.CommitID=6a000d9e93fc1a749a147d539907bcad0a84929f -X github.com/minio/mc/cmd.ShortCommitID=6a000d9e93fc1a749a147d539907bcad0a84929f' -o /home/prakash/go/src/github.com/minio/mc/mc
```

After building change permission of `/home/prakash/go/src/github.com/minio/mc`

e.g: `chmod 0555 /home/prakash/go/src/github.com/minio/mc`

Run: 
`/home/prakash/go/src/github.com/minio/mc/mc update`

Result e.g:
```
mc update to version RELEASE.2022-04-16T21-11-21Z  failed with: open /home/prakash/go/src/github.com/minio/mc/.mc.new: permission denied.
```

Later to check the real upgrade:
```
 /home/prakash/go/src/github.com/minio/mc/mc --version
mc version DEVELOPMENT.2022-02-20T11:30:12Z
```

`chmod 755 /home/prakash/go/src/github.com/minio/mc`
`/home/prakash/go/src/github.com/minio/mc/mc update`
`mc updated to version RELEASE.2022-04-16T21-11-21Z successfully.`

```
/home/prakash/go/src/github.com/minio/mc/mc --version
mc version RELEASE.2022-04-16T21-11-21Z
```


