### PR TITLE
Add --request-header to trace cmd to filter http requests

### DIFF
--- a/cmd/admin-scanner-trace.go
+++ b/cmd/admin-scanner-trace.go
@@ -76,6 +76,10 @@ EXAMPLES:
 
   3. Show trace for only ScanObject operations
     {{.Prompt}} {{.HelpName}} --funcname=scanner.ScanObject myminio
+
+  4. Avoid printing replication related S3 requests
+    {{.Prompt}} {{.HelpName}} --request-header '!X-Minio-Source' myminio
+
 `,
 }
 
@@ -124,11 +128,7 @@ func mainAdminScannerTrace(ctx *cli.Context) error {
 	opts, e := tracingOpts(ctx, []string{"scanner"})
 	fatalIf(probe.NewError(e), "Unable to start tracing")
 
-	mopts := matchOpts{
-		funcNames: ctx.StringSlice("funcname"),
-		apiPaths:  ctx.StringSlice("path"),
-		nodes:     ctx.StringSlice("node"),
-	}
+	mopts := matchingOpts(ctx)
 
 	// Start listening on all trace activity.
 	traceCh := client.ServiceTrace(ctxt, opts)

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -85,6 +85,12 @@ func nameMatch(pattern, path string) bool {
 	return matched
 }
 
+func headerMatch(pattern, header string) bool {
+	pattern = strings.ToLower(pattern)
+	header = strings.ToLower(header)
+	return wildcard.Match(pattern, header)
+}
+
 // pathMatch reports whether path matches the wildcard pattern.
 // supports  '*' and '?' wildcards in the pattern string.
 // unlike path.Match(), considers a path as a flat name space

--- a/cmd/support-top-api.go
+++ b/cmd/support-top-api.go
@@ -97,11 +97,7 @@ func mainSupportTopAPI(ctx *cli.Context) error {
 	opts, e := tracingOpts(ctx, ctx.StringSlice("call"))
 	fatalIf(probe.NewError(e), "Unable to start tracing")
 
-	mopts := matchOpts{
-		funcNames: ctx.StringSlice("name"),
-		apiPaths:  ctx.StringSlice("path"),
-		nodes:     ctx.StringSlice("node"),
-	}
+	mopts := matchingOpts(ctx)
 
 	// Start listening on all trace activity.
 	traceCh := client.ServiceTrace(ctxt, opts)


### PR DESCRIPTION
## Description
e.g:

`mc admin trace --request-header "User-Agent: *hadoop*" <alias>`
   to print all S3 requests sent by Hadoop

`mc admin trace --request-header "!X-Minio-Source*" <alias>`
   to avoid printing S3 requests related to replication

## Motivation and Context
Filter replication requests

## How to test this PR?
mc admin trace --request-header "!X-Minio-Source*" <alias>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
