### PR TITLE
du: Do not count directories in FS mode

### DIFF
--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -167,7 +167,6 @@ func du(ctx context.Context, urlStr string, timeRef time.Time, withVersions bool
 		}
 
 		if content.Type.IsDir() && !recursive {
-
 			depth := depth
 			if depth > 0 {
 				depth--
@@ -184,8 +183,8 @@ func du(ctx context.Context, urlStr string, timeRef time.Time, withVersions bool
 			size += used
 			objects += n
 		} else {
-			size += content.Size
-			if !content.IsDeleteMarker {
+			if !content.IsDeleteMarker && !content.Type.IsDir() {
+				size += content.Size
 				objects++
 			}
 		}


### PR DESCRIPTION
## Description
du summary shows the number of the objects, no need to count the directories.

## Motivation and Context
'mc du' is sometimes to compare source and target after mc mirror.

## How to test this PR?
mc mb play/somebucket/
mc mirror /usr/share/doc/ play/somebucket
mc du /usr/share/doc/
mc du play/somebucket

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
