### PR TITLE
fix unable to validate source error

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1589,9 +1589,9 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 
 	// No object found, start looking for a prefix with the same name
 	// or a directory marker. Add a trailing slash if it is not in the path
-	if !strings.HasSuffix(path, string(c.targetURL.Separator)) {
-		path += string(c.targetURL.Separator)
-	}
+	//if !strings.HasSuffix(path, string(c.targetURL.Separator)) {
+	//	path += string(c.targetURL.Separator)
+	//}
 
 	nonRecursive := false
 	maxKeys := 1


### PR DESCRIPTION
fix #4088 
I suggest deleting this content, because if I pass a file instead of a directory and take the --rewind parameter, it will add a delimiter to cause  The s3.ListObjectVersions interface returned an empty object.
![image](https://user-images.githubusercontent.com/37854724/177536113-9faddfbe-c6e8-41de-a194-0b2745f98574.png)
is ok:
![image](https://user-images.githubusercontent.com/37854724/177537311-a9b33641-4c3c-4c74-b551-02f63d8d3c40.png)
not ok:
![image](https://user-images.githubusercontent.com/37854724/177537445-b9d30459-07a8-4780-b5a5-8edd29029557.png)

