### PR TITLE
encrypt: remove sse-s3 example

### DIFF
--- a/cmd/encrypt-set.go
+++ b/cmd/encrypt-set.go
@@ -40,16 +40,16 @@ var encryptSetCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
    
 USAGE:
-  {{.HelpName}} TARGET
+  {{.HelpName}} <sse-type> [<key-id>] TARGET
    
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Enable SSE-S3 auto encryption on bucket "mybucket" for alias "myminio".
-     {{.Prompt}} {{.HelpName}} sse-s3 myminio/mybucket
+  1. Enable SSE-KMS auto encryption with KMS key on bucket "mybucket" for alias "myminio".
+     {{.Prompt}} {{.HelpName}} sse-kms my-minio-key myminio/mybucket
 
-  2. Enable SSE-KMS auto encryption with kms key on bucket "mybucket" for alias "s3".
+  2. Enable SSE-KMS auto encryption with KMS key on bucket "mybucket" for alias "s3".
      {{.Prompt}} {{.HelpName}} sse-kms arn:aws:kms:us-east-1:xxx:key/xxx s3/mybucket  
 `,
 }


### PR DESCRIPTION
## Description
This commit removes the sse-s3 example
for the CLI help. SSE-S3 is a legacy
server-side encryption method with several
design flaws.

We should not promote it in the example even
though we have to support it for being S3
compatible.

## Motivation and Context
CLI, docs

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
