### PR TITLE
trace: Show milliseconds in trace output

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -111,7 +111,7 @@ EXAMPLES:
 `,
 }
 
-const timeFormat = "2006-01-02T15:04:05:000"
+const traceTimeFormat = "2006-01-02T15:04:05.000"
 
 var colors = []color.Attribute{color.FgCyan, color.FgWhite, color.FgYellow, color.FgGreen}
 
@@ -439,7 +439,7 @@ func (s shortTraceMsg) String() string {
 	if s.Host != "" {
 		hostStr = colorizedNodeName(s.Host)
 	}
-	fmt.Fprintf(b, "%s ", s.Time.Local().Format(timeFormat))
+	fmt.Fprintf(b, "%s ", s.Time.Local().Format(traceTimeFormat))
 
 	switch s.trcType {
 	case madmin.TraceStorage:
@@ -563,17 +563,17 @@ func (t traceMessage) String() string {
 
 	switch trc.TraceType {
 	case madmin.TraceStorage:
-		fmt.Fprintf(b, "%s %s [%s] %s %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[STORAGE %s]", trc.FuncName)), trc.Time.Local().Format(timeFormat), trc.StorageStats.Path, trc.StorageStats.Duration)
+		fmt.Fprintf(b, "%s %s [%s] %s %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[STORAGE %s]", trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.StorageStats.Path, trc.StorageStats.Duration)
 		return b.String()
 	case madmin.TraceOS:
-		fmt.Fprintf(b, "%s %s [%s] %s %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[OS %s]", trc.FuncName)), trc.Time.Local().Format(timeFormat), trc.OSStats.Path, trc.OSStats.Duration)
+		fmt.Fprintf(b, "%s %s [%s] %s %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[OS %s]", trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.OSStats.Path, trc.OSStats.Duration)
 		return b.String()
 	}
 
 	ri := trc.ReqInfo
 	rs := trc.RespInfo
 	fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[REQUEST %s] ", trc.FuncName)))
-	fmt.Fprintf(b, "[%s] %s\n", ri.Time.Local().Format(timeFormat), console.Colorize("Host", fmt.Sprintf("[Client IP: %s]", ri.Client)))
+	fmt.Fprintf(b, "[%s] %s\n", ri.Time.Local().Format(traceTimeFormat), console.Colorize("Host", fmt.Sprintf("[Client IP: %s]", ri.Client)))
 	fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("Method", fmt.Sprintf("%s %s", ri.Method, ri.Path)))
 	if ri.RawQuery != "" {
 		fmt.Fprintf(b, "?%s", ri.RawQuery)
@@ -593,7 +593,7 @@ func (t traceMessage) String() string {
 
 	fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("Body", fmt.Sprintf("%s\n", string(ri.Body))))
 	fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("Response", "[RESPONSE] "))
-	fmt.Fprintf(b, "[%s] ", rs.Time.Local().Format(timeFormat))
+	fmt.Fprintf(b, "[%s] ", rs.Time.Local().Format(traceTimeFormat))
 	fmt.Fprint(b, console.Colorize("Stat", fmt.Sprintf("[ Duration %2s  ↑ %s  ↓ %s ]\n", trc.CallStats.Latency.Round(time.Microsecond), humanize.IBytes(uint64(trc.CallStats.InputBytes)), humanize.IBytes(uint64(trc.CallStats.OutputBytes)))))
 
 	statusStr := console.Colorize("RespStatus", fmt.Sprintf("%d %s", rs.StatusCode, http.StatusText(rs.StatusCode)))


### PR DESCRIPTION
Trace output without --verbose was always missing milliseconds precision
due to a typo in the code. This commit fixes the issue.