### PR TITLE
ignore remove errors for WORM protected objects

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -53,7 +53,6 @@ var adminTraceFlags = []cli.Flag{
 		Name:  "response-threshold",
 		Usage: "trace calls only with response duration greater than this threshold (e.g. `5ms`)",
 	},
-
 	cli.IntSliceFlag{
 		Name:  "status-code",
 		Usage: "trace only matching status code",

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -536,10 +536,14 @@ func listAndRemove(url string, opts removeOpts) error {
 					if result.Err != nil {
 						errorIf(result.Err.Trace(path),
 							"Failed to remove `"+path+"`.")
-						switch result.Err.ToGoError().(type) {
+						switch e := result.Err.ToGoError().(type) {
 						case PathInsufficientPermission:
 							// Ignore Permission error.
 							continue
+						case minio.ErrorResponse:
+							if strings.Contains(e.Message, "Object is WORM protected and cannot be overwritten") {
+								continue
+							}
 						}
 						close(contentCh)
 						return exitStatus(globalErrorExitStatus)


### PR DESCRIPTION
this error is similar to insufficient permission
on local folders, we can proceed to remove whatever
objects we can.