### PR TITLE
Replace 'policy' with 'anonymous' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ retention   set retention for object(s)
 legalhold   set legal hold for object(s)
 diff        list differences in object name, size, and date between two buckets
 rm          remove objects
-encrypt    manage bucket encryption config
+encrypt     manage bucket encryption config
 event       manage object notifications
 watch       listen for object notification events
 undo        undo PUT/DELETE operations
-policy      manage anonymous access to buckets and objects
+anonymous   manage anonymous access to buckets and objects
 tag         manage tags for bucket(s) and object(s)
 ilm         manage bucket lifecycle
 version     manage bucket versioning

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -5,23 +5,23 @@ MinIO Client (mc)为ls，cat，cp，mirror，diff，find等UNIX命令提供了�
 
 
 ```
-ls       列出文件和文件夹。
-mb       创建一个存储桶或一个文件夹。
-cat      显示文件和对象内容。
-pipe     将一个STDIN重定向到一个对象或者文件或者STDOUT。
-share    生成用于共享的URL。
-cp       拷贝文件和对象。
-mirror   给存储桶和文件夹做镜像。
-find     基于参数查找文件。
-diff     对两个文件夹或者存储桶比较差异。
-rm       删除文件和对象。
-events   管理对象通知。
-watch    监听文件和对象的事件。
-policy   管理访问策略。
-session  为cp命令管理保存的会话。
-config   管理mc配置文件。
-update   检查软件更新。
-version  输出版本信息。
+ls        列出文件和文件夹。
+mb        创建一个存储桶或一个文件夹。
+cat       显示文件和对象内容。
+pipe      将一个STDIN重定向到一个对象或者文件或者STDOUT。
+share     生成用于共享的URL。
+cp        拷贝文件和对象。
+mirror    给存储桶和文件夹做镜像。
+find      基于参数查找文件。
+diff      对两个文件夹或者存储桶比较差异。
+rm        删除文件和对象。
+events    管理对象通知。
+watch     监听文件和对象的事件。
+anonymous 管理访问策略。
+session   为cp命令管理保存的会话。
+config    管理mc配置文件。
+update    检查软件更新。
+version   输出版本信息。
 ```
 
 ## Docker容器


### PR DESCRIPTION
## Description
[This commit](https://github.com/minio/mc/pull/4276/commits/9d6ea124fa294ff1fe02a6e2dd133be9ee263200) removed the `mc policy` command because it has been replaced by `mc anonymous`. The readme in the repo was still describing the `policy` command

## Motivation and Context
Readme should match the code

## How to test this PR?
Just a readme update. No need to test.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] Fixes a regression (commit-id [9d6ea124fa294ff1fe02a6e2dd133be9ee263200](https://github.com/minio/mc/pull/4276/commits/9d6ea124fa294ff1fe02a6e2dd133be9ee263200))
- [ ] Unit tests added/updated
- [X] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
