### PR TITLE
Export perf test result related types

### DIFF
--- a/cmd/speedtest-spinner.go
+++ b/cmd/speedtest-spinner.go
@@ -37,31 +37,35 @@ var whiteStyle = lipgloss.NewStyle().
 type speedTestUI struct {
 	spinner  spinner.Model
 	quitting bool
-	result   speedTestResult
+	result   PerfTestResult
 }
 
-type speedTestType byte
+// PerfTestType - The type of performance test (net/drive/object)
+type PerfTestType byte
 
+// Constants for performance test type
 const (
-	netSpeedTest speedTestType = 1 << iota
-	driveSpeedTest
-	objectSpeedTest
+	NetPerfTest PerfTestType = 1 << iota
+	DrivePerfTest
+	ObjectPerfTest
 )
 
-func (s speedTestType) Name() string {
-	switch s {
-	case netSpeedTest:
+// Name - returns name of the performance test
+func (p PerfTestType) Name() string {
+	switch p {
+	case NetPerfTest:
 		return "NetPerf"
-	case driveSpeedTest:
+	case DrivePerfTest:
 		return "DrivePerf"
-	case objectSpeedTest:
+	case ObjectPerfTest:
 		return "ObjectPerf"
 	}
 	return "<unknown>"
 }
 
-type speedTestResult struct {
-	Type         speedTestType                 `json:"type"`
+// PerfTestResult - stores the result of a performance test
+type PerfTestResult struct {
+	Type         PerfTestType                  `json:"type"`
 	ObjectResult *madmin.SpeedTestResult       `json:"object,omitempty"`
 	NetResult    *madmin.NetperfResult         `json:"network,omitempty"`
 	DriveResult  []madmin.DriveSpeedTestResult `json:"drive,omitempty"`
@@ -92,7 +96,7 @@ func (m *speedTestUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			return m, nil
 		}
-	case speedTestResult:
+	case PerfTestResult:
 		m.result = msg
 		if msg.Final {
 			m.quitting = true

--- a/cmd/support-perf-drive.go
+++ b/cmd/support-perf-drive.go
@@ -68,8 +68,8 @@ func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string) error {
 
 	if globalJSON {
 		if e != nil {
-			printMsg(speedTestResult{
-				Type:  driveSpeedTest,
+			printMsg(PerfTestResult{
+				Type:  DrivePerfTest,
 				Err:   e.Error(),
 				Final: true,
 			})
@@ -82,8 +82,8 @@ func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string) error {
 				results = append(results, result)
 			}
 		}
-		printMsg(speedTestResult{
-			Type:        driveSpeedTest,
+		printMsg(PerfTestResult{
+			Type:        DrivePerfTest,
 			DriveResult: results,
 			Final:       true,
 		})
@@ -103,8 +103,8 @@ func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string) error {
 
 	go func() {
 		if e != nil {
-			printMsg(speedTestResult{
-				Type: driveSpeedTest,
+			printMsg(PerfTestResult{
+				Type: DrivePerfTest,
 				Err:  e.Error(),
 			})
 			return
@@ -115,14 +115,14 @@ func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string) error {
 			if result.Version != "" {
 				results = append(results, result)
 			} else {
-				p.Send(speedTestResult{
-					Type:        driveSpeedTest,
+				p.Send(PerfTestResult{
+					Type:        DrivePerfTest,
 					DriveResult: []madmin.DriveSpeedTestResult{},
 				})
 			}
 		}
-		p.Send(speedTestResult{
-			Type:        driveSpeedTest,
+		p.Send(PerfTestResult{
+			Type:        DrivePerfTest,
 			DriveResult: results,
 			Final:       true,
 		})

--- a/cmd/support-perf-net.go
+++ b/cmd/support-perf-net.go
@@ -64,14 +64,14 @@ func mainAdminSpeedTestNetperf(ctx *cli.Context, aliasedURL string) error {
 	if globalJSON {
 		select {
 		case e := <-errorCh:
-			printMsg(speedTestResult{
-				Type:  netSpeedTest,
+			printMsg(PerfTestResult{
+				Type:  NetPerfTest,
 				Err:   e.Error(),
 				Final: true,
 			})
 		case result := <-resultCh:
-			printMsg(speedTestResult{
-				Type:      netSpeedTest,
+			printMsg(PerfTestResult{
+				Type:      NetPerfTest,
 				NetResult: &result,
 				Final:     true,
 			})
@@ -93,22 +93,22 @@ func mainAdminSpeedTestNetperf(ctx *cli.Context, aliasedURL string) error {
 		for {
 			select {
 			case e := <-errorCh:
-				p.Send(speedTestResult{
-					Type:  netSpeedTest,
+				p.Send(PerfTestResult{
+					Type:  NetPerfTest,
 					Err:   e.Error(),
 					Final: true,
 				})
 				return
 			case result := <-resultCh:
-				p.Send(speedTestResult{
-					Type:      netSpeedTest,
+				p.Send(PerfTestResult{
+					Type:      NetPerfTest,
 					NetResult: &result,
 					Final:     true,
 				})
 				return
 			default:
-				p.Send(speedTestResult{
-					Type:      netSpeedTest,
+				p.Send(PerfTestResult{
+					Type:      NetPerfTest,
 					NetResult: &madmin.NetperfResult{},
 				})
 				time.Sleep(100 * time.Millisecond)

--- a/cmd/support-perf-object.go
+++ b/cmd/support-perf-object.go
@@ -95,8 +95,8 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string) error {
 
 	if globalJSON {
 		if e != nil {
-			printMsg(speedTestResult{
-				Type:  objectSpeedTest,
+			printMsg(PerfTestResult{
+				Type:  ObjectPerfTest,
 				Err:   e.Error(),
 				Final: true,
 			})
@@ -108,14 +108,14 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string) error {
 			if result.Version == "" {
 				continue
 			}
-			printMsg(speedTestResult{
-				Type:         objectSpeedTest,
+			printMsg(PerfTestResult{
+				Type:         ObjectPerfTest,
 				ObjectResult: &result,
 			})
 		}
 
-		printMsg(speedTestResult{
-			Type:         objectSpeedTest,
+		printMsg(PerfTestResult{
+			Type:         ObjectPerfTest,
 			ObjectResult: &result,
 			Final:        true,
 		})
@@ -135,8 +135,8 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string) error {
 
 	go func() {
 		if e != nil {
-			p.Send(speedTestResult{
-				Type:  objectSpeedTest,
+			p.Send(PerfTestResult{
+				Type:  ObjectPerfTest,
 				Err:   e.Error(),
 				Final: true,
 			})
@@ -145,13 +145,13 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string) error {
 
 		var result madmin.SpeedTestResult
 		for result = range resultCh {
-			p.Send(speedTestResult{
-				Type:         objectSpeedTest,
+			p.Send(PerfTestResult{
+				Type:         ObjectPerfTest,
 				ObjectResult: &result,
 			})
 		}
-		p.Send(speedTestResult{
-			Type:         objectSpeedTest,
+		p.Send(PerfTestResult{
+			Type:         ObjectPerfTest,
 			ObjectResult: &result,
 			Final:        true,
 		})

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -128,12 +128,13 @@ func objectTestShortResult(result *madmin.SpeedTestResult) (msg string) {
 	return msg
 }
 
-func (s speedTestResult) String() string {
+func (p PerfTestResult) String() string {
 	return ""
 }
 
-func (s speedTestResult) JSON() string {
-	JSONBytes, e := json.MarshalIndent(s, "", "    ")
+// JSON - jsonified update message.
+func (p PerfTestResult) JSON() string {
+	JSONBytes, e := json.MarshalIndent(p, "", "    ")
 	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
 	return string(JSONBytes)
 }


### PR DESCRIPTION
## Description

So that they can be used by `health-analyzer` when parsing the performance test results data.

## Motivation and Context

In a future enhancement, the performance results will be uploaded to SUBNET, which will parse
the same using a `health-analyzer` api.

Exporting the test results related types will allow `health-analyzer` to parse the data into the same,
without having to keep duplicate versions of these types.

## How to test this PR?

`mc support perf` command should work fine.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
