### PR TITLE
ls: Fix ls exit code related to some errors in FS

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -230,21 +230,6 @@ func doList(ctx context.Context, clnt Client, o doListOptions) error {
 		ListZip:           o.listZip,
 	}) {
 		if content.Err != nil {
-			switch content.Err.ToGoError().(type) {
-			// handle this specifically for filesystem related errors.
-			case BrokenSymlink:
-				errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list broken link.")
-				continue
-			case TooManyLevelsSymlink:
-				errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list too many levels link.")
-				continue
-			case PathNotFound:
-				errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
-				continue
-			case PathInsufficientPermission:
-				errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
-				continue
-			}
 			errorIf(content.Err.Trace(clnt.GetURL().String()), "Unable to list folder.")
 			cErr = exitStatus(globalErrorExitStatus) // Set the exit status.
 			continue


### PR DESCRIPTION
The code that is being modified is from 2016. Currently it does not set
an exit code status in the following cases, all of them are returned by
the FS layer:

    BrokenSymlink
    TooManyLevelsSymlink
    PathNotFound
    PathInsufficientPermission

There is no reason to avoid setting an exit code in this case. The only
functional change of this PR is by setting an exit code