### PR TITLE
Add support for NewerNoncurrentVersions for NonCurrentVersionExpiration and NonCurrentVersionTransition

### DIFF
--- a/cmd/ilm-add.go
+++ b/cmd/ilm-add.go
@@ -108,7 +108,7 @@ var ilmAddFlags = []cli.Flag{
 	},
 	cli.IntFlag{
 		Name:  "newer-noncurrentversions-transition",
-		Usage: "the number of noncurrent versions to not transition",
+		Usage: "the number of noncurrent versions to retain. If there are this many more recent noncurrent versions they will be transitioned",
 	},
 	cli.StringFlag{
 		Name:  "noncurrentversion-transition-storage-class",

--- a/cmd/ilm-add.go
+++ b/cmd/ilm-add.go
@@ -100,7 +100,7 @@ var ilmAddFlags = []cli.Flag{
 	},
 	cli.IntFlag{
 		Name:  "newer-noncurrentversions-expiration",
-		Usage: "the number of noncurrent versions to not remove",
+		Usage: "the number of noncurrent versions to retain",
 	},
 	cli.IntFlag{
 		Name:  "noncurrentversion-transition-days",

--- a/cmd/ilm-add.go
+++ b/cmd/ilm-add.go
@@ -99,8 +99,16 @@ var ilmAddFlags = []cli.Flag{
 		Usage: "the number of days to remove noncurrent versions",
 	},
 	cli.IntFlag{
+		Name:  "newer-noncurrentversions-expiration",
+		Usage: "the number of noncurrent versions to not remove",
+	},
+	cli.IntFlag{
 		Name:  "noncurrentversion-transition-days",
 		Usage: "the number of days to transition noncurrent versions",
+	},
+	cli.IntFlag{
+		Name:  "newer-noncurrentversions-transition",
+		Usage: "the number of noncurrent versions to not transition",
 	},
 	cli.StringFlag{
 		Name:  "noncurrentversion-transition-storage-class",


### PR DESCRIPTION
Adds two new flags, --newer-noncurrentversions-expiration and --newer-noncurrentversions-transition, to mc ilm add and mc ilm edit. These control NoncurrentVersionExpiration.NewerNoncurrentVersions and NoncurrentVersionTransition.NewerNoncurrentVersions in lifecycle config's rules.