### PR TITLE
Remove isURLPrefixExists() call

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1591,8 +1591,8 @@ func (c *S3Client) Stat(ctx context.Context, opts StatOptions) (*ClientContent, 
 	//     - /path/to/existing/object
 	//     - /path/to/existing_directory
 	//     - /path/to/existing_directory/
-	//     - /path/to/empty_directory
-	//     - /path/to/empty_directory/
+	//     - /path/to/directory_marker
+	//     - /path/to/directory_marker/
 
 	// First an HEAD call is issued, this is faster than doing listing even if the object exists
 	// because the list could be very large. At the same time, the HEAD call is avoided if the

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -185,7 +185,7 @@ func urlJoinPath(url1, url2 string) string {
 	return joinURLs(u1, u2).String()
 }
 
-// url2Stat returns stat info for URL.
+// url2Stat returns stat info for URL - supports bucket, object and a prefixe with or without a trailing slash
 func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encKeyDB map[string][]prefixSSEPair, timeRef time.Time, isZip bool) (client Client, content *ClientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {
@@ -239,18 +239,6 @@ func url2Alias(aliasedURL string) (alias, path string) {
 		return urlParts[0], urlParts[1]
 	}
 	return urlParts[0], ""
-}
-
-// isURLPrefixExists - check if object key prefix exists.
-func isURLPrefixExists(urlPrefix string, incomplete bool) bool {
-	clnt, err := newClient(urlPrefix)
-	if err != nil {
-		return false
-	}
-	for entry := range clnt.List(globalContext, ListOptions{Recursive: false, Incomplete: incomplete, WithMetadata: false, ShowDir: DirNone}) {
-		return entry.Err == nil
-	}
-	return false
 }
 
 // guessURLContentType - guess content-type of the URL.

--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -183,15 +183,7 @@ func checkCopySyntaxTypeC(ctx context.Context, srcURLs []string, tgtURL string, 
 
 	for _, srcURL := range srcURLs {
 		c, srcContent, err := url2Stat(ctx, srcURL, "", false, keys, timeRef, isZip)
-		// incomplete uploads are not necessary for copy operation, no need to verify for them.
-		isIncomplete := false
-		if err != nil {
-			if !isURLPrefixExists(srcURL, isIncomplete) {
-				fatalIf(err.Trace(srcURL), "Unable to stat source `"+srcURL+"`.")
-			}
-			// No more check here, continue to the next source url
-			continue
-		}
+		fatalIf(err.Trace(srcURL), "Unable to stat source `"+srcURL+"`.")
 
 		if srcContent.Type.IsDir() {
 			// Require --recursive flag if we are copying a directory

--- a/cmd/find-main.go
+++ b/cmd/find-main.go
@@ -175,7 +175,7 @@ func checkFindSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 	// Extract input URLs and validate.
 	for _, url := range args {
 		_, _, err := url2Stat(ctx, url, "", false, encKeyDB, time.Time{}, false)
-		if err != nil && !isURLPrefixExists(url, false) {
+		if err != nil {
 			// Bucket name empty is a valid error for 'find myminio' unless we are using watch, treat it as such.
 			if _, ok := err.ToGoError().(BucketNameEmpty); ok && !cliCtx.Bool("watch") {
 				continue

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -114,7 +114,6 @@ func parseAndCheckStatSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB 
 
 	// extract URLs.
 	URLs := cliCtx.Args()
-	isIncomplete := false
 
 	if versionID != "" && len(args) > 1 {
 		fatalIf(errInvalidArgument().Trace(args...), "You cannot specify --version-id with multiple arguments.")
@@ -126,7 +125,7 @@ func parseAndCheckStatSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB 
 
 	for _, url := range URLs {
 		_, _, err := url2Stat(ctx, url, versionID, false, encKeyDB, rewind, false)
-		if err != nil && !isURLPrefixExists(url, isIncomplete) {
+		if err != nil {
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 		}
 	}

--- a/cmd/tree-main.go
+++ b/cmd/tree-main.go
@@ -131,9 +131,8 @@ func parseTreeSyntax(ctx context.Context, cliCtx *cli.Context) (args []string, d
 	}
 
 	for _, url := range args {
-		if _, _, err := url2Stat(ctx, url, "", false, nil, timeRef, false); err != nil && !isURLPrefixExists(url, false) {
-			fatalIf(err.Trace(url), "Unable to tree `"+url+"`.")
-		}
+		_, _, err := url2Stat(ctx, url, "", false, nil, timeRef, false)
+		fatalIf(err.Trace(url), "Unable to tree `"+url+"`.")
 	}
 	return
 }


### PR DESCRIPTION
isURLPrefixExists() is used after url2Stat() function to check if the
given aliased URL corresponds to an existing prefix in the server. However,
 url2Stat() is already doing that and returns valid information for
those prefixes.

Removing isURLPrefixExists() all together.