### PR TITLE
Update version printing to include more information

### DIFF
--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -28,10 +28,15 @@ import (
 	"time"
 )
 
-func genLDFlags(version string) string {
+func genLDFlags(now time.Time) string {
+	version := now.Format(time.RFC3339)
+	releaseTag := releaseTag(version)
+	copyrightYear := fmt.Sprintf("%d", now.Year())
+
 	var ldflagsStr string
 	ldflagsStr = "-s -w -X github.com/minio/mc/cmd.Version=" + version + " "
-	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.ReleaseTag=" + releaseTag(version) + " "
+	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.CopyrightYear=" + copyrightYear + " "
+	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.ReleaseTag=" + releaseTag + " "
 	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.CommitID=" + commitID() + " "
 	ldflagsStr = ldflagsStr + "-X github.com/minio/mc/cmd.ShortCommitID=" + commitID()[:12]
 	return ldflagsStr
@@ -68,5 +73,5 @@ func commitID() string {
 }
 
 func main() {
-	fmt.Println(genLDFlags(time.Now().UTC().Format(time.RFC3339)))
+	fmt.Println(genLDFlags(time.Now().UTC()))
 }

--- a/cmd/build-constants.go
+++ b/cmd/build-constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 MinIO, Inc.
+// Copyright (c) 2015-2022 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -26,4 +26,6 @@ var (
 	CommitID = "DEVELOPMENT.GOGET"
 	// ShortCommitID - first 12 characters from CommitID.
 	ShortCommitID = CommitID[:12]
+	// CopyrightYear - dynamic value of the copyright end year
+	CopyrightYear = "0000"
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -453,11 +453,21 @@ var appCmds = []cli.Command{
 	updateCmd,
 }
 
+func printMCVersion(c *cli.Context) {
+	fmt.Fprintf(c.App.Writer, "%s version %s (commit-id=%s)\n", c.App.Name, c.App.Version, CommitID)
+	fmt.Fprintf(c.App.Writer, "Runtime: %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(c.App.Writer, "Copyright (c) 2015-%s MinIO, Inc.\n", CopyrightYear)
+	fmt.Fprintf(c.App.Writer, "Licence AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>\n")
+}
+
 func registerApp(name string) *cli.App {
 	cli.HelpFlag = cli.BoolFlag{
 		Name:  "help, h",
 		Usage: "show help",
 	}
+
+	// Override default cli version printer
+	cli.VersionPrinter = printMCVersion
 
 	app := cli.NewApp()
 	app.Name = name


### PR DESCRIPTION
Show licence, copyright header and platform in addition to mc version.

```
$ ./mc --version
mc version RELEASE.2022-06-16T17-13-07Z (darwin/arm64)
Copyright (c) 2015-2022 MinIO, Inc.
Licence AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>
```