### PR TITLE
Keep help output after quitting

### DIFF
--- a/cmd/term-pager.go
+++ b/cmd/term-pager.go
@@ -123,7 +123,6 @@ func (tp *termPager) init() {
 	go func() {
 		tp.teaPager = tea.NewProgram(
 			tp.model,
-			tea.WithAltScreen(),
 		)
 
 		go func() {


### PR DESCRIPTION
## Description
After quitting the help page, leave the help text in the screen. 
Technically, this means avoid using an alternate screen buffer.

## Motivation and Context
Some users want to still see the help after quitting it,
mainly to continue building the mc command and reading
the help message in parallel

## How to test this PR?
1 ./mc cp -h
2. Quit the help

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
