### PR TITLE
Avoid cutting policy name in admin policy list command

### DIFF
--- a/cmd/admin-policy-add.go
+++ b/cmd/admin-policy-add.go
@@ -92,11 +92,7 @@ func (u userPolicyMessage) String() string {
 		fatalIf(probe.NewError(e), "Unable to marshal to JSON.")
 		return string(buf)
 	case "list":
-		policyFieldMaxLen := 20
-		// Create a new pretty table with cols configuration
-		return newPrettyTable("  ",
-			Field{"Policy", policyFieldMaxLen},
-		).buildRow(u.Policy)
+		return console.Colorize("PolicyName", u.Policy)
 	case "remove":
 		return console.Colorize("PolicyMessage", "Removed policy `"+u.Policy+"` successfully.")
 	case "add":

--- a/cmd/admin-policy-list.go
+++ b/cmd/admin-policy-list.go
@@ -57,8 +57,7 @@ func checkAdminPolicyListSyntax(ctx *cli.Context) {
 func mainAdminPolicyList(ctx *cli.Context) error {
 	checkAdminPolicyListSyntax(ctx)
 
-	console.SetColor("PolicyMessage", color.New(color.FgGreen))
-	console.SetColor("Policy", color.New(color.FgBlue))
+	console.SetColor("PolicyName", color.New(color.FgBlue))
 
 	// Get the alias parameter from cli
 	args := ctx.Args()


### PR DESCRIPTION
## Description
`mc admin policy list` only shows policy names, it does not need
 to cut the policy name to 20 characters when showing it.

## Motivation and Context
Trivial

## How to test this PR?
mc admin policy list <alias>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
