### PR TITLE
reset timer after the function body is finished 

### DIFF
--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -147,8 +147,6 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		case <-globalContext.Done():
 			return globalContext.Err()
 		case <-timer.C:
-			timer.Reset(time.Second)
-
 			ctx, cancel := context.WithTimeout(globalContext, 3*time.Second)
 			// Fetch the service status of the specified MinIO server
 			info, e := client.ServerInfo(ctx)
@@ -168,6 +166,8 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 			default:
 				printProgress()
 			}
+
+			timer.Reset(time.Second)
 		}
 	}
 }

--- a/cmd/ready.go
+++ b/cmd/ready.go
@@ -136,7 +136,6 @@ func mainReady(cliCtx *cli.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-timer.C:
-			timer.Reset(healthCheckInterval)
 			healthResult, hErr := anonClient.Healthy(ctx, healthOpts)
 			fatalIf(probe.NewError(hErr).Trace(aliasedURL), "Couldn't get the health status for `"+aliasedURL+"`.")
 			printMsg(readyMessage{
@@ -148,6 +147,8 @@ func mainReady(cliCtx *cli.Context) error {
 			if healthResult.Healthy {
 				return nil
 			}
+
+			timer.Reset(healthCheckInterval)
 		}
 	}
 }


### PR DESCRIPTION
this is needed to make sure to wait "expected" amount
of time, otherwise the timer has already fired (negating
the wait of your function body)