### PR TITLE
support perf to execute all speed tests

### DIFF
--- a/cmd/speedtest-spinner.go
+++ b/cmd/speedtest-spinner.go
@@ -146,12 +146,13 @@ func (m *speedTestUI) View() string {
 		table.Render()
 
 		if m.quitting {
-			s.WriteString(fmt.Sprintf("\nSpeedtest: %s", m.result.String()))
+			s.WriteString("\n" + m.result.String())
 			if vstr := m.result.StringVerbose(); vstr != "" {
-				s.WriteString(vstr)
+				s.WriteString(vstr + "\n")
 			} else {
 				s.WriteString("\n")
 			}
+			s.WriteString("Objectperf: ✔\n")
 		}
 	} else if nres != nil {
 		table.SetHeader([]string{"Node", "RX", "TX", ""})


### PR DESCRIPTION
This commit will make `mc support perf <alias>` to execute all
performance tests, networking, drive and object speed tests.

perf will only have --duration and --verbose flags.

The user can still test with 'drive', 'object' and 'net' but they will
be hidden for now along with their flags.