### PR TITLE
Make environment variables output highlighted

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -46,5 +46,6 @@ func printMsg(msg message) {
 			}
 		}
 	}
+	msgStr = strings.TrimSuffix(msgStr, "\n")
 	console.Println(msgStr)
 }


### PR DESCRIPTION
For `mc admin config get|export`

Sample output:
![Screenshot from 2022-08-10 14-59-55](https://user-images.githubusercontent.com/200059/184028114-e5f8a8d2-e892-486b-a5cc-8100b03771cd.png)

