### PR TITLE
Improve help text for `support profile|perf`

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -63,7 +63,7 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 	subnetCommonFlags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "airgap",
-			Usage: "Use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
+			Usage: "use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
 		},
 		cli.StringFlag{
 			Name:  "api-key",

--- a/cmd/support-callhome.go
+++ b/cmd/support-callhome.go
@@ -47,14 +47,14 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Enable callhome for cluster with alias 'play'
-     {{.Prompt}} {{.HelpName}} enable play
+  1. Enable callhome for cluster with alias 'myminio'
+     {{.Prompt}} {{.HelpName}} enable myminio
 
-  2. Disable callhome for cluster with alias 'play'
-     {{.Prompt}} {{.HelpName}} disable play
+  2. Disable callhome for cluster with alias 'myminio'
+     {{.Prompt}} {{.HelpName}} disable myminio
 
-  3. Check callhome status for cluster with alias 'play'
-     {{.Prompt}} {{.HelpName}} status play
+  3. Check callhome status for cluster with alias 'myminio'
+     {{.Prompt}} {{.HelpName}} status myminio
 `,
 }
 

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -84,11 +84,11 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Upload MinIO diagnostics report for 'play' (https://play.min.io by default) to SUBNET
-     {{.Prompt}} {{.HelpName}} play
+  1. Upload MinIO diagnostics report for cluster with alias 'myminio' to SUBNET
+     {{.Prompt}} {{.HelpName}} myminio
 
-  2. Generate MinIO diagnostics report for alias 'play' (https://play.min.io by default), save and upload to SUBNET manually
-     {{.Prompt}} {{.HelpName}} play --airgap
+  2. Generate MinIO diagnostics report for cluster with alias 'myminio', save and upload to SUBNET manually
+     {{.Prompt}} {{.HelpName}} myminio --airgap
 `,
 }
 

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -87,7 +87,7 @@ EXAMPLES:
   1. Upload MinIO diagnostics report for 'play' (https://play.min.io by default) to SUBNET
      {{.Prompt}} {{.HelpName}} play
 
-  2. Generate MinIO diagnostics report for alias 'play' (https://play.min.io by default) save and upload to SUBNET manually
+  2. Generate MinIO diagnostics report for alias 'play' (https://play.min.io by default), save and upload to SUBNET manually
      {{.Prompt}} {{.HelpName}} play --airgap
 `,
 }

--- a/cmd/support-logs-show.go
+++ b/cmd/support-logs-show.go
@@ -62,12 +62,12 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Show logs for a MinIO server with alias 'play'
-     {{.Prompt}} {{.HelpName}} play
+  1. Show logs for a MinIO server with alias 'myminio'
+     {{.Prompt}} {{.HelpName}} myminio
   2. Show last 5 log entries for node 'node1' for a MinIO server with alias 'myminio'
      {{.Prompt}} {{.HelpName}} --last 5 myminio node1
-  3. Show application errors in logs for a MinIO server with alias 'play'
-     {{.Prompt}} {{.HelpName}} --type application play
+  3. Show application errors in logs for a MinIO server with alias 'myminio'
+     {{.Prompt}} {{.HelpName}} --type application myminio
 `,
 }
 

--- a/cmd/support-logs-status.go
+++ b/cmd/support-logs-status.go
@@ -36,9 +36,8 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Show current status of MinIO logs with alias 'play', whether
-     it is uploading to SUBNET or not
-     {{.Prompt}} {{.HelpName}} play
+  1. Show current status of MinIO logs for cluster with alias 'myminio', whether it is uploading to SUBNET or not
+     {{.Prompt}} {{.HelpName}} myminio
 `,
 }
 

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -82,7 +82,7 @@ var supportPerfFlags = append([]cli.Flag{
 
 var supportPerfCmd = cli.Command{
 	Name:            "perf",
-	Usage:           "analyze object, network and drive performance",
+	Usage:           "upload object, network and drive performance analysis",
 	Action:          mainSupportPerf,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
@@ -99,8 +99,10 @@ FLAGS:
   {{end}}
 
 EXAMPLES:
-  1. Run object storage, network, and drive performance tests on 'myminio' cluster:
-     {{.Prompt}} {{.HelpName}} myminio/
+  1. Upload object storage, network, and drive performance analysis for 'play' (https://play.min.io by default) to SUBNET
+     {{.Prompt}} {{.HelpName}} play
+  2. Run object storage, network, and drive performance tests on 'play' (https://play.min.io by default), save and upload to SUBNET manually
+     {{.Prompt}} {{.HelpName}} --airgap play
 `,
 }
 

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -99,10 +99,10 @@ FLAGS:
   {{end}}
 
 EXAMPLES:
-  1. Upload object storage, network, and drive performance analysis for 'play' (https://play.min.io by default) to SUBNET
-     {{.Prompt}} {{.HelpName}} play
-  2. Run object storage, network, and drive performance tests on 'play' (https://play.min.io by default), save and upload to SUBNET manually
-     {{.Prompt}} {{.HelpName}} --airgap play
+  1. Upload object storage, network, and drive performance analysis for cluster with alias 'myminio' to SUBNET
+     {{.Prompt}} {{.HelpName}} myminio
+  2. Run object storage, network, and drive performance tests on cluster with alias 'myminio', save and upload to SUBNET manually
+     {{.Prompt}} {{.HelpName}} --airgap myminio
 `,
 }
 

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -68,17 +68,17 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Profile CPU for 10 seconds on 'play' (https://play.min.io by default) and upload results to SUBNET
-     {{.Prompt}} {{.HelpName}} --type cpu play
+  1. Profile CPU for 10 seconds on cluster with alias 'myminio' and upload results to SUBNET
+     {{.Prompt}} {{.HelpName}} --type cpu myminio
 
-  2. Profile CPU, Memory, Goroutines for 10 seconds on 'play' (https://play.min.io by default) and upload results to SUBNET
-     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines play
+  2. Profile CPU, Memory, Goroutines for 10 seconds on cluster with alias 'myminio' and upload results to SUBNET
+     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines myminio
 
-  3. Profile CPU, Memory, Goroutines for 10 minutes on 'play' (https://play.min.io by default) and upload results to SUBNET
-     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines --duration 600 play
+  3. Profile CPU, Memory, Goroutines for 10 minutes on cluster with alias 'myminio' and upload results to SUBNET
+     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines --duration 600 myminio
 
-  4. Profile CPU for 10 seconds on 'play' (https://play.min.io by default), save and upload to SUBNET manually
-     {{.Prompt}} {{.HelpName}} --type cpu --airgap play
+  4. Profile CPU for 10 seconds on cluster with alias 'myminio', save and upload to SUBNET manually
+     {{.Prompt}} {{.HelpName}} --type cpu --airgap myminio
 `,
 }
 

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -37,7 +37,7 @@ var (
 	profileFlags = append([]cli.Flag{
 		cli.IntFlag{
 			Name:  "duration",
-			Usage: "start profiling for the specified duration in seconds",
+			Usage: "profile for the specified duration in seconds",
 			Value: 10,
 		},
 		cli.StringFlag{
@@ -52,7 +52,7 @@ const profileFile = "profile.zip"
 
 var supportProfileCmd = cli.Command{
 	Name:            "profile",
-	Usage:           "generate profile data for debugging",
+	Usage:           "upload profile data for debugging",
 	Action:          mainSupportProfile,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
@@ -68,14 +68,17 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Profile CPU for 10 seconds.
-     {{.Prompt}} {{.HelpName}} --type cpu myminio/
+  1. Profile CPU for 10 seconds on 'play' (https://play.min.io by default) and upload results to SUBNET
+     {{.Prompt}} {{.HelpName}} --type cpu play
 
-  2. Profile CPU, Memory, Goroutines for 10 seconds.
-     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines myminio/
+  2. Profile CPU, Memory, Goroutines for 10 seconds on 'play' (https://play.min.io by default) and upload results to SUBNET
+     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines play
 
-  3. Profile CPU, Memory, Goroutines for 10 minutes.
-     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines --duration 600 myminio/
+  3. Profile CPU, Memory, Goroutines for 10 minutes on 'play' (https://play.min.io by default) and upload results to SUBNET
+     {{.Prompt}} {{.HelpName}} --type cpu,mem,goroutines --duration 600 play
+
+  4. Profile CPU for 10 seconds on 'play' (https://play.min.io by default), save and upload to SUBNET manually
+     {{.Prompt}} {{.HelpName}} --type cpu --airgap play
 `,
 }
 


### PR DESCRIPTION
## Description

- Use `play` as the example cluster to be consistent with `support diag`
- Mention `upload` in usage
- Replace `start profiling` with `profile` in usage of `--duration` flag
- Downcase first letter of `--airgap` help text
- Add `--airgap` examples

## Motivation and Context

Better help text

## How to test this PR?

```
mc support profile --help
mc support perf --help
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
