### PR TITLE
Fix mc stat for filesystem items

### DIFF
--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -27,10 +27,10 @@ import (
 	"strings"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	json "github.com/minio/colorjson"
 	"github.com/minio/mc/pkg/probe"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
 	"github.com/minio/minio-go/v7/pkg/notification"
 	"github.com/minio/minio-go/v7/pkg/replication"
@@ -220,7 +220,7 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 		url := targetAlias + getKey(content)
 		standardizedURL := getStandardizedURL(targetURL)
 
-		if !isRecursive && !strings.HasPrefix(url, standardizedURL) {
+		if !isRecursive && !strings.HasPrefix(url, standardizedURL) && !filepath.IsAbs(url) {
 			return nil, nil, errTargetNotFound(targetURL).Trace(url, standardizedURL)
 		}
 


### PR DESCRIPTION
## Description

Create folder `test`. Add file `test/main.go`

Before:
```
λ go build&&mc stat .\test\main.go
mc: <ERROR> Unable to stat `.\test\main.go`. Target `.\test\main.go` not found.
```

After:

```
λ go build&&mc stat .\test\main.go
Name      : main.go
Date      : 2022-10-27 18:34:17 CEST
Size      : 1.6 KiB
Type      : file
Metadata  :
  Content-Type       : application/octet-stream
  X-Amz-Meta-Mc-Attrs:
```

## How to test this PR?

See above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
