### PR TITLE
use showAppAndExit() for pager help

### DIFF
--- a/cmd/batch-describe.go
+++ b/cmd/batch-describe.go
@@ -50,7 +50,7 @@ EXAMPLES:
 // checkBatchDescribeSyntax - validate all the passed arguments
 func checkBatchDescribeSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+		showCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
 	}
 }
 

--- a/cmd/batch-generate.go
+++ b/cmd/batch-generate.go
@@ -50,7 +50,7 @@ EXAMPLES:
 // checkBatchGenerateSyntax - validate all the passed arguments
 func checkBatchGenerateSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+		showCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
 	}
 }
 

--- a/cmd/batch-list.go
+++ b/cmd/batch-list.go
@@ -120,7 +120,7 @@ func (c batchListMessage) JSON() string {
 // checkBatchListSyntax - validate all the passed arguments
 func checkBatchListSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 1 {
-		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+		showCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
 	}
 }
 

--- a/cmd/batch-start.go
+++ b/cmd/batch-start.go
@@ -75,7 +75,7 @@ func (c batchStartMessage) JSON() string {
 // checkBatchStartSyntax - validate all the passed arguments
 func checkBatchStartSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+		showCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
 	}
 }
 

--- a/cmd/batch-status.go
+++ b/cmd/batch-status.go
@@ -44,7 +44,7 @@ EXAMPLES:
 // checkBatchStatusSyntax - validate all the passed arguments
 func checkBatchStatusSyntax(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
-		cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
+		showCommandHelpAndExit(ctx, ctx.Command.Name, 1) // last argument is exit code
 	}
 }
 

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -240,7 +240,7 @@ func runPerfTests(ctx *cli.Context, aliasedURL string, perfType string) []PerfTe
 		case "net":
 			mainAdminSpeedTestNetperf(ctx, aliasedURL, resultCh)
 		default:
-			cli.ShowCommandHelpAndExit(ctx, "perf", 1) // last argument is exit code
+			showCommandHelpAndExit(ctx, "perf", 1) // last argument is exit code
 		}
 
 		if !globalJSON {


### PR DESCRIPTION
## Description
use showAppAndExit() for pager help

## Motivation and Context
this was missed in the pager help requirements

## How to test this PR?
just type `mc batch generate` it should show help instead
it hangs the terminal, causing one to run 'reset'

// cc @vadmeste the issue in perhaps just calling

cli.ShowAppAndExist()

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
