### PR TITLE
Do Go vulncheck directly

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -13,5 +13,13 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-    - name: Check for vulnerabilities
-      uses: kmulvey/govulncheck-action@v1.0.0
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+    - name: Get official govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      shell: bash
+    - name: Run govulncheck
+      run: govulncheck ./...
+      shell: bash

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19.x
+        check-latest: true
     - name: Get official govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash


### PR DESCRIPTION
## Description

Skip action, just invoke it ourselves. Right now it is reporting an error since upstream uses v1.19.0

This allows us to specify Go version in our code.


## Types of changes
- [x] CI/CD change
