### PR TITLE
restart: Use health check instead of service info API

### DIFF
--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -157,7 +157,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		case <-timer.C:
 			healthCtx, healthCancel := context.WithTimeout(ctxt, 3*time.Second)
 			// Fetch the health status of the specified MinIO server
-			healthResult, healthErr := anonClient.Healthy(healthCtx, madmin.HealthOpts{ClusterRead: true})
+			healthResult, healthErr := anonClient.Healthy(healthCtx, madmin.HealthOpts{})
 			healthCancel()
 			switch {
 			case healthErr == nil && healthResult.Healthy:


### PR DESCRIPTION
mc admin service restart currently uses ServerInfo() API which is
costly.

Use healthcheck with read quorum instead.