### PR TITLE
Support `--dev` flag in license info|update

### DIFF
--- a/cmd/license-info.go
+++ b/cmd/license-info.go
@@ -36,7 +36,7 @@ var licenseInfoCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainLicenseInfo,
 	Before:       setGlobalsFromContext,
-	Flags:        append(globalFlags, subnetCommonFlags...),
+	Flags:        append(supportGlobalFlags, subnetCommonFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/license-update.go
+++ b/cmd/license-update.go
@@ -35,7 +35,7 @@ var licenseUpdateCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainLicenseUpdate,
 	Before:       setGlobalsFromContext,
-	Flags:        append(globalFlags, subnetCommonFlags...),
+	Flags:        append(supportGlobalFlags, subnetCommonFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 


### PR DESCRIPTION
## Description

If `--dev` is not supported, then the `mc license info|update` commands can fail in development mode
as they will always try to parse the license using production public key.

## Motivation and Context

Support development mode in `mc license info|update` commands

## How to test this PR?

- Register a cluster with a locally running subnet (`mc license register {alias} --dev`)
- Run `mc license info {alias} --dev` and verify that it doesn't error out, and shows license info properly
- Download the license file for the account from locally running subnet (`Deployments -> Cluster -> License`)
- Run `mc license update {alias} {path-to-lic-file} --dev` and verify that it doesn't error out

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression https://github.com/minio/mc/pull/4271
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
