### PR TITLE
allow terminal control back for 'top api/disk'

### DIFF
--- a/cmd/admin-scanner-status.go
+++ b/cmd/admin-scanner-status.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -129,7 +128,7 @@ func mainAdminScannerInfo(ctx *cli.Context) error {
 	if !globalJSON {
 		if e := ui.Start(); e != nil {
 			cancel()
-			os.Exit(1)
+			fatalIf(probe.NewError(e).Trace(aliasedURL), "Unable to fetch scanner metrics")
 		}
 	}
 

--- a/cmd/top-api-spinner.go
+++ b/cmd/top-api-spinner.go
@@ -104,7 +104,7 @@ func (m *traceUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c":
+		case "ctrl+c", "q", "esc":
 			m.quitting = true
 			return m, tea.Quit
 		default:
@@ -120,14 +120,11 @@ func (m *traceUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 		return m, nil
-
-	case spinner.TickMsg:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
-	default:
-		return m, nil
 	}
+
+	var cmd tea.Cmd
+	m.spinner, cmd = m.spinner.Update(msg)
+	return m, cmd
 }
 
 func (m *traceUI) View() string {


### PR DESCRIPTION

## Description
allow terminal control back for 'top api/disk'

## Motivation and Context
similar to #4237 fix other command TUI's as well,
also no locking is needed to protect maps.

Update()/View() are serial so need to add mutexes.


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
