### PR TITLE
Deprecate --name flag from `support diag`

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -46,10 +46,6 @@ const (
 )
 
 var subnetCommonFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "name",
-		Usage: "Specify the name to associate to this MinIO cluster in SUBNET",
-	},
 	cli.BoolFlag{
 		Name:  "airgap",
 		Usage: "Use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",

--- a/cmd/support-register.go
+++ b/cmd/support-register.go
@@ -29,13 +29,20 @@ import (
 	"github.com/minio/pkg/console"
 )
 
+var supportRegisterFlags = append([]cli.Flag{
+	cli.StringFlag{
+		Name:  "name",
+		Usage: "Specify the name to associate to this MinIO cluster in SUBNET",
+	},
+}, subnetCommonFlags...)
+
 var supportRegisterCmd = cli.Command{
 	Name:         "register",
 	Usage:        "register with MinIO subscription network",
 	OnUsageError: onUsageError,
 	Action:       mainSupportRegister,
 	Before:       setGlobalsFromContext,
-	Flags:        append(subnetCommonFlags, globalFlags...),
+	Flags:        append(supportRegisterFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/go.sum
+++ b/go.sum
@@ -62,7 +62,6 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/briandowns/spinner v1.18.1 h1:yhQmQtM1zsqFsouh09Bk/jCjd50pC3EOGsh28gLVvwY=
 github.com/briandowns/spinner v1.18.1/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -274,7 +273,6 @@ github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -345,7 +343,6 @@ github.com/minio/colorjson v1.0.2/go.mod h1:JWxcL2n8T8JVf+NY6awl6kn5nK49aAzHOeQE
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
-github.com/minio/madmin-go v1.3.11/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/madmin-go v1.3.13 h1:157u3bFK9qh2EkkqjpJ/bwOw/5KonXUWqhKP3ZczAdY=
 github.com/minio/madmin-go v1.3.13/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=


### PR DESCRIPTION
Earlier the `support diag` command used to work even when the cluster
was not registered with SUBNET. In such cases, it used to pass the value
of `--name` flag as the cluster name to be set on SUBNET.

Now it errors out if the cluster is not registered. i.e. It expects the
cluster to be already registered with SUBNET, which means it already has
a name. Hence the `--name` flag is meaningless.

Removing the code that used this flag, and marking it as hidden and
deprecated.