### PR TITLE
Add command to unregister a cluster

### DIFF
--- a/cmd/license-unregister.go
+++ b/cmd/license-unregister.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-2022 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/console"
+)
+
+const licUnregisterMsgTag = "licenseUnregisterMessage"
+
+var licenseUnregisterCmd = cli.Command{
+	Name:         "unregister",
+	Usage:        "unregister from MinIO Subscription Network",
+	OnUsageError: onUsageError,
+	Action:       mainLicenseUnregister,
+	Before:       setGlobalsFromContext,
+	Hidden:       true,
+	Flags:        supportGlobalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} TARGET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Unregister MinIO cluster at alias 'myminio' from SUBNET
+     {{.Prompt}} {{.HelpName}} myminio
+`,
+}
+
+type licUnregisterMessage struct {
+	Status string `json:"status"`
+	Alias  string `json:"-"`
+}
+
+// String colorized license unregister message
+func (li licUnregisterMessage) String() string {
+	msg := fmt.Sprintf("%s unregistered successfully.", li.Alias)
+	return console.Colorize(licUnregisterMsgTag, msg)
+}
+
+// JSON jsonified license unregister message
+func (li licUnregisterMessage) JSON() string {
+	jsonBytes, e := json.MarshalIndent(li, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+
+	return string(jsonBytes)
+}
+
+// checkLicenseUnregisterSyntax - validate arguments passed by a user
+func checkLicenseUnregisterSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		showCommandHelpAndExit(ctx, "unregister", 1) // last argument is exit code
+	}
+}
+
+func mainLicenseUnregister(ctx *cli.Context) error {
+	console.SetColor(licUnregisterMsgTag, color.New(color.FgGreen, color.Bold))
+	checkLicenseUnregisterSyntax(ctx)
+
+	aliasedURL := ctx.Args().Get(0)
+	alias, _ := initSubnetConnectivity(ctx, aliasedURL, false)
+
+	apiKey, e := getSubnetAPIKey(alias)
+	fatalIf(probe.NewError(e), "Error in fetching SUBNET API Key:")
+
+	info := getAdminInfo(aliasedURL)
+	e = unregisterClusterFromSubnet(alias, info.DeploymentID, apiKey)
+	fatalIf(probe.NewError(e), "Could not unregister cluster from SUBNET:")
+
+	printMsg(licUnregisterMessage{Status: "success", Alias: alias})
+	return nil
+}

--- a/cmd/license.go
+++ b/cmd/license.go
@@ -25,6 +25,7 @@ var licenseSubcommands = []cli.Command{
 	licenseRegisterCmd,
 	licenseInfoCmd,
 	licenseUpdateCmd,
+	licenseUnregisterCmd,
 }
 
 var licenseCmd = cli.Command{

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -99,6 +99,10 @@ func subnetRegisterURL() string {
 	return subnetBaseURL() + "/api/cluster/register"
 }
 
+func subnetUnregisterURL(depID string) string {
+	return subnetBaseURL() + "/api/cluster/unregister?deploymentId=" + depID
+}
+
 func subnetOfflineRegisterURL(regToken string) string {
 	return subnetBaseURL() + "/cluster/register?token=" + regToken
 }
@@ -553,6 +557,28 @@ func registerClusterOnSubnet(clusterRegInfo ClusterRegistrationInfo, alias strin
 	}
 
 	return extractAndSaveSubnetCreds(alias, resp)
+}
+
+func removeSubnetAuthConfig(alias string) {
+	setSubnetConfig(alias, "api_key", "")
+	setSubnetConfig(alias, "license", "")
+}
+
+// unregisterClusterFromSubnet - Unregisters the given cluster from SUBNET using given API key for auth
+func unregisterClusterFromSubnet(alias string, depID string, apiKey string) error {
+	regURL, headers, e := subnetURLWithAuth(subnetUnregisterURL(depID), apiKey)
+	if e != nil {
+		return e
+	}
+
+	_, e = subnetPostReq(regURL, nil, headers)
+	if e != nil {
+		return e
+	}
+
+	removeSubnetAuthConfig(alias)
+
+	return nil
 }
 
 // extractAndSaveSubnetCreds - extract license from response and set it in minio config


### PR DESCRIPTION
## Description

syntax: `mc license unregister {alias}`

This will call the unregister api on subnet and clear the registration info from minio.

## Motivation and Context

Tool to unregister a cluster. Will be especially helpful during development/testing.

## How to test this PR?

- Register a cluster (`mc license register {alias}`)
- Verify that it gets listed in SUBNET and `mc license info {alias}` shows appropriate (`STANDARD|ENTERPRISE`) license
- Unregister using `mc license unregister {alias}`
- Verify that it is gone from SUBNET and `mc license info {alias}` shows AGPL
- Check normal as well as JSON (`--json`) mode

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
