### PR TITLE
Fix example description for `mc support perf`

### DIFF
--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -92,9 +92,8 @@ FLAGS:
   {{end}}
 
 EXAMPLES:
-  1. Run performance tests on 'myminio' cluster: networking, drive speed and:
+  1. Run object storage, network, and drive performance tests on 'myminio' cluster:
      {{.Prompt}} {{.HelpName}} myminio/
-
 `,
 }
 


### PR DESCRIPTION
The current description seems incomplete as it doesn't mention object
storage performance.