### PR TITLE
allow terminal control back after bubbletea UI

### DIFF
--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -333,8 +333,8 @@ var completeCmds = map[string]complete.Predictor{
 	"/admin/top/locks": aliasCompleter,
 	"/admin/top/api":   aliasCompleter,
 
-	"/admin/scanner/info":  aliasCompleter,
-	"/admin/scanner/trace": aliasCompleter,
+	"/admin/scanner/status": aliasCompleter,
+	"/admin/scanner/trace":  aliasCompleter,
 
 	"/admin/service/stop":     aliasCompleter,
 	"/admin/service/restart":  aliasCompleter,

--- a/cmd/speedtest-spinner.go
+++ b/cmd/speedtest-spinner.go
@@ -86,7 +86,7 @@ func (m *speedTestUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c":
+		case "q", "esc", "ctrl+c":
 			m.quitting = true
 			return m, tea.Quit
 		default:
@@ -99,12 +99,10 @@ func (m *speedTestUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		return m, nil
-	case spinner.TickMsg:
+	default:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		return m, cmd
-	default:
-		return m, nil
 	}
 }
 


### PR DESCRIPTION


## Description
allow terminal control back after bubbletea UI

## Motivation and Context
terminal control was not relinquished since ui.Start() 
must not be run in a go-routine as it is expected
to be a blocking call, and must be serialized with when 
an application exits.

refactor the 'scanner info/status' to ensure we have 
correct behavior.

This PR also renames 'info-> status', keeps the older 
one as alias for now.

## How to test this PR?
Test `mc admin scanner info alias/ -n 2`  the terminal
control is never relinquished, causes the terminal to
sort of hang and we have to manually perform `reset`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
