### PR TITLE
ls: Fix listing versions when the system clock is off

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1759,10 +1759,6 @@ func (c *S3Client) listVersions(ctx context.Context, b, o string, isRecursive bo
 }
 
 func (c *S3Client) listVersionsRoutine(ctx context.Context, b, o string, isRecursive bool, timeRef time.Time, includeOlderVersions, withDeleteMarkers bool, objectInfoCh chan minio.ObjectInfo) {
-	if timeRef.IsZero() {
-		timeRef = time.Now().UTC()
-	}
-
 	var buckets []string
 	if b == "" {
 		bucketsInfo, err := c.api.ListBuckets(ctx)
@@ -1797,7 +1793,7 @@ func (c *S3Client) listVersionsRoutine(ctx context.Context, b, o string, isRecur
 				continue
 			}
 
-			if objectVersion.LastModified.Before(timeRef) {
+			if timeRef.IsZero() || objectVersion.LastModified.Before(timeRef) {
 				skipKey = objectVersion.Key
 
 				// Skip if this is a delete marker and we are not asked to list it

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -175,9 +175,6 @@ func checkListSyntax(ctx context.Context, cliCtx *cli.Context) ([]string, doList
 	listZip := cliCtx.Bool("zip")
 
 	timeRef := parseRewindFlag(cliCtx.String("rewind"))
-	if timeRef.IsZero() && withOlderVersions {
-		timeRef = time.Now().UTC()
-	}
 
 	if listZip && (withOlderVersions || !timeRef.IsZero()) {
 		fatalIf(errInvalidArgument().Trace(args...), "Zip file listing can only be performed on the latest version")


### PR DESCRIPTION
## Description
When the user passes --versions, a timeRef set to time.now() is created and listing
will only shows versions before timeRef. However this is not needed and can have 
issues when the system clock is wrong.

## Motivation and Context
fix mc ls --versions output when the system clock is not precise

## How to test this PR?
1. Upload an object in a bucket
2. Chang the system clock, make it 10 minutes in the past
3. mc ls --versions

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
