### PR TITLE
Show airgapped registration link in different color

### DIFF
--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -28,7 +28,10 @@ import (
 	"github.com/minio/pkg/console"
 )
 
-const licRegisterMsgTag = "licenseRegisterMessage"
+const (
+	licRegisterMsgTag  = "licenseRegisterMessage"
+	licRegisterLinkTag = "licenseRegisterLink"
+)
 
 var licenseRegisterFlags = append([]cli.Flag{
 	cli.StringFlag{
@@ -83,12 +86,12 @@ func (li licRegisterMessage) String() string {
 	var msg string
 	switch li.Type {
 	case "online":
-		msg = fmt.Sprintf("%s %s successfully.", li.Alias, li.Action)
+		msg = console.Colorize(licRegisterMsgTag, fmt.Sprintf("%s %s successfully.", li.Alias, li.Action))
 	case "offline":
 		msg = fmt.Sprintln("Open the following URL in the browser to register", li.Alias, "on SUBNET:")
-		msg += li.URL
+		msg = console.Colorize(licRegisterMsgTag, msg) + console.Colorize(licRegisterLinkTag, li.URL)
 	}
-	return console.Colorize(licRegisterMsgTag, msg)
+	return msg
 }
 
 // JSON jsonified license register message
@@ -148,6 +151,7 @@ type SubnetMFAReq struct {
 
 func mainLicenseRegister(ctx *cli.Context) error {
 	console.SetColor(licRegisterMsgTag, color.New(color.FgGreen, color.Bold))
+	console.SetColor(licRegisterLinkTag, color.New(color.FgWhite, color.Bold))
 	checkLicenseRegisterSyntax(ctx)
 
 	// Get the alias parameter from cli


### PR DESCRIPTION
## Description

Show airgapped registration link in different color

## Motivation and Context

Distinguish between message and link

## How to test this PR?

Run `mc license register {alias} --airgap`
and verify that the subnet link is shown in a different color than the preceding message.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
