### PR TITLE
Add admin bucket info command

### DIFF
--- a/cmd/admin-bucket-info.go
+++ b/cmd/admin-bucket-info.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	humanize "github.com/dustin/go-humanize"
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/madmin-go"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/console"
+)
+
+var adminBucketInfoFlags = []cli.Flag{}
+
+type adminBucketInfoMessage struct {
+	Status    string                 `json:"status"`
+	URL       string                 `json:"url"`
+	UsageInfo madmin.BucketUsageInfo `json:"usage"`
+	Props     BucketInfo             `json:"props"`
+}
+
+func (bi adminBucketInfoMessage) String() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, console.Colorize("Title", "Usage:\n"))
+
+	fmt.Fprintf(&b, "%16s: %s\n", "Total size", console.Colorize("Count", humanize.IBytes(bi.UsageInfo.Size)))
+	fmt.Fprintf(&b, "%16s: %s\n", "Objects count", console.Colorize("Count", humanize.Comma(int64(bi.UsageInfo.ObjectsCount))))
+	fmt.Fprintf(&b, "%16s: %s\n", "Versions count", console.Colorize("Count", humanize.Comma(int64(bi.UsageInfo.VersionsCount))))
+	fmt.Fprintf(&b, "\n")
+
+	fmt.Fprintf(&b, console.Colorize("Title", "Properties:\n"))
+	fmt.Fprintf(&b, prettyPrintBucketMetadata(bi.Props))
+	return b.String()
+}
+
+func (bi adminBucketInfoMessage) JSON() string {
+	jsonMessageBytes, e := json.MarshalIndent(bi, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(jsonMessageBytes)
+}
+
+var adminBucketInfoCmd = cli.Command{
+	Name:         "info",
+	Usage:        "display bucket information",
+	Action:       mainAdminBucketInfo,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        append(adminBucketInfoFlags, globalFlags...),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Display the usage data and configuration of a bucket on MinIO.
+     {{.Prompt}} {{.HelpName}} myminio/mybucket
+`,
+}
+
+// checkAdminBucketInfoSyntax - validate all the passed arguments
+func checkAdminBucketInfoSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+	}
+}
+
+// mainAdminBucketInfo is the handler for "mc admin bucket info" command.
+func mainAdminBucketInfo(ctx *cli.Context) error {
+	checkAdminBucketInfoSyntax(ctx)
+
+	console.SetColor("Title", color.New(color.Bold, color.FgBlue))
+	console.SetColor("Count", color.New(color.FgGreen))
+	console.SetColor("Metadata", color.New(color.FgWhite))
+	console.SetColor("Key", color.New(color.FgCyan))
+	console.SetColor("Value", color.New(color.FgYellow))
+	console.SetColor("Unset", color.New(color.FgRed))
+	console.SetColor("Set", color.New(color.FgGreen))
+
+	// Get the alias parameter from cli
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	adminClient, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	s3Client, err := newClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	aliasedURL = filepath.ToSlash(aliasedURL)
+	splits := splitStr(aliasedURL, "/", 3)
+	bucket := splits[1]
+
+	duinfo, e := adminClient.DataUsageInfo(globalContext)
+	fatalIf(probe.NewError(e).Trace(args...), "Unable to get data usage")
+
+	bi, err := s3Client.GetBucketInfo(globalContext)
+	fatalIf(err.Trace(args...), "Unable to get bucket properties")
+
+	bu, ok := duinfo.BucketsUsage[bucket]
+	if !ok {
+		fatalIf(errDummy().Trace(args...), "Unable to get bucket usage info. Bucket usage is not ready yet.")
+	}
+
+	printMsg(adminBucketInfoMessage{
+		Status:    "success",
+		URL:       aliasedURL,
+		UsageInfo: bu,
+		Props:     bi,
+	})
+
+	return nil
+}

--- a/cmd/admin-bucket.go
+++ b/cmd/admin-bucket.go
@@ -22,6 +22,7 @@ import "github.com/minio/cli"
 var adminBucketSubcommands = []cli.Command{
 	adminBucketRemoteCmd,
 	adminBucketQuotaCmd,
+	adminBucketInfoCmd,
 }
 
 var adminBucketCmd = cli.Command{

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -391,6 +391,7 @@ var completeCmds = map[string]complete.Predictor{
 	"/admin/bucket/remote/rm":        aliasCompleter,
 	"/admin/bucket/remote/bandwidth": aliasCompleter,
 	"/admin/bucket/quota":            aliasCompleter,
+	"/admin/bucket/info":             s3Complete{deepLevel: 2},
 
 	"/admin/kms/key/create": aliasCompleter,
 	"/admin/kms/key/status": aliasCompleter,

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -352,6 +352,14 @@ func (v bucketInfoMessage) String() string {
 	}()
 	fmt.Fprintf(&b, fmt.Sprintf("%-10s: %s \n", "Type", fType))
 	fmt.Fprintf(&b, fmt.Sprintf("%-10s:\n", "Metadata"))
+
+	fmt.Fprintf(&b, prettyPrintBucketMetadata(info))
+	return b.String()
+}
+
+// Pretty print bucket configuration - used by stat and admin bucket info as well
+func prettyPrintBucketMetadata(info BucketInfo) string {
+	var b strings.Builder
 	placeHolder := ""
 	if info.Encryption.Algorithm != "" {
 		fmt.Fprintf(&b, "%2s%s", placeHolder, "Encryption: ")
@@ -370,7 +378,7 @@ func (v bucketInfoMessage) String() string {
 	fmt.Fprintln(&b)
 
 	if info.Locking.Mode != "" {
-		fmt.Fprintf(&b, "%2s%s", placeHolder, "LockConfiguration: ")
+		fmt.Fprintf(&b, "%2s%s\n", placeHolder, "LockConfiguration: ")
 		fmt.Fprintf(&b, "%4s%s", placeHolder, "RetentionMode: ")
 		fmt.Fprintf(&b, console.Colorize("Value", info.Locking.Mode))
 		fmt.Fprintln(&b)

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -271,6 +272,7 @@ github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -340,6 +342,7 @@ github.com/minio/colorjson v1.0.2/go.mod h1:JWxcL2n8T8JVf+NY6awl6kn5nK49aAzHOeQE
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
+github.com/minio/madmin-go v1.3.11/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/madmin-go v1.4.5 h1:Y9LnZdDhv+tA2BAnGHB523NSeBZCkWe+bdMTxFkpi1A=
 github.com/minio/madmin-go v1.4.5/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=


### PR DESCRIPTION
Print bucket usage and configuration (encryption, policy, ILM, etc..)

e.g:

```
$ mc admin bucket info myminio/testbucket/
Usage:
      Total size: 17 MiB
   Objects count: 63
  Versions count: 63

Properties:
  Encryption: 
        Algorithm: AES256
        Key ID: 
  Versioning: Enabled
  LockConfiguration: 
    RetentionMode: GOVERNANCE
    Retention Until Date: 30DAYS
  Location: us-east-1
  Policy: readwrite
  ILM: Set
```