### PR TITLE
rb: Better error message when the user passes an object name

### DIFF
--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -73,7 +73,7 @@ type BucketInvalid struct {
 }
 
 func (e BucketInvalid) Error() string {
-	return "Bucket name " + e.Bucket + " not valid."
+	return "Bucket name `" + e.Bucket + "` not valid."
 }
 
 // ObjectAlreadyExists - typed return for MethodNotAllowed


### PR DESCRIPTION
The new error message is:
```
$ mc rb --force play/testbucket/dir/
mc: <ERROR> Failed to remove `play/testbucket/dir/`. Bucket name `testbucket/dir/` not valid.
```

Fixes https://github.com/minio/mc/issues/4174