### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/buildscripts/gen-ldflags.go
+++ b/buildscripts/gen-ldflags.go
@@ -48,9 +48,9 @@ func releaseTag(version string) (string, time.Time) {
 		relPrefix = prefix
 	}
 
-	relTag := strings.Replace(version, " ", "-", -1)
-	relTag = strings.Replace(relTag, ":", "-", -1)
-	relTag = strings.Replace(relTag, ",", "", -1)
+	relTag := strings.ReplaceAll(version, " ", "-")
+	relTag = strings.ReplaceAll(relTag, ":", "-")
+	relTag = strings.ReplaceAll(relTag, ",", "")
 	t, err := time.Parse("2006-01-02T15-04-05Z", relTag)
 	if err != nil {
 		panic(err)

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -167,7 +167,7 @@ func (u ClientURL) String() string {
 			if u.Path != "" && u.Path[0] != '\\' && u.Host != "" && u.Path[0] != '/' {
 				buf.WriteByte('/')
 			}
-			buf.WriteString(strings.Replace(u.Path, "\\", "/", -1))
+			buf.WriteString(strings.ReplaceAll(u.Path, "\\", "/"))
 		default:
 			if u.Path != "" && u.Path[0] != '/' && u.Host != "" {
 				buf.WriteByte('/')

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -324,62 +324,62 @@ func stringsReplace(ctx context.Context, args string, fileContent contentMessage
 	// replace all instances of {}
 	str := args
 	if strings.Contains(str, "{}") {
-		str = strings.Replace(str, "{}", fileContent.Key, -1)
+		str = strings.ReplaceAll(str, "{}", fileContent.Key)
 	}
 
 	// replace all instances of {""}
 	if strings.Contains(str, `{""}`) {
-		str = strings.Replace(str, `{""}`, strconv.Quote(fileContent.Key), -1)
+		str = strings.ReplaceAll(str, `{""}`, strconv.Quote(fileContent.Key))
 	}
 
 	// replace all instances of {base}
 	if strings.Contains(str, "{base}") {
-		str = strings.Replace(str, "{base}", filepath.Base(fileContent.Key), -1)
+		str = strings.ReplaceAll(str, "{base}", filepath.Base(fileContent.Key))
 	}
 
 	// replace all instances of {"base"}
 	if strings.Contains(str, `{"base"}`) {
-		str = strings.Replace(str, `{"base"}`, strconv.Quote(filepath.Base(fileContent.Key)), -1)
+		str = strings.ReplaceAll(str, `{"base"}`, strconv.Quote(filepath.Base(fileContent.Key)))
 	}
 
 	// replace all instances of {dir}
 	if strings.Contains(str, "{dir}") {
-		str = strings.Replace(str, "{dir}", filepath.Dir(fileContent.Key), -1)
+		str = strings.ReplaceAll(str, "{dir}", filepath.Dir(fileContent.Key))
 	}
 
 	// replace all instances of {"dir"}
 	if strings.Contains(str, `{"dir"}`) {
-		str = strings.Replace(str, `{"dir"}`, strconv.Quote(filepath.Dir(fileContent.Key)), -1)
+		str = strings.ReplaceAll(str, `{"dir"}`, strconv.Quote(filepath.Dir(fileContent.Key)))
 	}
 
 	// replace all instances of {size}
 	if strings.Contains(str, "{size}") {
-		str = strings.Replace(str, "{size}", humanize.IBytes(uint64(fileContent.Size)), -1)
+		str = strings.ReplaceAll(str, "{size}", humanize.IBytes(uint64(fileContent.Size)))
 	}
 
 	// replace all instances of {"size"}
 	if strings.Contains(str, `{"size"}`) {
-		str = strings.Replace(str, `{"size"}`, strconv.Quote(humanize.IBytes(uint64(fileContent.Size))), -1)
+		str = strings.ReplaceAll(str, `{"size"}`, strconv.Quote(humanize.IBytes(uint64(fileContent.Size))))
 	}
 
 	// replace all instances of {time}
 	if strings.Contains(str, "{time}") {
-		str = strings.Replace(str, "{time}", fileContent.Time.Format(printDate), -1)
+		str = strings.ReplaceAll(str, "{time}", fileContent.Time.Format(printDate))
 	}
 
 	// replace all instances of {"time"}
 	if strings.Contains(str, `{"time"}`) {
-		str = strings.Replace(str, `{"time"}`, strconv.Quote(fileContent.Time.Format(printDate)), -1)
+		str = strings.ReplaceAll(str, `{"time"}`, strconv.Quote(fileContent.Time.Format(printDate)))
 	}
 
 	// replace all instances of {url}
 	if strings.Contains(str, "{url}") {
-		str = strings.Replace(str, "{url}", getShareURL(ctx, fileContent.Key), -1)
+		str = strings.ReplaceAll(str, "{url}", getShareURL(ctx, fileContent.Key))
 	}
 
 	// replace all instances of {"url"}
 	if strings.Contains(str, `{"url"}`) {
-		str = strings.Replace(str, `{"url"}`, strconv.Quote(getShareURL(ctx, fileContent.Key)), -1)
+		str = strings.ReplaceAll(str, `{"url"}`, strconv.Quote(getShareURL(ctx, fileContent.Key)))
 	}
 
 	return str


### PR DESCRIPTION
Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.