### PR TITLE
Add mc cat --tail and --offset

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -435,6 +435,14 @@ func (f *fsClient) Get(ctx context.Context, opts GetOptions) (io.ReadCloser, *pr
 		err := f.toClientError(e, f.PathURL.Path)
 		return nil, err.Trace(f.PathURL.Path)
 	}
+	if opts.RangeStart != 0 {
+		_, e := fileData.Seek(opts.RangeStart, os.SEEK_SET)
+		if e != nil {
+			err := f.toClientError(e, f.PathURL.Path)
+			return nil, err.Trace(f.PathURL.Path)
+		}
+	}
+
 	return fileData, nil
 }
 

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -829,6 +829,12 @@ func (c *S3Client) Get(ctx context.Context, opts GetOptions) (io.ReadCloser, *pr
 	if opts.Zip {
 		o.Set("x-minio-extract", "true")
 	}
+	if opts.RangeStart != 0 {
+		err := o.SetRange(opts.RangeStart, 0)
+		if err != nil {
+			return nil, probe.NewError(err)
+		}
+	}
 
 	reader, e := c.api.GetObject(ctx, bucket, object, o)
 	if e != nil {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -45,9 +45,10 @@ const (
 
 // GetOptions holds options of the GET operation
 type GetOptions struct {
-	SSE       encrypt.ServerSide
-	VersionID string
-	Zip       bool
+	SSE        encrypt.ServerSide
+	VersionID  string
+	Zip        bool
+	RangeStart int64
 }
 
 // PutOptions holds options for PUT operation

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -551,9 +551,10 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 		var reader io.ReadCloser
 		// Proceed with regular stream copy.
 		reader, metadata, err = getSourceStream(ctx, sourceAlias, sourceURL.String(), getSourceOpts{
-			GetOptions: GetOptions{VersionID: sourceVersion,
-				SSE: srcSSE,
-				Zip: isZip,
+			GetOptions: GetOptions{
+				VersionID: sourceVersion,
+				SSE:       srcSSE,
+				Zip:       isZip,
 			},
 			fetchStat: true,
 			preserve:  preserve,

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -159,18 +159,29 @@ func getSourceStreamMetadataFromURL(ctx context.Context, aliasedURL, versionID s
 		}
 		versionID = content.VersionID
 	}
-	sseKey := getSSE(aliasedURL, encKeyDB[alias])
-	return getSourceStream(ctx, alias, urlStrFull, versionID, true, sseKey, false, false)
+	return getSourceStream(ctx, alias, urlStrFull, getSourceOpts{
+		GetOptions: GetOptions{
+			SSE:       getSSE(aliasedURL, encKeyDB[alias]),
+			VersionID: versionID,
+			Zip:       false,
+		},
+	})
+}
+
+type getSourceOpts struct {
+	GetOptions
+	fetchStat bool
+	preserve  bool
 }
 
 // getSourceStreamFromURL gets a reader from URL.
-func getSourceStreamFromURL(ctx context.Context, urlStr, versionID string, encKeyDB map[string][]prefixSSEPair, isZip bool) (reader io.ReadCloser, err *probe.Error) {
+func getSourceStreamFromURL(ctx context.Context, urlStr string, encKeyDB map[string][]prefixSSEPair, opts getSourceOpts) (reader io.ReadCloser, err *probe.Error) {
 	alias, urlStrFull, _, err := expandAlias(urlStr)
 	if err != nil {
 		return nil, err.Trace(urlStr)
 	}
-	sse := getSSE(urlStr, encKeyDB[alias])
-	reader, _, err = getSourceStream(ctx, alias, urlStrFull, versionID, false, sse, false, isZip)
+	opts.SSE = getSSE(urlStr, encKeyDB[alias])
+	reader, _, err = getSourceStream(ctx, alias, urlStrFull, opts)
 	return reader, err
 }
 
@@ -222,18 +233,18 @@ func isReadAt(reader io.Reader) (ok bool) {
 }
 
 // getSourceStream gets a reader from URL.
-func getSourceStream(ctx context.Context, alias, urlStr, versionID string, fetchStat bool, sse encrypt.ServerSide, preserve, isZip bool) (reader io.ReadCloser, metadata map[string]string, err *probe.Error) {
+func getSourceStream(ctx context.Context, alias, urlStr string, opts getSourceOpts) (reader io.ReadCloser, metadata map[string]string, err *probe.Error) {
 	sourceClnt, err := newClientFromAlias(alias, urlStr)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
-	reader, err = sourceClnt.Get(ctx, GetOptions{SSE: sse, VersionID: versionID, Zip: isZip})
+	reader, err = sourceClnt.Get(ctx, opts.GetOptions)
 	if err != nil {
 		return nil, nil, err.Trace(alias, urlStr)
 	}
 
 	metadata = make(map[string]string)
-	if fetchStat {
+	if opts.fetchStat {
 		var st *ClientContent
 		mo, mok := reader.(*minio.Object)
 		if mok {
@@ -253,7 +264,7 @@ func getSourceStream(ctx context.Context, alias, urlStr, versionID string, fetch
 			}
 			st.ETag = oinfo.ETag
 		} else {
-			st, err = sourceClnt.Stat(ctx, StatOptions{preserve: preserve, sse: sse})
+			st, err = sourceClnt.Stat(ctx, StatOptions{preserve: opts.preserve, sse: opts.SSE})
 			if err != nil {
 				return nil, nil, err.Trace(alias, urlStr)
 			}
@@ -539,7 +550,14 @@ func uploadSourceToTargetURL(ctx context.Context, urls URLs, progress io.Reader,
 
 		var reader io.ReadCloser
 		// Proceed with regular stream copy.
-		reader, metadata, err = getSourceStream(ctx, sourceAlias, sourceURL.String(), sourceVersion, true, srcSSE, preserve, isZip)
+		reader, metadata, err = getSourceStream(ctx, sourceAlias, sourceURL.String(), getSourceOpts{
+			GetOptions: GetOptions{VersionID: sourceVersion,
+				SSE: srcSSE,
+				Zip: isZip,
+			},
+			fetchStat: true,
+			preserve:  preserve,
+		})
 		if err != nil {
 			return urls.WithError(err.Trace(sourceURL.String()))
 		}


### PR DESCRIPTION
Allow range requests for cat operations, either specifying tail or an absolute offset.

If tail is longer than file, the entire file is listed.

Example:
```
λ mc cat --tail=100 play/testbucket/go1/src/README.vendor
e current module. If a new package is needed,
it should be imported before running 'go mod vendor'.
```