### PR TITLE
Clarify error when user has no policy

### DIFF
--- a/cmd/admin-user-policy.go
+++ b/cmd/admin-user-policy.go
@@ -74,6 +74,9 @@ func mainAdminUserPolicy(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to get user info")
 
 	pinfo, e := getPolicyInfo(client, user.PolicyName)
+	if user.PolicyName == "" {
+		e = fmt.Errorf("Policy not found for user %s", args.Get(1))
+	}
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to fetch user policy document")
 
 	fmt.Println(string(pinfo.Policy))


### PR DESCRIPTION
Changes error when `mc admin user policy` is used on a user with no policy

Changed from `Unable to fetch user policy document. Only a single policy may be specified here.` to 'Unable to fetch user policy document. Policy not found for user username.`

Fixes issue #4179 