### PR TITLE
add errors to admin top api command

### DIFF
--- a/cmd/top-api-spinner.go
+++ b/cmd/top-api-spinner.go
@@ -37,6 +37,7 @@ type topAPIStats struct {
 	TotalCalls   uint64
 	TotalBytesRX uint64
 	TotalBytesTX uint64
+	TotalErrors  uint64
 }
 
 func (s *topAPIStats) addAPICall(n int) {
@@ -51,6 +52,10 @@ func (s *topAPIStats) addAPIBytesTX(n int) {
 	atomic.AddUint64(&s.TotalBytesTX, uint64(n))
 }
 
+func (s *topAPIStats) addAPIErrors(n int) {
+	atomic.AddUint64(&s.TotalErrors, uint64(n))
+}
+
 func (s *topAPIStats) loadAPICall() uint64 {
 	return atomic.LoadUint64(&s.TotalCalls)
 }
@@ -61,6 +66,10 @@ func (s *topAPIStats) loadAPIBytesRX() uint64 {
 
 func (s *topAPIStats) loadAPIBytesTX() uint64 {
 	return atomic.LoadUint64(&s.TotalBytesTX)
+}
+
+func (s *topAPIStats) loadAPIErrors() uint64 {
+	return atomic.LoadUint64(&s.TotalErrors)
 }
 
 type traceUI struct {
@@ -153,16 +162,20 @@ func (m *traceUI) View() string {
 			traceSt.addAPIBytesRX(res.Trace.HTTP.CallStats.InputBytes)
 			traceSt.addAPIBytesTX(res.Trace.HTTP.CallStats.OutputBytes)
 		}
+		if res.Trace.HTTP.RespInfo.StatusCode >= 500 {
+			traceSt.addAPIErrors(1)
+		}
 		m.apiStatsMap[res.Trace.FuncName] = traceSt
 	}
 
-	table.SetHeader([]string{"API", "CALLS", "RX", "TX"})
+	table.SetHeader([]string{"API", "CALLS", "ERRORS", "RX", "TX"})
 	data := make([][]string, 0, len(m.apiStatsMap))
 
 	for k, stats := range m.apiStatsMap {
 		data = append(data, []string{
 			k,
 			whiteStyle.Render(fmt.Sprintf("%d", stats.loadAPICall())),
+			whiteStyle.Render(fmt.Sprintf("%d", stats.loadAPIErrors())),
 			whiteStyle.Render(humanize.IBytes(stats.loadAPIBytesRX())),
 			whiteStyle.Render(humanize.IBytes(stats.loadAPIBytesTX())),
 		})

--- a/cmd/top-api-spinner.go
+++ b/cmd/top-api-spinner.go
@@ -162,22 +162,22 @@ func (m *traceUI) View() string {
 			traceSt.addAPIBytesRX(res.Trace.HTTP.CallStats.InputBytes)
 			traceSt.addAPIBytesTX(res.Trace.HTTP.CallStats.OutputBytes)
 		}
-		if res.Trace.HTTP.RespInfo.StatusCode >= 500 {
+		if res.Trace.HTTP.RespInfo.StatusCode >= 499 {
 			traceSt.addAPIErrors(1)
 		}
 		m.apiStatsMap[res.Trace.FuncName] = traceSt
 	}
 
-	table.SetHeader([]string{"API", "CALLS", "ERRORS", "RX", "TX"})
+	table.SetHeader([]string{"API", "RX", "TX", "CALLS", "ERRORS"})
 	data := make([][]string, 0, len(m.apiStatsMap))
 
 	for k, stats := range m.apiStatsMap {
 		data = append(data, []string{
 			k,
-			whiteStyle.Render(fmt.Sprintf("%d", stats.loadAPICall())),
-			whiteStyle.Render(fmt.Sprintf("%d", stats.loadAPIErrors())),
 			whiteStyle.Render(humanize.IBytes(stats.loadAPIBytesRX())),
 			whiteStyle.Render(humanize.IBytes(stats.loadAPIBytesTX())),
+			whiteStyle.Render(fmt.Sprintf("%d", stats.loadAPICall())),
+			whiteStyle.Render(fmt.Sprintf("%d", stats.loadAPIErrors())),
 		})
 	}
 	sort.Slice(data, func(i, j int) bool {


### PR DESCRIPTION
Add the errors column to `admin top api` command. It displays the total number of errors whose response has error code >= 500.

```
API                             CALLS   ERRORS  RX      TX      
s3.DeleteBucket                 1       0       121 B   323 B  
s3.DeleteBucketPolicy           1       0       98 B    323 B  
s3.DeleteObject                 1       0       155 B   323 B  
s3.GetBucketEncryption          13      13      1.2 KiB 9.2 KiB
s3.GetBucketLifecycle           2       2       196 B   1.3 KiB
s3.GetBucketLocation            105     7       11 KiB  51 KiB 
s3.GetBucketNotification        4       0       392 B   1.8 KiB
s3.GetBucketObjectLockConfig    17      10      1.6 KiB 11 KiB 
s3.GetBucketPolicy           	30   	17    	2.9 KiB	21 KiB 	
s3.GetBucketReplicationConfig	17   	17    	1.6 KiB	12 KiB 	
s3.GetBucketTagging          	22   	22    	2.1 KiB	14 KiB 	
s3.GetBucketVersioning       	16   	0     	1.5 KiB	7.1 KiB	
s3.GetObject                 	22   	13    	2.7 KiB	519 KiB	
s3.HeadBucket                	15   	9     	1.5 KiB	4.9 KiB	
s3.HeadObject                	12   	10    	1.6 KiB	4.0 KiB	
s3.ListBuckets               	78   	3     	9.1 KiB	4.0 MiB	
s3.ListObjectsV1             	5    	3     	534 B  	4.9 KiB	
s3.ListObjectsV2             	4    	0     	438 B  	3.2 KiB	
s3.PutBucket                 	9    	2     	1.2 KiB	3.7 KiB	
s3.PutBucketPolicy           	1    	0     	557 B  	323 B  	
s3.PutObject                 	11   	0     	338 KiB	3.8 KiB	
```