### PR TITLE
Fix stat command with a directory marker

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -2192,12 +2192,6 @@ func (c *S3Client) listInRoutine(ctx context.Context, contentCh chan *ClientCont
 				}
 				return
 			}
-
-			// Avoid sending an empty directory when we are specifically listing it
-			if strings.HasSuffix(object.Key, string(c.targetURL.Separator)) && o == object.Key {
-				continue
-			}
-
 			contentCh <- c.objectInfo2ClientContent(b, object)
 		}
 	}


### PR DESCRIPTION
## Description
Currently, mc stat <alias>/bucket/directory-marker/ does not work. This
can be rooted to a code from 2016, commit https://github.com/minio/mc/commit/53ab0168e47eaa1818f9c948ff049b4d84d93eb3.

This does not seem needed. We also introduced directory marker in server
side after this commit.

## Motivation and Context
Fix stating a directory marker

## How to test this PR?
mc mb myminio/testbucket/my/dir/
mc stat myminio/testbucket/my/dir/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
