### PR TITLE
Fix typo in rebalance-stop output

### DIFF
--- a/cmd/admin-rebalance-stop.go
+++ b/cmd/admin-rebalance-stop.go
@@ -62,7 +62,7 @@ func (r rebalanceStopMsg) JSON() string {
 }
 
 func (r rebalanceStopMsg) String() string {
-	return console.Colorize("rebalanceStopMsg", fmt.Sprintf("Rebalance started for %s", r.Target))
+	return console.Colorize("rebalanceStopMsg", fmt.Sprintf("Rebalance stopped for %s", r.Target))
 }
 
 func mainAdminRebalanceStop(ctx *cli.Context) error {


### PR DESCRIPTION
## Description
Typo in `mc admin rebalance stop ALIAS/`. It says "Rebalance started ..." instead of "Rebalance stopped ..."

## How to test this PR?
1. Start rebalance
2. Stop rebalance (without waiting for rebalance operation to complete)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
