### PR TITLE
alias: Enable self signed TLS prompt in darwin platforms

### DIFF
--- a/cmd/tofu.go
+++ b/cmd/tofu.go
@@ -102,7 +102,8 @@ func promptTrustSelfSignedCert(ctx context.Context, endpoint, alias string) (*x5
 		return nil, nil
 	}
 
-	if te != nil && !strings.Contains(te.Error(), "certificate signed by unknown authority") {
+	if te != nil && !strings.Contains(te.Error(), "certificate signed by unknown authority") &&
+		!strings.Contains(te.Error(), "certificate is not trusted") /* darwin specific error message */ {
 		return nil, probe.NewError(te)
 	}
 


### PR DESCRIPTION
Not trusted TLS error message has another string representation in
Darwin platform. Since there is no another way to test for this specific
error with Golang API, we will need to support this alternate error message.