### PR TITLE
Remove duplicate key in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,3 @@
-linters-settings:
-  golint:
-    min-confidence: 0
-
-  misspell:
-    locale: US
-
 linters:
   disable-all: true
   enable:
@@ -24,6 +17,12 @@ linters:
     - gofumpt
 
 linters-settings:
+  golint:
+    min-confidence: 0
+
+  misspell:
+    locale: US
+
   gofumpt:
     lang-version: "1.17"
 


### PR DESCRIPTION
## Description

The .golangci.yml file contains the root level key `linters-settings` twice, resulting in following error when we run `make lint`:

```
> make lint
Running lint check
ERRO Can't read config: can't read viper config: While parsing config: yaml: unmarshal errors:
  line 26: mapping key "linters-settings" already defined at line 1
make: *** [Makefile:36: lint] Error 3
```

Fixed by merging into a single key.

## Motivation and Context

To fix error thrown by `make lint`

## How to test this PR?

Verify that `make lint` works fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
