### PR TITLE
Error out from support commands if not registered

### DIFF
--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -43,7 +43,7 @@ var licenseRegisterCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainLicenseRegister,
 	Before:       setGlobalsFromContext,
-	Flags:        append(licenseRegisterFlags, globalFlags...),
+	Flags:        append(licenseRegisterFlags, supportGlobalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -65,11 +65,6 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 			Name:  "airgap",
 			Usage: "Use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
 		},
-		cli.BoolFlag{
-			Name:   "dev",
-			Usage:  "Development mode - talks to local SUBNET",
-			Hidden: true,
-		},
 		cli.StringFlag{
 			Name:  "api-key",
 			Usage: "API Key of the account on SUBNET",
@@ -725,10 +720,6 @@ func validateSubnetFlags(ctx *cli.Context) error {
 			return errors.New("--json is applicable only when --airgap is also passed")
 		}
 		return nil
-	}
-
-	if globalDevMode {
-		return errors.New("--dev is not applicable in airgap mode")
 	}
 
 	if len(ctx.String("api-key")) > 0 {

--- a/cmd/support-callhome.go
+++ b/cmd/support-callhome.go
@@ -31,7 +31,7 @@ var supportCallhomeCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainCallhome,
 	Before:       setGlobalsFromContext,
-	Flags:        globalFlags,
+	Flags:        supportGlobalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
@@ -93,7 +93,11 @@ func mainCallhome(ctx *cli.Context) error {
 		return nil
 	}
 
-	setCallhomeConfig(alias, arg == "enable")
+	enable := arg == "enable"
+	if enable {
+		validateClusterRegistered(alias, true)
+	}
+	setCallhomeConfig(alias, enable)
 
 	return nil
 }
@@ -109,7 +113,6 @@ func setCallhomeConfig(alias string, enableCallhome bool) {
 
 	enableStr := "off"
 	if enableCallhome {
-		validateClusterRegistered(alias)
 		enableStr = "on"
 	}
 	configStr := "callhome enable=" + enableStr

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -73,7 +73,7 @@ var supportDiagCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainSupportDiag,
 	Before:       setGlobalsFromContext,
-	Flags:        append(supportDiagFlags, globalFlags...),
+	Flags:        append(supportDiagFlags, supportGlobalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
@@ -160,6 +160,10 @@ func mainSupportDiag(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	aliasedURL := ctx.Args().Get(0)
 	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL)
+	if len(apiKey) == 0 {
+		// api key not passed as flag. Check that the cluster is registered.
+		apiKey = validateClusterRegistered(alias, true)
+	}
 
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)

--- a/cmd/support-inspect.go
+++ b/cmd/support-inspect.go
@@ -58,7 +58,7 @@ var supportInspectCmd = cli.Command{
 	Action:          mainSupportInspect,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(supportInspectFlags, globalFlags...),
+	Flags:           append(supportInspectFlags, supportGlobalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
@@ -100,6 +100,9 @@ func mainSupportInspect(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 	encrypt := ctx.Bool("encrypt")
+
+	alias, _ := url2Alias(aliasedURL)
+	validateClusterRegistered(alias, false)
 
 	console.SetColor("File", color.New(color.FgWhite, color.Bold))
 	console.SetColor("Key", color.New(color.FgHiRed, color.Bold))

--- a/cmd/support-logs-disable.go
+++ b/cmd/support-logs-disable.go
@@ -27,7 +27,7 @@ var supportLogsDisableCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainDisableLogs,
 	Before:       setGlobalsFromContext,
-	Flags:        logsConfigureFlags,
+	Flags:        supportGlobalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 USAGE:

--- a/cmd/support-logs-enable.go
+++ b/cmd/support-logs-enable.go
@@ -27,7 +27,7 @@ var supportLogsEnableCmd = cli.Command{
 	Action:          mainEnableLogs,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           logsConfigureFlags,
+	Flags:           supportGlobalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support-logs-status.go
+++ b/cmd/support-logs-status.go
@@ -27,7 +27,7 @@ var supportLogsStatusCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainStatusLogs,
 	Before:       setGlobalsFromContext,
-	Flags:        logsConfigureFlags,
+	Flags:        supportGlobalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 USAGE:

--- a/cmd/support-logs.go
+++ b/cmd/support-logs.go
@@ -33,12 +33,6 @@ var supportLogsSubcommands = []cli.Command{
 	supportLogsShowCmd,
 }
 
-var logsConfigureFlags = append(globalFlags, cli.BoolFlag{
-	Name:   "dev",
-	Usage:  "development mode - talks to local SUBNET",
-	Hidden: true,
-})
-
 var supportLogsCmd = cli.Command{
 	Name:            "logs",
 	Usage:           "configure/display MinIO console logs",
@@ -75,15 +69,14 @@ func configureSubnetWebhook(alias string, enable bool) {
 	client, err := newAdminClient(alias)
 	fatalIf(err, "Unable to initialize admin connection.")
 
-	apiKey := validateClusterRegistered(alias)
-
-	enableStr := "off"
+	var input string
 	if enable {
-		enableStr = "on"
+		apiKey := validateClusterRegistered(alias, true)
+		input = fmt.Sprintf("logger_webhook:subnet endpoint=%s auth_token=%s enable=on",
+			subnetLogWebhookURL(), apiKey)
+	} else {
+		input = "logger_webhook:subnet enable=off"
 	}
-
-	input := fmt.Sprintf("logger_webhook:subnet endpoint=%s auth_token=%s enable=%s",
-		subnetLogWebhookURL(), apiKey, enableStr)
 
 	// Call set config API
 	_, e := client.SetConfigKV(globalContext, input)

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -86,7 +86,7 @@ var supportPerfCmd = cli.Command{
 	Action:          mainSupportPerf,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(supportPerfFlags, globalFlags...),
+	Flags:           append(supportPerfFlags, supportGlobalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
@@ -176,16 +176,9 @@ func mainSupportPerf(ctx *cli.Context) error {
 
 func execSupportPerf(ctx *cli.Context, aliasedURL string, perfType string) {
 	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL)
-
 	if len(apiKey) == 0 {
-		// api key not passed as flag. check if it's available in the config
-		var e error
-		apiKey, e = getSubnetAPIKey(alias)
-
-		// Non-registered execution allowed only in debug+airgapped mode
-		if !(globalDebug && globalAirgapped) {
-			fatalIf(probe.NewError(e), "Unable to retrieve SUBNET API key")
-		}
+		// api key not passed as flag. Check that the cluster is registered.
+		apiKey = validateClusterRegistered(alias, true)
 	}
 
 	results := runPerfTests(ctx, aliasedURL, perfType)
@@ -218,10 +211,6 @@ func execSupportPerf(ctx *cli.Context, aliasedURL string, perfType string) {
 
 	clr := color.New(color.FgGreen, color.Bold)
 	clr.Println("uploaded successfully to SUBNET.")
-
-	if len(apiKey) > 0 {
-		setSubnetAPIKey(alias, apiKey)
-	}
 }
 
 func savePerfResultFile(tmpFileName string, resultFileNamePfx string, alias string) {

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -56,7 +56,7 @@ var supportProfileCmd = cli.Command{
 	Action:          mainSupportProfile,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(profileFlags, globalFlags...),
+	Flags:           append(profileFlags, supportGlobalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
@@ -169,6 +169,10 @@ func mainSupportProfile(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	aliasedURL := ctx.Args().Get(0)
 	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL)
+	if len(apiKey) == 0 {
+		// api key not passed as flag. Check that the cluster is registered.
+		apiKey = validateClusterRegistered(alias, true)
+	}
 
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)

--- a/cmd/support-register.go
+++ b/cmd/support-register.go
@@ -35,7 +35,7 @@ var supportRegisterCmd = cli.Command{
 	OnUsageError:       onUsageError,
 	Action:             mainSupportRegister,
 	Before:             setGlobalsFromContext,
-	Flags:              append(supportRegisterFlags, globalFlags...),
+	Flags:              append(supportRegisterFlags, supportGlobalFlags...),
 	CustomHelpTemplate: "Please use 'mc license register'",
 }
 

--- a/cmd/support-top-api.go
+++ b/cmd/support-top-api.go
@@ -51,7 +51,7 @@ var supportTopAPICmd = cli.Command{
 	Action:          mainSupportTopAPI,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(supportTopAPIFlags, globalFlags...),
+	Flags:           append(supportTopAPIFlags, supportGlobalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
@@ -82,6 +82,8 @@ func mainSupportTopAPI(ctx *cli.Context) error {
 	checkSupportTopAPISyntax(ctx)
 
 	aliasedURL := ctx.Args().Get(0)
+	alias, _ := url2Alias(aliasedURL)
+	validateClusterRegistered(alias, false)
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)

--- a/cmd/support-top-drive.go
+++ b/cmd/support-top-drive.go
@@ -42,7 +42,7 @@ var supportTopDriveCmd = cli.Command{
 	Action:          mainSupportTopDrive,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(supportTopDriveFlags, globalFlags...),
+	Flags:           append(supportTopDriveFlags, supportGlobalFlags...),
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
@@ -70,6 +70,8 @@ func mainSupportTopDrive(ctx *cli.Context) error {
 	checkSupportTopDriveSyntax(ctx)
 
 	aliasedURL := ctx.Args().Get(0)
+	alias, _ := url2Alias(aliasedURL)
+	validateClusterRegistered(alias, false)
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)

--- a/cmd/support-top-locks.go
+++ b/cmd/support-top-locks.go
@@ -48,7 +48,7 @@ var supportTopLocksCmd = cli.Command{
 	Before:       setGlobalsFromContext,
 	Action:       mainSupportTopLocks,
 	OnUsageError: onUsageError,
-	Flags:        append(supportTopLocksFlag, globalFlags...),
+	Flags:        append(supportTopLocksFlag, supportGlobalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
@@ -121,6 +121,8 @@ func mainSupportTopLocks(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
+	alias, _ := url2Alias(aliasedURL)
+	validateClusterRegistered(alias, false)
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)


### PR DESCRIPTION
## Description

Allow execution of support sub-commands only if the cluster is registered,
only exceptions being the commands that disable a feature or check its status:

- callhome disable
- callhome status
- logs disable
- logs status

OR when the `--api-key` flag is passed (where applicable)

## Motivation and Context

Registration is necessary for support-related functionality

## How to test this PR?

- Try all the `mc support` commands on an unregistered cluster and verify that they
fail with error `Please register the cluster first by running 'mc license register {alias}'`
- They should fail even when `--airgap` is passed (where applicable)
- Register the cluster and verify that the commands start working

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
