### PR TITLE
rm: Fix successful message for operations on the filesystem

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -522,9 +522,8 @@ func (f *fsClient) Remove(ctx context.Context, isIncomplete, isRemoveBucket, isB
 			}
 			e := deleteFile(f.PathURL.Path, name)
 			if e == nil {
-				_, objectName := url2BucketAndObject(&content.URL)
 				res := RemoveResult{}
-				res.ObjectName = objectName
+				res.ObjectName = content.URL.Path
 				resultCh <- res
 				continue
 			}


### PR DESCRIPTION
Names of the removed files when mc operatres on the filesystem are
not shown properly. The code is splitting the removed path into bucket
and prefix which doesn't make sense for filesystem.

The commit will just send the path of the removed object.

Fixes https://github.com/minio/mc/issues/4165