### PR TITLE
allow support for airgapped 'mc update' URL

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -401,7 +401,7 @@ func checkUpdate(ctx *cli.Context) {
 	// Do not print update messages, if quiet flag is set.
 	if ctx.Bool("quiet") || ctx.GlobalBool("quiet") {
 		// Its OK to ignore any errors during doUpdate() here.
-		if updateMsg, _, currentReleaseTime, latestReleaseTime, err := getUpdateInfo(2 * time.Second); err == nil {
+		if updateMsg, _, currentReleaseTime, latestReleaseTime, _, err := getUpdateInfo("", 2*time.Second); err == nil {
 			printMsg(updateMessage{
 				Status:  "success",
 				Message: updateMsg,


### PR DESCRIPTION
## Description
allow support for airgapped 'mc update' URL

## Motivation and Context
support airgapped environments to update `mc`
via a URL, similar to `minio server`

## How to test this PR?
```
~ GO111MODULE=on CGO_ENABLED=0 go build -trimpath -tags kqueue --ldflags "-s -w -X github.com/minio/mc/cmd.Version=2022-01-12T09:25:17Z -X github.com/minio/mc/cmd.CopyrightYear=2022 -X github.com/minio/mc/cmd.ReleaseTag=DEVELOPMENT.2022-01-12T09-25-17Z -X github.com/minio/mc/cmd.CommitID=9560d5993e478bcdf9cffe044f1effead2b85534 -X github.com/minio/mc/cmd.ShortCommitID=9560d5993e47" -o /home/harsha/go/src/github.com/minio/mc/mc

~  ./mc update https://dl.minio.io/client/mc/hotfixes/linux-amd64/archive/mc.RELEASE.2022-03-03T21-12-24Z.hotfix.12ad456a.sha256su
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
