### PR TITLE
Save API key if present in the license

### DIFF
--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -110,5 +110,9 @@ func performLicenseUpdate(licFile string, alias string) licUpdateMessage {
 	}
 
 	setSubnetLicense(alias, lic)
+	if len(li.APIKey) > 0 {
+		setSubnetAPIKey(alias, li.APIKey)
+	}
+
 	return lum
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/minio/madmin-go v1.4.29
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.38
-	github.com/minio/pkg v1.3.2
+	github.com/minio/pkg v1.4.1
 	github.com/minio/selfupdate v0.4.0
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/minio/minio-go/v7 v7.0.23/go.mod h1:ei5JjmxwHaMrgsMrn4U/+Nmg+d8MKS1U2
 github.com/minio/minio-go/v7 v7.0.38 h1:6hBjq6m/TWV+RcdsB95JwOw8PVv1P9LLb3gzL76IHWI=
 github.com/minio/minio-go/v7 v7.0.38/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
 github.com/minio/pkg v1.1.20/go.mod h1:Xo7LQshlxGa9shKwJ7NzQbgW4s8T/Wc1cOStR/eUiMY=
-github.com/minio/pkg v1.3.2 h1:zCpX8jtdF4k6r50sfqVY7rVMsagB4b9BYZaTiqpiknI=
-github.com/minio/pkg v1.3.2/go.mod h1:mxCLAG+fOGIQr6odQ5Ukqc6qv9Zj6v1d6TD3NP82B7Y=
+github.com/minio/pkg v1.4.1 h1:GXDy/CQ/NVxZ75dhAjM/5T2USWXAzoj6mXSXnD/vfgg=
+github.com/minio/pkg v1.4.1/go.mod h1:mxCLAG+fOGIQr6odQ5Ukqc6qv9Zj6v1d6TD3NP82B7Y=
 github.com/minio/selfupdate v0.4.0 h1:A7t07pN4Ch1tBTIRStW0KhUVyykz+2muCqFsITQeEW8=
 github.com/minio/selfupdate v0.4.0/go.mod h1:mcDkzMgq8PRcpCRJo/NlPY7U45O5dfYl2Y0Rg7IustY=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=


### PR DESCRIPTION
## Description

Save API key if present in the license

## Motivation and Context

Currently, when cluster is registered in airgapped mode, only the license is saved
on MinIO, and api key remains empty.

Now, if the api key is present in the license, we will extract and save it, so that
the registration is consistent in both connected and airgapped mode.

## How to test this PR?

- Register a new cluster on SUBNET using `mc license register {alias} --airgap`
- Download the license file from SUBNET
- Update the license on MinIO using `mc license update {alias} {license-file}`
- Verify that the api key has been set on MinIO using `mc admin config get {alias} subnet`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
