### PR TITLE
Upload results of perf tests to SUBNET

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -494,15 +494,15 @@ func getSubnetCreds(alias string) (string, string, error) {
 // getSubnetAPIKey - returns the SUBNET API key.
 // Returns error if the cluster is not registered with SUBNET.
 func getSubnetAPIKey(alias string) (string, error) {
-	apiKey, _, e := getSubnetCreds(alias)
+	apiKey, lic, e := getSubnetCreds(alias)
 	if e != nil {
 		return "", e
 	}
-	if len(apiKey) > 0 {
-		return apiKey, nil
+	if len(apiKey) == 0 && len(lic) == 0 {
+		e = fmt.Errorf("Please register the cluster first by running 'mc license register %s'", alias)
+		return "", e
 	}
-	e = fmt.Errorf("Please register the cluster first by running 'mc support register %s'", alias)
-	return "", e
+	return apiKey, nil
 }
 
 func getSubnetAPIKeyUsingLicense(lic string) (string, error) {

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -501,7 +501,7 @@ func getSubnetAPIKey(alias string) (string, error) {
 	if len(apiKey) > 0 {
 		return apiKey, nil
 	}
-	e = fmt.Errorf("Please register the cluster first by running 'mc support register %s', or use --airgap flag", alias)
+	e = fmt.Errorf("Please register the cluster first by running 'mc support register %s'", alias)
 	return "", e
 }
 

--- a/cmd/support-perf-drive.go
+++ b/cmd/support-perf-drive.go
@@ -28,7 +28,7 @@ import (
 	"github.com/minio/mc/pkg/probe"
 )
 
-func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string) error {
+func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string, outCh chan<- PerfTestResult) error {
 	client, perr := newAdminClient(aliasedURL)
 	if perr != nil {
 		fatalIf(perr.Trace(aliasedURL), "Unable to initialize admin client.")
@@ -121,11 +121,15 @@ func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string) error {
 				})
 			}
 		}
-		p.Send(PerfTestResult{
+		r := PerfTestResult{
 			Type:        DrivePerfTest,
 			DriveResult: results,
 			Final:       true,
-		})
+		}
+		p.Send(r)
+		if outCh != nil {
+			outCh <- r
+		}
 	}()
 
 	<-done

--- a/cmd/support-perf-drive.go
+++ b/cmd/support-perf-drive.go
@@ -103,10 +103,15 @@ func mainAdminSpeedTestDrive(ctx *cli.Context, aliasedURL string, outCh chan<- P
 
 	go func() {
 		if e != nil {
-			printMsg(PerfTestResult{
-				Type: DrivePerfTest,
-				Err:  e.Error(),
-			})
+			r := PerfTestResult{
+				Type:  DrivePerfTest,
+				Err:   e.Error(),
+				Final: true,
+			}
+			p.Send(r)
+			if outCh != nil {
+				outCh <- r
+			}
 			return
 		}
 

--- a/cmd/support-perf-net.go
+++ b/cmd/support-perf-net.go
@@ -93,11 +93,15 @@ func mainAdminSpeedTestNetperf(ctx *cli.Context, aliasedURL string, outCh chan<-
 		for {
 			select {
 			case e := <-errorCh:
-				p.Send(PerfTestResult{
+				r := PerfTestResult{
 					Type:  NetPerfTest,
 					Err:   e.Error(),
 					Final: true,
-				})
+				}
+				p.Send(r)
+				if outCh != nil {
+					outCh <- r
+				}
 				return
 			case result := <-resultCh:
 				r := PerfTestResult{

--- a/cmd/support-perf-net.go
+++ b/cmd/support-perf-net.go
@@ -28,7 +28,7 @@ import (
 	"github.com/minio/mc/pkg/probe"
 )
 
-func mainAdminSpeedTestNetperf(ctx *cli.Context, aliasedURL string) error {
+func mainAdminSpeedTestNetperf(ctx *cli.Context, aliasedURL string, outCh chan<- PerfTestResult) error {
 	client, perr := newAdminClient(aliasedURL)
 	if perr != nil {
 		fatalIf(perr.Trace(aliasedURL), "Unable to initialize admin client.")
@@ -100,11 +100,15 @@ func mainAdminSpeedTestNetperf(ctx *cli.Context, aliasedURL string) error {
 				})
 				return
 			case result := <-resultCh:
-				p.Send(PerfTestResult{
+				r := PerfTestResult{
 					Type:      NetPerfTest,
 					NetResult: &result,
 					Final:     true,
-				})
+				}
+				p.Send(r)
+				if outCh != nil {
+					outCh <- r
+				}
 				return
 			default:
 				p.Send(PerfTestResult{

--- a/cmd/support-perf-object.go
+++ b/cmd/support-perf-object.go
@@ -135,11 +135,15 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string, outCh chan<- 
 
 	go func() {
 		if e != nil {
-			p.Send(PerfTestResult{
+			r := PerfTestResult{
 				Type:  ObjectPerfTest,
 				Err:   e.Error(),
 				Final: true,
-			})
+			}
+			p.Send(r)
+			if outCh != nil {
+				outCh <- r
+			}
 			return
 		}
 

--- a/cmd/support-perf-object.go
+++ b/cmd/support-perf-object.go
@@ -46,7 +46,7 @@ func mainAdminSpeedtest(ctx *cli.Context) error {
 	return nil
 }
 
-func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string) error {
+func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string, outCh chan<- PerfTestResult) error {
 	client, perr := newAdminClient(aliasedURL)
 	if perr != nil {
 		fatalIf(perr.Trace(aliasedURL), "Unable to initialize admin client.")
@@ -150,11 +150,15 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string) error {
 				ObjectResult: &result,
 			})
 		}
-		p.Send(PerfTestResult{
+		r := PerfTestResult{
 			Type:         ObjectPerfTest,
 			ObjectResult: &result,
 			Final:        true,
-		})
+		}
+		p.Send(r)
+		if outCh != nil {
+			outCh <- r
+		}
 	}()
 
 	<-done

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -177,6 +177,17 @@ func mainSupportPerf(ctx *cli.Context) error {
 func execSupportPerf(ctx *cli.Context, aliasedURL string, perfType string) {
 	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL)
 
+	if len(apiKey) == 0 {
+		// api key not passed as flag. check if it's available in the config
+		var e error
+		apiKey, e = getSubnetAPIKey(alias)
+
+		// Non-registered execution allowed only in debug+airgapped mode
+		if !(globalDebug && globalAirgapped) {
+			fatalIf(probe.NewError(e), "Unable to retrieve SUBNET API key")
+		}
+	}
+
 	results := runPerfTests(ctx, aliasedURL, perfType)
 	if globalJSON {
 		// No file to be saved or uploaded to SUBNET in case of `--json`

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -170,11 +170,6 @@ func mainSupportProfile(ctx *cli.Context) error {
 	aliasedURL := ctx.Args().Get(0)
 	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL)
 
-	// if `--airgap` is provided do not try to upload to SUBNET.
-	if !globalAirgapped {
-		fatalIf(checkURLReachable(subnetBaseURL()).Trace(aliasedURL), "Unable to reach %s to upload MinIO profile file, please use --airgap to upload manually", subnetBaseURL())
-	}
-
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)
 


### PR DESCRIPTION
## Description

Apart from displaying the summary of the perf results on the screen,
generate a zip file containing the cluster metadata file (cluster.info)
and a JSON file containing the perf test results, and upload it to
SUBNET. Create this file as a temp file so that it gets automatically
deleted.
  
When the `--airgap` flag is passed (or if SUBNET upload fails), move the
temp file to current directory so that it can be inspected manually.

## Motivation and Context

Push performance test results to SUBNET so that they can be displayed
in a user friendly way on the browser.

## How to test this PR?

- Register a cluster on SUBNET (`mc license register`)
- Run the perf tests in non-airgapped mode (`mc support perf ALIAS`)
  - (the command should run succesfully without any error - currently there is no UI in SUBNET to test)
- Run the perf tests in airgapped mode (`mc support perf ALIAS --airgap`)
  - This should generate a zip file (`ALIAS-perf_timestamp.zip`) containing two files: `cluster.info` and `ALIAS-perf_timestamp.json`
  - Inspect the contents of both files and verify that they look fine
- Run the perf tests with `--json` flag (`mc support perf ALIAS --airgap --json`)
  - Check that the command prints the output in JSON format and exits, without generating any file or uploading the data to SUBNET.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
