### PR TITLE
Remove perf tests from support diagnostics

### DIFF
--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -308,9 +308,6 @@ func fetchServerDiagInfo(ctx *cli.Context, client *madmin.AdminClient) (interfac
 	mem := spinner("Mem Info", madmin.HealthDataTypeSysMem)
 	process := spinner("Process Info", madmin.HealthDataTypeSysLoad)
 	config := spinner("Server Config", madmin.HealthDataTypeMinioConfig)
-	drive := spinner("Drive Test", madmin.HealthDataTypePerfDrive)
-	net := spinner("Network Test", madmin.HealthDataTypePerfNet)
-	obj := spinner("Objects Test", madmin.HealthDataTypePerfObj)
 	syserr := spinner("System Errors", madmin.HealthDataTypeSysErrors)
 	syssrv := spinner("System Services", madmin.HealthDataTypeSysServices)
 	sysconfig := spinner("System Config", madmin.HealthDataTypeSysConfig)
@@ -339,16 +336,12 @@ func fetchServerDiagInfo(ctx *cli.Context, client *madmin.AdminClient) (interfac
 	}
 
 	progress := func(info madmin.HealthInfo) {
-		noOfServers := len(info.Sys.CPUInfo)
 		_ = cpu(len(info.Sys.CPUInfo) > 0) &&
 			diskHw(len(info.Sys.Partitions) > 0) &&
 			osInfo(len(info.Sys.OSInfo) > 0) &&
 			mem(len(info.Sys.MemInfo) > 0) &&
 			process(len(info.Sys.ProcInfo) > 0) &&
 			config(info.Minio.Config.Config != nil) &&
-			drive(len(info.Perf.DrivePerf) > 0) &&
-			obj(len(info.Perf.ObjPerf) > 0) &&
-			net(noOfServers == 1 || len(info.Perf.NetPerf) > 0) &&
 			syserr(len(info.Sys.SysErrs) > 0) &&
 			syssrv(len(info.Sys.SysServices) > 0) &&
 			sysconfig(len(info.Sys.SysConfig) > 0) &&

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.24.0
 	github.com/minio/colorjson v1.0.2
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.4.29
+	github.com/minio/madmin-go v1.5.2
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.38
 	github.com/minio/pkg v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/minio/colorjson v1.0.2/go.mod h1:JWxcL2n8T8JVf+NY6awl6kn5nK49aAzHOeQE
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.3.5/go.mod h1:vGKGboQgGIWx4DuDUaXixjlIEZOCIp6ivJkQoiVaACc=
-github.com/minio/madmin-go v1.4.29 h1:Cu3F8Bh4vZNtNjrhAZnoM985hgXUDLUzJavUACafNc0=
-github.com/minio/madmin-go v1.4.29/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
+github.com/minio/madmin-go v1.5.2 h1:GRhnQO9fa+OQX+VgksLzR//ZkYWd5NB74UDY/7rQzRw=
+github.com/minio/madmin-go v1.5.2/go.mod h1:ez87VmMtsxP7DRxjKJKD4RDNW+nhO2QF9KSzwxBDQ98=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=


### PR DESCRIPTION
## Description

Remove perf tests from support diagnostics

## Motivation and Context

Now it is possible to run the `support perf` command separately,
which uploads the result to subnet. So there is not need to run
them as part of `support diag`. Removing them will make the diag
run way faster without affecting the s3 traffic.

## How to test this PR?

Run `mc support diag {alias} --airgap` and verify that it doesn't run
the perf tests and finishes in a matter of seconds.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
