### PR TITLE
Hide `mc support callhome` command

### DIFF
--- a/cmd/support-callhome.go
+++ b/cmd/support-callhome.go
@@ -33,6 +33,7 @@ var supportCallhomeCmd = cli.Command{
 	Action:       mainCallhome,
 	Before:       setGlobalsFromContext,
 	Flags:        globalFlags,
+	Hidden:       true,
 	Subcommands:  callhomeSubcommands,
 }
 


### PR DESCRIPTION
As the functionality is not fully ready yet.