### PR TITLE
Enhancements in registration and diagnostics

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -65,6 +65,7 @@ var (
 	globalInsecure       = false  // Insecure flag set via command line
 	globalDevMode        = false  // dev flag set via command line
 	globalSubnetProxyURL *url.URL // Proxy to be used for communication with subnet
+	globalAirgapped      = false  // Airgapped flag set via command line
 
 	globalConnReadDeadline  time.Duration
 	globalConnWriteDeadline time.Duration
@@ -88,6 +89,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	noColor := ctx.IsSet("no-color") || ctx.GlobalIsSet("no-color")
 	insecure := ctx.IsSet("insecure") || ctx.GlobalIsSet("insecure")
 	devMode := ctx.IsSet("dev") || ctx.GlobalIsSet("dev")
+	airgapped := ctx.IsSet("airgap") || ctx.GlobalIsSet("airgap")
 
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
@@ -96,6 +98,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	globalNoColor = globalNoColor || noColor || globalJSONLine
 	globalInsecure = globalInsecure || insecure
 	globalDevMode = globalDevMode || devMode
+	globalAirgapped = globalAirgapped || airgapped
 
 	// Disable colorified messages if requested.
 	if globalNoColor || globalQuiet {

--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -18,17 +18,17 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/google/uuid"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
 	"github.com/minio/madmin-go"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/pkg/console"
 )
+
+const licRegisterMsgTag = "licenseRegisterMessage"
 
 var licenseRegisterFlags = append([]cli.Flag{
 	cli.StringFlag{
@@ -58,11 +58,19 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Register MinIO cluster at alias 'play' on SUBNET, using alias as the cluster name.
-     {{.Prompt}} {{.HelpName}} play
+  1. Register MinIO cluster at alias 'play' on SUBNET, using api key for auth
+     {{.Prompt}} {{.HelpName}} play --api-key 08efc836-4289-dbd4-ad82-b5e8b6d25577
 
-  2. Register MinIO cluster at alias 'play' on SUBNET, using the name "play-cluster".
-     {{.Prompt}} {{.HelpName}} play --name play-cluster
+  2. Register MinIO cluster at alias 'play' on SUBNET, using api key for auth,
+     and "play-cluster" as the preferred name for the cluster on SUBNET.
+     {{.Prompt}} {{.HelpName}} play --api-key 08efc836-4289-dbd4-ad82-b5e8b6d25577 --name play-cluster
+
+  3. Register MinIO cluster at alias 'play' on SUBNET in an airgapped environment
+     {{.Prompt}} {{.HelpName}} play --airgap
+
+  4. Register MinIO cluster at alias 'play' on SUBNET, using alias as the cluster name.
+     This asks for SUBNET credentials if the cluster is not already registered.
+     {{.Prompt}} {{.HelpName}} play
 `,
 }
 
@@ -84,7 +92,7 @@ func (li licRegisterMessage) String() string {
 		msg = fmt.Sprintln("Open the following URL in the browser to register", li.Alias, "on SUBNET:")
 		msg += li.URL
 	}
-	return console.Colorize(licUpdateMsgTag, msg)
+	return console.Colorize(licRegisterMsgTag, msg)
 }
 
 // JSON jsonified license register message
@@ -95,8 +103,8 @@ func (li licRegisterMessage) JSON() string {
 	return string(jsonBytes)
 }
 
-// checklicenseRegisterSyntax - validate arguments passed by a user
-func checklicenseRegisterSyntax(ctx *cli.Context) {
+// checkLicenseRegisterSyntax - validate arguments passed by a user
+func checkLicenseRegisterSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) == 0 || len(ctx.Args()) > 1 {
 		cli.ShowCommandHelpAndExit(ctx, "register", 1) // last argument is exit code
 	}
@@ -142,43 +150,19 @@ type SubnetMFAReq struct {
 	Token    string `json:"token"`
 }
 
-func validateAPIKey(apiKey string, offline bool) error {
-	if offline {
-		return errors.New("--api-key is not applicable in airgap mode")
-	}
-
-	_, e := uuid.Parse(apiKey)
-	if e != nil {
-		return e
-	}
-
-	return nil
-}
-
 func mainLicenseRegister(ctx *cli.Context) error {
-	console.SetColor("RegisterSuccessMessage", color.New(color.FgGreen, color.Bold))
-	checklicenseRegisterSyntax(ctx)
+	console.SetColor(licRegisterMsgTag, color.New(color.FgGreen, color.Bold))
+	checkLicenseRegisterSyntax(ctx)
 
 	// Get the alias parameter from cli
 	aliasedURL := ctx.Args().Get(0)
+	alias, accAPIKey := initSubnetConnectivity(ctx, aliasedURL)
 
-	offline := ctx.Bool("airgap") || ctx.Bool("offline")
-	if !offline {
-		fatalIf(checkURLReachable(subnetBaseURL()).Trace(aliasedURL), "Unable to reach %s register", subnetBaseURL())
-	}
-
-	accAPIKey := ctx.String("api-key")
-	if len(accAPIKey) > 0 {
-		e := validateAPIKey(accAPIKey, offline)
-		fatalIf(probe.NewError(e), "unable to parse input values")
-	}
-
-	alias, _ := url2Alias(aliasedURL)
 	clusterName := ctx.String("name")
 	if len(clusterName) == 0 {
 		clusterName = alias
 	} else {
-		if offline {
+		if globalAirgapped {
 			fatalIf(errInvalidArgument(), "'--name' is not allowed in airgapped mode")
 		}
 	}
@@ -190,10 +174,13 @@ func mainLicenseRegister(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e), "Error in fetching subnet credentials")
 	if len(apiKey) > 0 || len(lic) > 0 {
 		alreadyRegistered = true
+		if len(accAPIKey) == 0 {
+			accAPIKey = apiKey
+		}
 	}
 
 	lrm := licRegisterMessage{Status: "success", Alias: alias}
-	if offline {
+	if globalAirgapped {
 		lrm.Type = "offline"
 
 		regToken, e := generateRegToken(regInfo)
@@ -202,7 +189,8 @@ func mainLicenseRegister(ctx *cli.Context) error {
 		lrm.URL = subnetOfflineRegisterURL(regToken)
 	} else {
 		lrm.Type = "online"
-		registerOnline(regInfo, alias, accAPIKey)
+		_, _, e = registerClusterOnSubnet(regInfo, alias, accAPIKey)
+		fatalIf(probe.NewError(e), "Could not register cluster with SUBNET:")
 
 		lrm.Action = "registered"
 		if alreadyRegistered {
@@ -212,25 +200,6 @@ func mainLicenseRegister(ctx *cli.Context) error {
 
 	printMsg(lrm)
 	return nil
-}
-
-func registerOnline(clusterRegInfo ClusterRegistrationInfo, alias string, accAPIKey string) {
-	var resp string
-	var e error
-
-	if len(accAPIKey) > 0 {
-		resp, e = registerClusterWithSubnetCreds(clusterRegInfo, accAPIKey, "")
-		if e == nil {
-			// save the api key in config
-			setSubnetAPIKey(alias, accAPIKey)
-		}
-	} else {
-		resp, e = registerClusterOnSubnet(alias, clusterRegInfo)
-	}
-
-	fatalIf(probe.NewError(e), "Could not register cluster with SUBNET:")
-
-	extractAndSaveLicense(alias, resp)
 }
 
 func getAdminInfo(aliasedURL string) madmin.InfoMessage {

--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -84,15 +84,11 @@ func mainLicenseUpdate(ctx *cli.Context) error {
 
 	licFile := ctx.Args().Get(1)
 
-	// If set, the subnet public key will not be downloaded from subnet
-	// and the offline key embedded in mc will be used.
-	airgap := ctx.Bool("airgap")
-
-	printMsg(performLicenseUpdate(licFile, alias, airgap))
+	printMsg(performLicenseUpdate(licFile, alias))
 	return nil
 }
 
-func performLicenseUpdate(licFile string, alias string, airgap bool) licUpdateMessage {
+func performLicenseUpdate(licFile string, alias string) licUpdateMessage {
 	lum := licUpdateMessage{
 		Alias:  alias,
 		Status: "success",
@@ -102,7 +98,7 @@ func performLicenseUpdate(licFile string, alias string, airgap bool) licUpdateMe
 	fatalIf(probe.NewError(e), fmt.Sprintf("Unable to read license file %s", licFile))
 
 	lic := string(licBytes)
-	li, e := parseLicense(lic, airgap)
+	li, e := parseLicense(lic)
 	fatalIf(probe.NewError(e), fmt.Sprintf("Error parsing license from %s", licFile))
 
 	if li.ExpiresAt.Before(time.Now()) {


### PR DESCRIPTION
- When cluster is registered but only one of license and api-key are
available in the config, and when `--airgap` is not passed to the
command, try to automatically fetch and store the other.
- Add `--api-key` flag to `mc support diag`
- Use header based auth with subnet
- Introduce common function to initialize/check connectivity with subnet
- Make the health report upload function generic so that it can be used
by other commands like profile in future
- Add global variable for airgapped mode
- Add more examples to `mc license register`