### PR TITLE
Add mc admin trace --call=healing

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -47,7 +47,7 @@ var adminTraceFlags = []cli.Flag{
 	},
 	cli.StringSliceFlag{
 		Name:  "call",
-		Usage: "trace only matching Call types (values: `s3`, `internal`, `storage`, `os`, `scanner`, `decommission`)",
+		Usage: "trace only matching Call types (values: `s3`, `internal`, `storage`, `os`, `scanner`, `decommission`, `healing`)",
 	},
 	cli.StringFlag{
 		Name:  "response-threshold",
@@ -235,6 +235,7 @@ func tracingOpts(ctx *cli.Context, apis []string) (opts madmin.ServiceTraceOpts,
 		opts.OS = true
 		opts.Scanner = true
 		opts.Decommission = true
+		opts.Healing = true
 		return
 	}
 
@@ -257,6 +258,8 @@ func tracingOpts(ctx *cli.Context, apis []string) (opts madmin.ServiceTraceOpts,
 			opts.OS = true
 		case "scanner":
 			opts.Scanner = true
+		case "heal", "healing":
+			opts.Healing = true
 		case "decom", "decommission":
 			opts.Decommission = true
 		}
@@ -375,15 +378,17 @@ type callStats struct {
 type verboseTrace struct {
 	Type string `json:"type"`
 
-	NodeName     string        `json:"host"`
-	FuncName     string        `json:"api"`
-	Time         time.Time     `json:"time"`
-	Duration     time.Duration `json:"duration"`
-	Path         string        `json:"path"`
-	Error        string        `json:"error"`
-	RequestInfo  *requestInfo  `json:"request,omitempty"`
-	ResponseInfo *responseInfo `json:"response,omitempty"`
-	CallStats    *callStats    `json:"callStats,omitempty"`
+	NodeName     string                 `json:"host"`
+	FuncName     string                 `json:"api"`
+	Time         time.Time              `json:"time"`
+	Duration     time.Duration          `json:"duration"`
+	Path         string                 `json:"path"`
+	Error        string                 `json:"error,omitempty"`
+	Message      string                 `json:"message,omitempty"`
+	RequestInfo  *requestInfo           `json:"request,omitempty"`
+	ResponseInfo *responseInfo          `json:"response,omitempty"`
+	CallStats    *callStats             `json:"callStats,omitempty"`
+	HealResult   *madmin.HealResultItem `json:"healResult,omitempty"`
 
 	trcType madmin.TraceType
 }
@@ -401,6 +406,7 @@ func shortTrace(ti madmin.ServiceTraceInfo) shortTraceMsg {
 	s.Error = t.Error
 	s.Host = t.NodeName
 	s.Duration = t.Duration
+	s.StatusMsg = t.Message
 
 	switch t.TraceType {
 	case madmin.TraceS3, madmin.TraceInternal:
@@ -496,14 +502,16 @@ func (t traceMessage) JSON() string {
 	t.Status = "success"
 
 	trc := verboseTrace{
-		trcType:  t.Trace.TraceType,
-		Type:     t.Trace.TraceType.String(),
-		NodeName: t.Trace.NodeName,
-		FuncName: t.Trace.FuncName,
-		Time:     t.Trace.Time,
-		Duration: t.Trace.Duration,
-		Path:     t.Trace.Path,
-		Error:    t.Trace.Error,
+		trcType:    t.Trace.TraceType,
+		Type:       t.Trace.TraceType.String(),
+		NodeName:   t.Trace.NodeName,
+		FuncName:   t.Trace.FuncName,
+		Time:       t.Trace.Time,
+		Duration:   t.Trace.Duration,
+		Path:       t.Trace.Path,
+		Error:      t.Trace.Error,
+		HealResult: t.Trace.HealResult,
+		Message:    t.Trace.Message,
 	}
 
 	if t.Trace.HTTP != nil {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.23.0
 	github.com/minio/colorjson v1.0.2
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.4.25
+	github.com/minio/madmin-go v1.4.26
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.34
 	github.com/minio/pkg v1.3.2
@@ -113,5 +113,3 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 )
-
-replace github.com/minio/madmin-go => github.com/klauspost/madmin-go v1.0.15-0.20220830094240-17a19a73d7b8

--- a/go.mod
+++ b/go.mod
@@ -113,3 +113,5 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 )
+
+replace github.com/minio/madmin-go => github.com/klauspost/madmin-go v1.0.15-0.20220830094240-17a19a73d7b8

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,6 @@ github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/klauspost/madmin-go v1.0.15-0.20220830094240-17a19a73d7b8 h1:lOP4b9b/LzAuk0kNVvbcS3OIlBj13rCabljkyOf+YHI=
-github.com/klauspost/madmin-go v1.0.15-0.20220830094240-17a19a73d7b8/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -338,6 +336,9 @@ github.com/minio/colorjson v1.0.2 h1:Em3IM68MTm3h+Oxa0nxrV9VQqDgbxvC5iq5A+pqzDeI
 github.com/minio/colorjson v1.0.2/go.mod h1:JWxcL2n8T8JVf+NY6awl6kn5nK49aAzHOeQEM33dL0k=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
+github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
+github.com/minio/madmin-go v1.4.26 h1:hss2NjaMpZEHlaGJh2rGRYH6GiNY6g8+ogrUoxbjafg=
+github.com/minio/madmin-go v1.4.26/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/klauspost/madmin-go v1.0.15-0.20220830094240-17a19a73d7b8 h1:lOP4b9b/LzAuk0kNVvbcS3OIlBj13rCabljkyOf+YHI=
+github.com/klauspost/madmin-go v1.0.15-0.20220830094240-17a19a73d7b8/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -336,9 +338,6 @@ github.com/minio/colorjson v1.0.2 h1:Em3IM68MTm3h+Oxa0nxrV9VQqDgbxvC5iq5A+pqzDeI
 github.com/minio/colorjson v1.0.2/go.mod h1:JWxcL2n8T8JVf+NY6awl6kn5nK49aAzHOeQEM33dL0k=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
-github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
-github.com/minio/madmin-go v1.4.25 h1:IEJpsTXlHz18/yRI5HxY84KaJdDjUUYdMiC5f8fId4g=
-github.com/minio/madmin-go v1.4.25/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=


### PR DESCRIPTION
Provide healing operation traces.

See https://github.com/minio/minio/pull/15616 for basic implementation.

Requires https://github.com/minio/madmin-go/pull/122

```
λ go build&& mc admin trace --call=heal myminio
2022-08-30T12:33:54.770 [HEALING] heal.checkVersion 127.0.0.1:9002 testbucket/src/cmd/compile/internal/walk/compare.go 1.1024ms
2022-08-30T12:33:57.919 [HEALING] heal.checkVersion 127.0.0.1:9002 testbucket/src/math/big/arith_386.s 1.0528ms
2022-08-30T12:33:59.466 [HEALING] heal.checkVersion 127.0.0.1:9002 testbucket/src/math/big/decimal_test.go 1.0712ms
2022-08-30T12:34:00.313 [HEALING] heal.checkVersion 127.0.0.1:9002 testbucket/src/math/big/floatmarsh_test.go 1.0553ms
[...]
```