### PR TITLE
Validate license against deployment id

### DIFF
--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -109,6 +109,10 @@ func performLicenseUpdate(licFile string, alias string, airgap bool) licUpdateMe
 		fatalIf(errDummy().Trace(), fmt.Sprintf("License has expired on %s", li.ExpiresAt))
 	}
 
+	if li.DeploymentID != getAdminInfo(alias).DeploymentID {
+		fatalIf(errDummy().Trace(), fmt.Sprintf("Invalid license"))
+	}
+
 	setSubnetCreds(alias, "", lic)
 	return lum
 }

--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -110,7 +110,7 @@ func performLicenseUpdate(licFile string, alias string, airgap bool) licUpdateMe
 	}
 
 	if li.DeploymentID != getAdminInfo(alias).DeploymentID {
-		fatalIf(errDummy().Trace(), fmt.Sprintf("Invalid license"))
+		fatalIf(errDummy().Trace(), fmt.Sprintf("License is invalid for the deployment %s", alias))
 	}
 
 	setSubnetCreds(alias, "", lic)


### PR DESCRIPTION
The command `mc license update` should error out in case the deployment
id from the license doesn't match the cluster's.