### PR TITLE
Fix replicate rm example

### DIFF
--- a/cmd/replicate-rm.go
+++ b/cmd/replicate-rm.go
@@ -62,10 +62,10 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Remove replication configuration rule on bucket "mybucket" for alias "myminio" with rule id "bsib5mgt874bi56l0fmg".
-     {{.Prompt}} {{.HelpName}} --id "bsib5mgt874bi56l0fmg" myminio/mybucket
+     {{.Prompt}} {{.HelpName}} myminio/mybucket --id "bsib5mgt874bi56l0fmg"
 
   2. Remove all the replication configuration rules on bucket "mybucket" for alias "myminio". --force flag is required.
-     {{.Prompt}} {{.HelpName}} --all --force myminio/mybucket
+     {{.Prompt}} {{.HelpName}} myminio/mybucket --all --force
 `,
 }
 


### PR DESCRIPTION
Current example is misleading, as the order doesn't work - Replication ID should come after target bucket.

doesn't work:
```
# ./mc replicate rm --id "cab086jl15hqjo2npgqg" tenant2/replication-source1 --insecure 
NAME:
  mc replicate rm - remove a server side replication configuration rule
   
USAGE:
  mc replicate rm TARGET
     
FLAGS:
  --config-dir value, -C value  path to configuration folder (default: "/root/.mc")
  --quiet, -q                   disable progress bar display
  --no-color                    disable color theme
  --json                        enable JSON lines formatted output
  --debug                       enable debug output
  --insecure                    disable SSL certificate verification
  --id value                    id for the rule, should be a unique value
  --force                       force remove all the replication configuration rules on the bucket
  --all                         remove all replication configuration rules of the bucket, force flag enforced
  --help, -h                    show help
  
EXAMPLES:
  1. Remove replication configuration rule on bucket "mybucket" for alias "myminio" with rule id "bsib5mgt874bi56l0fmg".
     $ mc replicate rm --id "bsib5mgt874bi56l0fmg" myminio/mybucket

  2. Remove all the replication configuration rules on bucket "mybucket" for alias "myminio". --force flag is required.
     $ mc replicate rm --all --force myminio/mybucket
```

works:
```
# ./mc replicate rm tenant2/replication-source1 --id "cab086jl15hqjo2npgqg"  --insecure 
Replication configuration rule with ID `cab086jl15hqjo2npgqg`removed from tenant2/replication-source1.
```