### PR TITLE
Fix `support callhome status` command

### DIFF
--- a/cmd/support-callhome.go
+++ b/cmd/support-callhome.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
+	"github.com/minio/madmin-go"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/pkg/console"
 )
@@ -78,7 +79,7 @@ func (s supportCallhomeMessage) JSON() string {
 }
 
 func isSupportCallhomeEnabled(alias string) bool {
-	return isFeatureEnabled(alias, "callhome", "callhome")
+	return isFeatureEnabled(alias, "callhome", madmin.Default)
 }
 
 func mainCallhome(ctx *cli.Context) error {


### PR DESCRIPTION
Because of recent changes in the way config is parsed in `mc`, we need
to pass `madmin.Default` as the target when looking for the callhome
config.