### PR TITLE
Fix mb with-versioning

### DIFF
--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -156,7 +156,7 @@ func mainMakeBucket(cliCtx *cli.Context) error {
 			continue
 		}
 
-		if cliCtx.Bool("s") {
+		if cliCtx.Bool("with-versioning") {
 			fatalIf(clnt.SetVersion(ctx, "enable", []string{}, false), "Unable to enable versioning")
 		}
 


### PR DESCRIPTION
`mc mb --with-versioning` no longer works after https://github.com/minio/mc/commit/f70b7e537c908e2c426f87218d5a44f807588074 (no PR)

Use long param name.