### PR TITLE
Update admin IDP commands with new design

### DIFF
--- a/cmd/admin-idp-info.go
+++ b/cmd/admin-idp-info.go
@@ -18,14 +18,8 @@
 package cmd
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/charmbracelet/lipgloss"
 	"github.com/minio/cli"
-	json "github.com/minio/colorjson"
 	"github.com/minio/madmin-go"
-	"github.com/minio/mc/pkg/probe"
 )
 
 var adminIDPInfoCmd = cli.Command{
@@ -34,6 +28,7 @@ var adminIDPInfoCmd = cli.Command{
 	Before:       setGlobalsFromContext,
 	Action:       mainAdminIDPGet,
 	OnUsageError: onUsageError,
+	Hidden:       true,
 	Flags:        globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
@@ -42,6 +37,9 @@ USAGE:
   {{.HelpName}} TARGET ID_TYPE [CFG_NAME]
 
   ID_TYPE must be one of 'ldap' or 'openid'.
+
+  **DEPRECATED**: This command will be removed in a future version. Please use
+  "mc admin idp ldap|openid" instead.
 
 FLAGS:
    {{range .VisibleFlags}}{{.}}
@@ -62,78 +60,14 @@ func mainAdminIDPGet(ctx *cli.Context) error {
 	}
 
 	args := ctx.Args()
-	aliasedURL := args.Get(0)
-
-	// Create a new MinIO Admin Client
-	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Unable to initialize admin connection.")
-
 	idpType := args.Get(1)
 	validateIDType(idpType)
+	isOpenID := idpType == madmin.OpenidIDPCfg
 
 	var cfgName string
 	if len(args) == 3 {
 		cfgName = args.Get(2)
 	}
 
-	result, e := client.GetIDPConfig(globalContext, idpType, cfgName)
-	fatalIf(probe.NewError(e), "Unable to get IDP config for '%s' to server", idpType)
-
-	// Print set config result
-	printMsg(idpConfig(result))
-
-	return nil
-}
-
-type idpConfig madmin.IDPConfig
-
-func (i idpConfig) JSON() string {
-	bs, e := json.MarshalIndent(i, "", "  ")
-	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
-
-	return string(bs)
-}
-
-func (i idpConfig) String() string {
-	// Determine required width for key column.
-	fieldColWidth := 0
-	for _, kv := range i.Info {
-		if fieldColWidth < len(kv.Key) {
-			fieldColWidth = len(kv.Key)
-		}
-	}
-	// Add 1 for the colon-suffix in each entry.
-	fieldColWidth++
-
-	fieldColStyle := lipgloss.NewStyle().
-		Width(fieldColWidth).
-		Foreground(lipgloss.Color("#04B575")). // green
-		Bold(true).
-		Align(lipgloss.Right)
-	valueColStyle := lipgloss.NewStyle().
-		PaddingLeft(1).
-		Align(lipgloss.Left)
-	envMarkStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("201")). // pinkish-red
-		PaddingLeft(1)
-
-	var lines []string
-	for _, kv := range i.Info {
-		envStr := ""
-		if kv.IsCfg && kv.IsEnv {
-			envStr = " (environment)"
-		}
-		lines = append(lines, fmt.Sprintf("%s%s%s",
-			fieldColStyle.Render(kv.Key+":"),
-			valueColStyle.Render(kv.Value),
-			envMarkStyle.Render(envStr),
-		))
-	}
-
-	boxContent := strings.Join(lines, "\n")
-
-	boxStyle := lipgloss.NewStyle().
-		BorderStyle(lipgloss.RoundedBorder())
-
-	return boxStyle.Render(boxContent)
+	return adminIDPInfo(ctx, isOpenID, cfgName)
 }

--- a/cmd/admin-idp-ldap-add.go
+++ b/cmd/admin-idp-ldap-add.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/minio/cli"
+	"github.com/minio/madmin-go"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var adminIDPLdapAddCmd = cli.Command{
+	Name:         "add",
+	Usage:        "Create an LDAP IDP server configuration",
+	Action:       mainAdminIDPLDAPAdd,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	OnUsageError: onUsageError,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET [CFG_NAME] [CFG_PARAMS...]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Create a default LDAP IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} myminio/ \
+          server_addr=myldapserver:636 \
+          lookup_bind_dn=cn=admin,dc=min,dc=io \
+          lookup_bind_password=somesecret \
+          user_dn_search_base_dn=dc=min,dc=io \
+          user_dn_search_filter="(uid=%s)" \
+          group_search_base_dn=ou=swengg,dc=min,dc=io \
+          group_search_filter="(&(objectclass=groupofnames)(member=%d))"
+`,
+}
+
+func mainAdminIDPLDAPAdd(ctx *cli.Context) error {
+	if len(ctx.Args()) < 2 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
+	args := ctx.Args()
+
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	cfgName := madmin.Default
+	input := args[1:]
+	if !strings.Contains(args.Get(1), "=") {
+		cfgName = args.Get(1)
+		input = args[2:]
+	}
+
+	inputCfg := strings.Join(input, " ")
+
+	restart, e := client.AddOrUpdateIDPConfig(globalContext, madmin.LDAPIDPCfg, cfgName, inputCfg, false)
+	fatalIf(probe.NewError(e), "Unable to add LDAP IDP config to server")
+
+	// Print set config result
+	printMsg(configSetMessage{
+		targetAlias: aliasedURL,
+		restart:     restart,
+	})
+
+	return nil
+}

--- a/cmd/admin-idp-ldap-disable.go
+++ b/cmd/admin-idp-ldap-disable.go
@@ -19,46 +19,33 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
 )
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPLdapDisableCmd = cli.Command{
+	Name:         "disable",
+	Usage:        "Disable an LDAP IDP server configuration",
+	Action:       mainAdminIDPLDAPDisable,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET [CFG_NAME]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Disable the default LDAP IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Disable LDAP IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+func mainAdminIDPLDAPDisable(ctx *cli.Context) error {
+	isOpenID, enable := false, false
+	return adminIDPEnableDisable(ctx, isOpenID, enable)
 }

--- a/cmd/admin-idp-ldap-enable.go
+++ b/cmd/admin-idp-ldap-enable.go
@@ -19,46 +19,33 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
 )
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPLdapEnableCmd = cli.Command{
+	Name:         "enable",
+	Usage:        "manage LDAP IDP server configuration",
+	Action:       mainAdminIDPLDAPEnable,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET [CFG_NAME]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Enable the default LDAP IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Enable LDAP IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+func mainAdminIDPLDAPEnable(ctx *cli.Context) error {
+	isOpenID, enable := false, true
+	return adminIDPEnableDisable(ctx, isOpenID, enable)
 }

--- a/cmd/admin-idp-ldap-info.go
+++ b/cmd/admin-idp-ldap-info.go
@@ -19,46 +19,42 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
 )
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPLdapInfoCmd = cli.Command{
+	Name:         "info",
+	Usage:        "get LDAP IDP server configuration info",
+	Action:       mainAdminIDPLDAPInfo,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET [CFG_NAME]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Get configuration info on the default LDAP IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Get configuration info on LDAP IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
+func mainAdminIDPLDAPInfo(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
 		showCommandHelpAndExit(ctx, 1)
 	}
 
 	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
+	var cfgName string
+	if len(args) == 2 {
+		cfgName = args.Get(1)
+	}
 
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+	return adminIDPInfo(ctx, false, cfgName)
 }

--- a/cmd/admin-idp-ldap-list.go
+++ b/cmd/admin-idp-ldap-list.go
@@ -17,48 +17,34 @@
 
 package cmd
 
-import (
-	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
-)
+import "github.com/minio/cli"
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPLdapListCmd = cli.Command{
+	Name:         "list",
+	Usage:        "list LDAP IDP server configuration(s)",
+	Action:       mainAdminIDPLDAPList,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. List configurations for LDAP IDP.
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
+func mainAdminIDPLDAPList(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
 		showCommandHelpAndExit(ctx, 1)
 	}
 
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+	return adminIDPListCommon(ctx, false)
 }

--- a/cmd/admin-idp-ldap-remove.go
+++ b/cmd/admin-idp-ldap-remove.go
@@ -17,48 +17,40 @@
 
 package cmd
 
-import (
-	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
-)
+import "github.com/minio/cli"
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPLdapRemoveCmd = cli.Command{
+	Name:         "remove",
+	Usage:        "remove LDAP IDP server configuration",
+	Action:       mainAdminIDPLDAPRemove,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET [CFG_NAME]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Remove the default LDAP IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
+func mainAdminIDPLDAPRemove(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
 		showCommandHelpAndExit(ctx, 1)
 	}
 
 	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
 
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+	var cfgName string
+	if len(args) == 2 {
+		cfgName = args.Get(2)
+	}
+	return adminIDPRemove(ctx, false, cfgName)
 }

--- a/cmd/admin-idp-ldap-update.go
+++ b/cmd/admin-idp-ldap-update.go
@@ -17,48 +17,32 @@
 
 package cmd
 
-import (
-	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
-)
+import "github.com/minio/cli"
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
-	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
+var adminIDPLdapUpdateCmd = cli.Command{
+	Name:         "update",
+	Usage:        "Update an LDAP IDP configuration",
+	Action:       mainAdminIDPLDAPUpdate,
 	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
 	Flags:        globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET ID_TYPE [CFG_NAME] [CFG_PARAMS...]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Create/Update the default LDAP IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/ ldap \
+          lookup_bind_dn=cn=admin,dc=min,dc=io \
+          lookup_bind_password=somesecret
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+func mainAdminIDPLDAPUpdate(ctx *cli.Context) error {
+	return nil
 }

--- a/cmd/admin-idp-ldap.go
+++ b/cmd/admin-idp-ldap.go
@@ -19,26 +19,29 @@ package cmd
 
 import "github.com/minio/cli"
 
-var adminIDPSubcommands = []cli.Command{
-	adminIDPOpenidCmd,
-	adminIDPLdapCmd,
-	adminIDPSetCmd,
-	adminIDPInfoCmd,
-	adminIDPLsCmd,
-	adminIDPRmCmd,
-}
+var (
+	adminIDPLdapSubcommands = []cli.Command{
+		adminIDPLdapAddCmd,
+		adminIDPLdapUpdateCmd,
+		adminIDPLdapRemoveCmd,
+		adminIDPLdapListCmd,
+		adminIDPLdapInfoCmd,
+		adminIDPLdapEnableCmd,
+		adminIDPLdapDisableCmd,
+		// TODO: adminIDPLdapPolicyCmd,
+	}
+	adminIDPLdapCmd = cli.Command{
+		Name:            "ldap",
+		Usage:           "manage Ldap IDP server configuration",
+		Action:          mainAdminIDPLdap,
+		Before:          setGlobalsFromContext,
+		Flags:           globalFlags,
+		Subcommands:     adminIDPLdapSubcommands,
+		HideHelpCommand: true,
+	}
+)
 
-var adminIDPCmd = cli.Command{
-	Name:            "idp",
-	Usage:           "manage MinIO IDentity Provider server configuration",
-	Action:          mainAdminIDP,
-	Before:          setGlobalsFromContext,
-	Flags:           globalFlags,
-	Subcommands:     adminIDPSubcommands,
-	HideHelpCommand: true,
-}
-
-func mainAdminIDP(ctx *cli.Context) error {
-	commandNotFound(ctx, adminIDPSubcommands)
+func mainAdminIDPLdap(ctx *cli.Context) error {
+	commandNotFound(ctx, adminIDPLdapSubcommands)
 	return nil
 }

--- a/cmd/admin-idp-openid-add.go
+++ b/cmd/admin-idp-openid-add.go
@@ -18,8 +18,6 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/minio/cli"
@@ -27,67 +25,48 @@ import (
 	"github.com/minio/mc/pkg/probe"
 )
 
-var adminIDPSetCmd = cli.Command{
-	Name:         "set",
-	Usage:        "Create/Update an IDP server configuration",
+var adminIDPOpenidAddCmd = cli.Command{
+	Name:         "add",
+	Usage:        "Create an OpenID IDP server configuration",
+	Action:       mainAdminIDPOpenIDAdd,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPSet,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET ID_TYPE [CFG_NAME] [CFG_PARAMS...]
-
-  ID_TYPE must be one of 'ldap' or 'openid'.
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET [CFG_NAME] [CFG_PARAMS...]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Create/Update the default OpenID IDP configuration (CFG_NAME is omitted).
-     {{.Prompt}} {{.HelpName}} play/ openid \
+  1. Create a default OpenID IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/ \
           client_id=minio-client-app \
           client_secret=minio-client-app-secret \
           config_url="http://localhost:5556/dex/.well-known/openid-configuration" \
           scopes="openid,groups" \
           redirect_uri="http://127.0.0.1:10000/oauth_callback" \
           role_policy="consoleAdmin"
-  2. Create/Update configuration for OpenID IDP configuration named "dex_test".
-     {{.Prompt}} {{.HelpName}} play/ openid dex_test \
+  2. Create OpenID IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test \
           client_id=minio-client-app \
           client_secret=minio-client-app-secret \
           config_url="http://localhost:5556/dex/.well-known/openid-configuration" \
           scopes="openid,groups" \
           redirect_uri="http://127.0.0.1:10000/oauth_callback" \
           role_policy="consoleAdmin"
-  3. Create/Update the LDAP IDP configuration (CFG_NAME must be empty for LDAP).
-     {{.Prompt}} {{.HelpName}} play/ ldap \
-          server_addr=ldap.corp.min.io:686 \
-          lookup_bind_dn=cn=readonly,ou=service_account,dc=min,dc=io \
-          lookup_bind_password=mysecretpassword \
-          user_dn_search_base_dn=dc=min,dc=io \
-          user_dn_search_filter="(uid=%s)" \
-          group_search_base_dn=ou=swengg,dc=min,dc=io \
-          group_search_filter="(&(objectclass=groupofnames)(member=%d))"
-
 `,
 }
 
-func validateIDType(idpType string) {
-	if !madmin.ValidIDPConfigTypes.Contains(idpType) {
-		fatalIf(probe.NewError(errors.New("invalid IDP type")),
-			fmt.Sprintf("IDP type must be one of %v", madmin.ValidIDPConfigTypes))
-	}
+func mainAdminIDPOpenIDAdd(ctx *cli.Context) error {
+	return mainAdminIDPOpenIDAddOrUpdate(ctx, false)
 }
 
-func mainAdminIDPSet(ctx *cli.Context) error {
-	if len(ctx.Args()) < 3 {
+func mainAdminIDPOpenIDAddOrUpdate(ctx *cli.Context, update bool) error {
+	if len(ctx.Args()) < 2 {
 		showCommandHelpAndExit(ctx, 1)
 	}
 
@@ -99,20 +78,17 @@ func mainAdminIDPSet(ctx *cli.Context) error {
 	client, err := newAdminClient(aliasedURL)
 	fatalIf(err, "Unable to initialize admin connection.")
 
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	var cfgName string
-	input := args[2:]
-	if !strings.Contains(args.Get(2), "=") {
-		cfgName = args.Get(2)
-		input = args[3:]
+	cfgName := madmin.Default
+	input := args[1:]
+	if !strings.Contains(args.Get(1), "=") {
+		cfgName = args.Get(1)
+		input = args[2:]
 	}
 
 	inputCfg := strings.Join(input, " ")
 
-	restart, e := client.AddOrUpdateIDPConfig(globalContext, idpType, cfgName, inputCfg, false)
-	fatalIf(probe.NewError(e), "Unable to set IDP config for '%s' to server", idpType)
+	restart, e := client.AddOrUpdateIDPConfig(globalContext, madmin.OpenidIDPCfg, cfgName, inputCfg, update)
+	fatalIf(probe.NewError(e), "Unable to add OpenID IDP config to server")
 
 	// Print set config result
 	printMsg(configSetMessage{

--- a/cmd/admin-idp-openid-disable.go
+++ b/cmd/admin-idp-openid-disable.go
@@ -19,46 +19,33 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
 )
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPOpenidDisableCmd = cli.Command{
+	Name:         "disable",
+	Usage:        "Disable an OpenID IDP server configuration",
+	Action:       mainAdminIDPOpenIDDisable,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
-	OnUsageError: onUsageError,
 	Flags:        globalFlags,
+	OnUsageError: onUsageError,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET [CFG_NAME]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Disable the default OpenID IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Disable OpenID IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+func mainAdminIDPOpenIDDisable(ctx *cli.Context) error {
+	isOpenID, enable := true, false
+	return adminIDPEnableDisable(ctx, isOpenID, enable)
 }

--- a/cmd/admin-idp-openid-enable.go
+++ b/cmd/admin-idp-openid-enable.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"github.com/minio/cli"
+	"github.com/minio/madmin-go"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var adminIDPOpenidEnableCmd = cli.Command{
+	Name:         "enable",
+	Usage:        "enable an OpenID IDP server configuration",
+	Action:       mainAdminIDPOpenIDEnable,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	OnUsageError: onUsageError,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET [CFG_NAME]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Enable the default OpenID IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Enable OpenID IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
+`,
+}
+
+func mainAdminIDPOpenIDEnable(ctx *cli.Context) error {
+	isOpenID, enable := true, true
+	return adminIDPEnableDisable(ctx, isOpenID, enable)
+}
+
+func adminIDPEnableDisable(ctx *cli.Context, isOpenID bool, enable bool) error {
+	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
+	args := ctx.Args()
+	cfgName := madmin.Default
+	if len(args) == 2 {
+		cfgName = args.Get(2)
+	}
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	idpType := madmin.LDAPIDPCfg
+	if isOpenID {
+		idpType = madmin.OpenidIDPCfg
+	}
+
+	configBody := "enable=on"
+	if !enable {
+		configBody = "enable=off"
+	}
+
+	restart, e := client.AddOrUpdateIDPConfig(globalContext, idpType, cfgName, configBody, true)
+	fatalIf(probe.NewError(e), "Unable to remove %s IDP config '%s'", idpType, cfgName)
+
+	printMsg(configSetMessage{
+		targetAlias: aliasedURL,
+		restart:     restart,
+	})
+
+	return nil
+}

--- a/cmd/admin-idp-openid-info.go
+++ b/cmd/admin-idp-openid-info.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/madmin-go"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var adminIDPOpenidInfoCmd = cli.Command{
+	Name:         "info",
+	Usage:        "get OpenID IDP server configuration info",
+	Action:       mainAdminIDPOpenIDInfo,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	OnUsageError: onUsageError,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET [CFG_NAME]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Get configuration info on the default OpenID IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Get configuration info on OpenID IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
+`,
+}
+
+func mainAdminIDPOpenIDInfo(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
+	args := ctx.Args()
+	var cfgName string
+	if len(args) == 2 {
+		cfgName = args.Get(1)
+	}
+
+	return adminIDPInfo(ctx, true, cfgName)
+}
+
+func adminIDPInfo(ctx *cli.Context, isOpenID bool, cfgName string) error {
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	idpType := madmin.LDAPIDPCfg
+	if isOpenID {
+		idpType = madmin.OpenidIDPCfg
+	}
+
+	result, e := client.GetIDPConfig(globalContext, idpType, cfgName)
+	fatalIf(probe.NewError(e), "Unable to get %s IDP config from server", idpType)
+
+	// Print set config result
+	printMsg(idpConfig(result))
+
+	return nil
+}
+
+type idpConfig madmin.IDPConfig
+
+func (i idpConfig) JSON() string {
+	bs, e := json.MarshalIndent(i, "", "  ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(bs)
+}
+
+func (i idpConfig) String() string {
+	// Determine required width for key column.
+	fieldColWidth := 0
+	for _, kv := range i.Info {
+		if fieldColWidth < len(kv.Key) {
+			fieldColWidth = len(kv.Key)
+		}
+	}
+	// Add 1 for the colon-suffix in each entry.
+	fieldColWidth++
+
+	fieldColStyle := lipgloss.NewStyle().
+		Width(fieldColWidth).
+		Foreground(lipgloss.Color("#04B575")). // green
+		Bold(true).
+		Align(lipgloss.Right)
+	valueColStyle := lipgloss.NewStyle().
+		PaddingLeft(1).
+		Align(lipgloss.Left)
+	envMarkStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("201")). // pinkish-red
+		PaddingLeft(1)
+
+	var lines []string
+	for _, kv := range i.Info {
+		envStr := ""
+		if kv.IsCfg && kv.IsEnv {
+			envStr = " (environment)"
+		}
+		lines = append(lines, fmt.Sprintf("%s%s%s",
+			fieldColStyle.Render(kv.Key+":"),
+			valueColStyle.Render(kv.Value),
+			envMarkStyle.Render(envStr),
+		))
+	}
+
+	boxContent := strings.Join(lines, "\n")
+
+	boxStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder())
+
+	return boxStyle.Render(boxContent)
+}

--- a/cmd/admin-idp-openid-list.go
+++ b/cmd/admin-idp-openid-list.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/madmin-go"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var adminIDPOpenidListCmd = cli.Command{
+	Name:         "list",
+	Usage:        "list OpenID IDP server configuration(s)",
+	Action:       mainAdminIDPOpenIDList,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	OnUsageError: onUsageError,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. List configurations for OpenID IDP.
+     {{.Prompt}} {{.HelpName}} play/
+`,
+}
+
+func mainAdminIDPOpenIDList(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
+	return adminIDPListCommon(ctx, true)
+}
+
+func adminIDPListCommon(ctx *cli.Context, isOpenID bool) error {
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	idpType := madmin.LDAPIDPCfg
+	if isOpenID {
+		idpType = madmin.OpenidIDPCfg
+	}
+	result, e := client.ListIDPConfig(globalContext, idpType)
+	fatalIf(probe.NewError(e), "Unable to list IDP config for '%s'", idpType)
+
+	printMsg(idpCfgList(result))
+
+	return nil
+}
+
+type idpCfgList []madmin.IDPListItem
+
+func (i idpCfgList) JSON() string {
+	bs, e := json.MarshalIndent(i, "", "  ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(bs)
+}
+
+func (i idpCfgList) String() string {
+	maxNameWidth := len("Name")
+	maxRoleARNWidth := len("RoleArn")
+	for _, item := range i {
+		name := item.Name
+		if name == "_" {
+			name = "(default)" // for the un-named config, don't show `_`
+		}
+		if maxNameWidth < len(name) {
+			maxNameWidth = len(name)
+		}
+		if maxRoleARNWidth < len(item.RoleARN) {
+			maxRoleARNWidth = len(item.RoleARN)
+		}
+	}
+	enabledWidth := 5
+	// Add 2 for padding
+	maxNameWidth += 2
+	maxRoleARNWidth += 2
+
+	enabledColStyle := lipgloss.NewStyle().
+		Align(lipgloss.Center).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Width(enabledWidth)
+	nameColStyle := lipgloss.NewStyle().
+		Align(lipgloss.Right).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Width(maxNameWidth)
+	arnColStyle := lipgloss.NewStyle().
+		Align(lipgloss.Left).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Foreground(lipgloss.Color("#04B575")). // green
+		Width(maxRoleARNWidth)
+
+	styles := []lipgloss.Style{enabledColStyle, nameColStyle, arnColStyle}
+
+	headers := []string{"On?", "Name", "RoleARN"}
+	headerRow := []string{}
+
+	// Override some style settings for the header
+	for ii, hdr := range headers {
+		headerRow = append(headerRow,
+			styles[ii].Copy().
+				Bold(true).
+				Foreground(lipgloss.Color("#6495ed")). // green
+				Align(lipgloss.Center).
+				Render(hdr),
+		)
+	}
+
+	lines := []string{strings.Join(headerRow, "")}
+
+	enabledOff := "🔴"
+	enabledOn := "🟢"
+
+	for _, item := range i {
+		enabled := enabledOff
+		if item.Enabled {
+			enabled = enabledOn
+		}
+
+		line := []string{
+			styles[0].Render(enabled),
+			styles[1].Render(item.Name),
+			styles[2].Render(item.RoleARN),
+		}
+		if item.Name == "_" {
+			// For default config, don't display `_` and make it look faint.
+			line[1] = styles[1].Copy().
+				Faint(true).
+				Render("(default)")
+		}
+		lines = append(lines, strings.Join(line, ""))
+	}
+
+	boxContent := strings.Join(lines, "\n")
+	boxStyle := lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder())
+
+	return boxStyle.Render(boxContent)
+}

--- a/cmd/admin-idp-openid-remove.go
+++ b/cmd/admin-idp-openid-remove.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"github.com/minio/cli"
+	"github.com/minio/madmin-go"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var adminIDPOpenidRemoveCmd = cli.Command{
+	Name:         "remove",
+	Usage:        "remove OpenID IDP server configuration",
+	Action:       mainAdminIDPOpenIDRemove,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	OnUsageError: onUsageError,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET [CFG_NAME]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Remove the default OpenID IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/
+  2. Remove OpenID IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ dex_test
+`,
+}
+
+func mainAdminIDPOpenIDRemove(ctx *cli.Context) error {
+	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
+	args := ctx.Args()
+
+	var cfgName string
+	if len(args) == 2 {
+		cfgName = args.Get(2)
+	}
+	return adminIDPRemove(ctx, true, cfgName)
+}
+
+func adminIDPRemove(ctx *cli.Context, isOpenID bool, cfgName string) error {
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	idpType := madmin.LDAPIDPCfg
+	if isOpenID {
+		idpType = madmin.OpenidIDPCfg
+	}
+
+	restart, e := client.DeleteIDPConfig(globalContext, idpType, cfgName)
+	fatalIf(probe.NewError(e), "Unable to remove %s IDP config '%s'", idpType, cfgName)
+
+	printMsg(configSetMessage{
+		targetAlias: aliasedURL,
+		restart:     restart,
+	})
+
+	return nil
+}

--- a/cmd/admin-idp-openid-update.go
+++ b/cmd/admin-idp-openid-update.go
@@ -17,48 +17,36 @@
 
 package cmd
 
-import (
-	"github.com/minio/cli"
-	"github.com/minio/madmin-go"
-)
+import "github.com/minio/cli"
 
-var adminIDPRmCmd = cli.Command{
-	Name:         "rm",
-	Usage:        "Remove an IDP configuration",
+var adminIDPOpenidUpdateCmd = cli.Command{
+	Name:         "update",
+	Usage:        "Update an OpenID IDP configuration",
+	Action:       mainAdminIDPOpenIDUpdate,
 	Before:       setGlobalsFromContext,
-	Action:       mainAdminIDPRemove,
-	Hidden:       true,
 	OnUsageError: onUsageError,
 	Flags:        globalFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
+  {{.HelpName}} TARGET ID_TYPE [CFG_NAME] [CFG_PARAMS...]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+  1. Update the default OpenID IDP configuration (CFG_NAME is omitted).
+     {{.Prompt}} {{.HelpName}} play/ openid \
+          scopes="openid,groups" \
+          role_policy="consoleAdmin"
+  2. Update configuration for OpenID IDP configuration named "dex_test".
+     {{.Prompt}} {{.HelpName}} play/ openid dex_test \
+          scopes="openid,groups" \
+          role_policy="consoleAdmin"
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+func mainAdminIDPOpenIDUpdate(ctx *cli.Context) error {
+	return mainAdminIDPOpenIDAddOrUpdate(ctx, true)
 }

--- a/cmd/admin-idp-openid.go
+++ b/cmd/admin-idp-openid.go
@@ -19,26 +19,29 @@ package cmd
 
 import "github.com/minio/cli"
 
-var adminIDPSubcommands = []cli.Command{
-	adminIDPOpenidCmd,
-	adminIDPLdapCmd,
-	adminIDPSetCmd,
-	adminIDPInfoCmd,
-	adminIDPLsCmd,
-	adminIDPRmCmd,
-}
+var (
+	adminIDPOpenidSubcommands = []cli.Command{
+		adminIDPOpenidAddCmd,
+		adminIDPOpenidUpdateCmd,
+		adminIDPOpenidRemoveCmd,
+		adminIDPOpenidListCmd,
+		adminIDPOpenidInfoCmd,
+		adminIDPOpenidEnableCmd,
+		adminIDPOpenidDisableCmd,
+		// TODO: adminIDPOpenidPolicyCmd,
+	}
+	adminIDPOpenidCmd = cli.Command{
+		Name:            "openid",
+		Usage:           "manage OpenID IDP server configuration",
+		Action:          mainAdminIDPOpenID,
+		Before:          setGlobalsFromContext,
+		Flags:           globalFlags,
+		Subcommands:     adminIDPOpenidSubcommands,
+		HideHelpCommand: true,
+	}
+)
 
-var adminIDPCmd = cli.Command{
-	Name:            "idp",
-	Usage:           "manage MinIO IDentity Provider server configuration",
-	Action:          mainAdminIDP,
-	Before:          setGlobalsFromContext,
-	Flags:           globalFlags,
-	Subcommands:     adminIDPSubcommands,
-	HideHelpCommand: true,
-}
-
-func mainAdminIDP(ctx *cli.Context) error {
-	commandNotFound(ctx, adminIDPSubcommands)
+func mainAdminIDPOpenID(ctx *cli.Context) error {
+	commandNotFound(ctx, adminIDPOpenidSubcommands)
 	return nil
 }

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -356,6 +356,22 @@ var completeCmds = map[string]complete.Predictor{
 	"/admin/idp/ls":   aliasCompleter,
 	"/admin/idp/rm":   aliasCompleter,
 
+	"/admin/idp/openid/add":     aliasCompleter,
+	"/admin/idp/openid/update":  aliasCompleter,
+	"/admin/idp/openid/remove":  aliasCompleter,
+	"/admin/idp/openid/list":    aliasCompleter,
+	"/admin/idp/openid/info":    aliasCompleter,
+	"/admin/idp/openid/enable":  aliasCompleter,
+	"/admin/idp/openid/disable": aliasCompleter,
+
+	"/admin/idp/ldap/add":     aliasCompleter,
+	"/admin/idp/ldap/update":  aliasCompleter,
+	"/admin/idp/ldap/remove":  aliasCompleter,
+	"/admin/idp/ldap/list":    aliasCompleter,
+	"/admin/idp/ldap/info":    aliasCompleter,
+	"/admin/idp/ldap/enable":  aliasCompleter,
+	"/admin/idp/ldap/disable": aliasCompleter,
+
 	"/admin/policy/info":   aliasCompleter,
 	"/admin/policy/set":    aliasCompleter,
 	"/admin/policy/unset":  aliasCompleter,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.24.0
 	github.com/minio/colorjson v1.0.4
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go v1.7.1
+	github.com/minio/madmin-go v1.7.3
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.41
 	github.com/minio/pkg v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbL
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go v1.7.1 h1:4eMyMkLSVUFZmrrwxJrYnzRimy6eCoobqijaQxzYqak=
-github.com/minio/madmin-go v1.7.1/go.mod h1:3SO8SROxHN++tF6QxdTii2SSUaYSrr8lnE9EJWjvz0k=
+github.com/minio/madmin-go v1.7.3 h1:ayR0rHXBQXsdkcd74t0mIqt9Tp0Rzy1cZ5K9gYBoFm8=
+github.com/minio/madmin-go v1.7.3/go.mod h1:3SO8SROxHN++tF6QxdTii2SSUaYSrr8lnE9EJWjvz0k=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.41 h1:Qhc82nDRep+VSuDEPSawKUHkARnZI5st7acEqgqVX+k=


### PR DESCRIPTION
## Description

This change adds new commands:

```shell
# mc admin idp openid add|remove|update|list|info|enable|disable
# mc admin idp ldap add|remove|update|list|info|enable|disable
```
and hides the following with a deprecation notice in the help:
```shell
# mc admin idp set|info|ls|rm
```

## Motivation and Context

Make it easier to configure and manage external IDPs.


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
