### PR TITLE
Fix `support logs status` command

### DIFF
--- a/cmd/support-logs-status.go
+++ b/cmd/support-logs-status.go
@@ -43,7 +43,7 @@ EXAMPLES:
 }
 
 func isSupportLogsEnabled(alias string) bool {
-	return isFeatureEnabled(alias, "logger_webhook", "logger_webhook:subnet")
+	return isFeatureEnabled(alias, "logger_webhook", "subnet")
 }
 
 func mainStatusLogs(ctx *cli.Context) error {


### PR DESCRIPTION
Earlier, the parsed config contained the `target` of the form
`subsystem:target` e.g. `logger_webhook:subnet`. Now it contains only
the target e.g. `subnet`.

Updating the `support logs status` command code accordingly to ensure
that it prints correct output.