### PR TITLE
Report data usage in `mc stat` of bucket

### DIFF
--- a/cmd/admin-bucket-info.go
+++ b/cmd/admin-bucket-info.go
@@ -18,178 +18,25 @@
 package cmd
 
 import (
-	"fmt"
-	"path/filepath"
-	"sort"
-	"strings"
-
-	"github.com/dustin/go-humanize"
-	"github.com/fatih/color"
 	"github.com/minio/cli"
-	json "github.com/minio/colorjson"
-	"github.com/minio/madmin-go/v2"
-	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/pkg/console"
 )
 
 var adminBucketInfoFlags = []cli.Flag{}
 
-type adminBucketInfoMessage struct {
-	Status    string                 `json:"status"`
-	URL       string                 `json:"url"`
-	UsageInfo madmin.BucketUsageInfo `json:"usage"`
-	Props     BucketInfo             `json:"props"`
-}
-
-type histogramDef struct {
-	start, end uint64
-	text       string
-}
-
-var histogramTagsDesc = map[string]histogramDef{
-	"LESS_THAN_1024_B":          {0, 1024, "less than 1024 bytes"},
-	"BETWEEN_1024_B_AND_1_MB":   {1024, 1024 * 1024, "between 1024 bytes and 1 MB"},
-	"BETWEEN_1_MB_AND_10_MB":    {1024 * 1024, 10 * 1024 * 1024, "between 1 MB and 10 MB"},
-	"BETWEEN_10_MB_AND_64_MB":   {10 * 1024 * 1024, 64 * 1024 * 1024, "between 10 MB and 64 MB"},
-	"BETWEEN_64_MB_AND_128_MB":  {64 * 1024 * 1024, 128 * 1024 * 1024, "between 64 MB and 128 MB"},
-	"BETWEEN_128_MB_AND_512_MB": {128 * 1024 * 1024, 512 * 1024 * 1024, "between 128 MB and 512 MB"},
-	"GREATER_THAN_512_MB":       {512 * 1024 * 1024, 0, "greater than 512 MB"},
-}
-
-// Return a sorted list of histograms
-func sortHistogramTags() (orderedTags []string) {
-	orderedTags = make([]string, 0, len(histogramTagsDesc))
-	for tag := range histogramTagsDesc {
-		orderedTags = append(orderedTags, tag)
-	}
-	sort.Slice(orderedTags, func(i, j int) bool {
-		return histogramTagsDesc[orderedTags[i]].start < histogramTagsDesc[orderedTags[j]].start
-	})
-	return
-}
-
-func countDigits(num uint64) (count uint) {
-	for num > 0 {
-		num /= 10
-		count++
-	}
-	return
-}
-
-func (bi adminBucketInfoMessage) String() string {
-	var b strings.Builder
-
-	fmt.Fprint(&b, console.Colorize("Title", "Usage:\n"))
-
-	fmt.Fprintf(&b, "%16s: %s\n", "Total size", console.Colorize("Count", humanize.IBytes(bi.UsageInfo.Size)))
-	fmt.Fprintf(&b, "%16s: %s\n", "Objects count", console.Colorize("Count", humanize.Comma(int64(bi.UsageInfo.ObjectsCount))))
-	fmt.Fprintf(&b, "%16s: %s\n", "Versions count", console.Colorize("Count", humanize.Comma(int64(bi.UsageInfo.VersionsCount))))
-	fmt.Fprintf(&b, "\n")
-
-	fmt.Fprint(&b, console.Colorize("Title", "Properties:\n"))
-	fmt.Fprint(&b, prettyPrintBucketMetadata(bi.Props))
-
-	fmt.Fprintf(&b, "\n")
-	fmt.Fprint(&b, console.Colorize("Title", "Object sizes histogram:\n"))
-
-	var maxDigits uint
-	for _, val := range bi.UsageInfo.ObjectSizesHistogram {
-		if d := countDigits(val); d > maxDigits {
-			maxDigits = d
-		}
-	}
-
-	sortedTags := sortHistogramTags()
-	for _, tagName := range sortedTags {
-		val, ok := bi.UsageInfo.ObjectSizesHistogram[tagName]
-		if ok {
-			fmt.Fprintf(&b, "   %*d object(s) %s\n", maxDigits, val, histogramTagsDesc[tagName].text)
-		}
-	}
-
-	return b.String()
-}
-
-func (bi adminBucketInfoMessage) JSON() string {
-	jsonMessageBytes, e := json.MarshalIndent(bi, "", " ")
-	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
-
-	return string(jsonMessageBytes)
-}
-
 var adminBucketInfoCmd = cli.Command{
-	Name:         "info",
-	Usage:        "display bucket information",
-	Action:       mainAdminBucketInfo,
-	OnUsageError: onUsageError,
-	Before:       setGlobalsFromContext,
-	Flags:        append(adminBucketInfoFlags, globalFlags...),
-	CustomHelpTemplate: `NAME:
-  {{.HelpName}} - {{.Usage}}
-
-USAGE:
-  {{.HelpName}} TARGET
-
-FLAGS:
-  {{range .VisibleFlags}}{{.}}
-  {{end}}
-EXAMPLES:
-  1. Display the usage data and configuration of a bucket on MinIO.
-     {{.Prompt}} {{.HelpName}} myminio/mybucket
-`,
-}
-
-// checkAdminBucketInfoSyntax - validate all the passed arguments
-func checkAdminBucketInfoSyntax(ctx *cli.Context) {
-	if len(ctx.Args()) != 1 {
-		showCommandHelpAndExit(ctx, 1) // last argument is exit code
-	}
+	Name:            "info",
+	Usage:           "display bucket information",
+	Action:          mainAdminBucketInfo,
+	OnUsageError:    onUsageError,
+	Before:          setGlobalsFromContext,
+	Flags:           append(adminBucketInfoFlags, globalFlags...),
+	HideHelpCommand: true,
+	Hidden:          true,
 }
 
 // mainAdminBucketInfo is the handler for "mc admin bucket info" command.
 func mainAdminBucketInfo(ctx *cli.Context) error {
-	checkAdminBucketInfoSyntax(ctx)
-
-	console.SetColor("Title", color.New(color.Bold, color.FgBlue))
-	console.SetColor("Count", color.New(color.FgGreen))
-	console.SetColor("Metadata", color.New(color.FgWhite))
-	console.SetColor("Key", color.New(color.FgCyan))
-	console.SetColor("Value", color.New(color.FgYellow))
-	console.SetColor("Unset", color.New(color.FgRed))
-	console.SetColor("Set", color.New(color.FgGreen))
-
-	// Get the alias parameter from cli
-	args := ctx.Args()
-	aliasedURL := args.Get(0)
-
-	// Create a new MinIO Admin Client
-	adminClient, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Unable to initialize admin connection.")
-
-	s3Client, err := newClient(aliasedURL)
-	fatalIf(err, "Unable to initialize admin connection.")
-
-	aliasedURL = filepath.ToSlash(aliasedURL)
-	splits := splitStr(aliasedURL, "/", 3)
-	bucket := splits[1]
-
-	duinfo, e := adminClient.DataUsageInfo(globalContext)
-	fatalIf(probe.NewError(e).Trace(args...), "Unable to get data usage")
-
-	bi, err := s3Client.GetBucketInfo(globalContext)
-	fatalIf(err.Trace(args...), "Unable to get bucket properties")
-
-	bu, ok := duinfo.BucketsUsage[bucket]
-	if !ok {
-		fatalIf(errDummy().Trace(args...), "Unable to get bucket usage info. Bucket usage is not ready yet.")
-	}
-
-	printMsg(adminBucketInfoMessage{
-		Status:    "success",
-		URL:       aliasedURL,
-		UsageInfo: bu,
-		Props:     bi,
-	})
-
+	console.Infoln("Please use 'mc stat'")
 	return nil
 }

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -150,6 +150,9 @@ func mainStat(cliCtx *cli.Context) error {
 	console.SetColor("Unset", color.New(color.FgRed))
 	console.SetColor("Set", color.New(color.FgGreen))
 
+	console.SetColor("Title", color.New(color.Bold, color.FgBlue))
+	console.SetColor("Count", color.New(color.FgGreen))
+
 	// Parse encryption keys per command.
 	encKeyDB, err := getEncKeys(cliCtx)
 	fatalIf(err, "Unable to parse encryption keys.")

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	json "github.com/minio/colorjson"
+	"github.com/minio/madmin-go/v2"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
@@ -59,8 +60,13 @@ func (stat statMessage) String() (msg string) {
 	// Format properly for alignment based on maxKey leng
 	stat.Key = fmt.Sprintf("%-10s: %s", "Name", stat.Key)
 	msgBuilder.WriteString(console.Colorize("Name", stat.Key) + "\n")
-	msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Date", stat.Date.Format(printDate)) + "\n")
-	msgBuilder.WriteString(fmt.Sprintf("%-10s: %-6s ", "Size", humanize.IBytes(uint64(stat.Size))) + "\n")
+	if !stat.Date.IsZero() {
+		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Date", stat.Date.Format(printDate)) + "\n")
+	}
+	if stat.Type != "folder" {
+		msgBuilder.WriteString(fmt.Sprintf("%-10s: %-6s ", "Size", humanize.IBytes(uint64(stat.Size))) + "\n")
+	}
+
 	if stat.ETag != "" {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "ETag", stat.ETag) + "\n")
 	}
@@ -170,7 +176,6 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 	}
 
 	targetAlias, _, _ := mustExpandAlias(targetURL)
-
 	prefixPath := clnt.GetURL().Path
 	separator := string(clnt.GetURL().Separator)
 	if !strings.HasSuffix(prefixPath, separator) {
@@ -186,6 +191,8 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 		lstOptions.WithDeleteMarkers = true
 		lstOptions.TimeRef = timeRef
 	}
+	adminClient, _ := newAdminClient(targetURL)
+
 	var e error
 	for content := range clnt.List(ctx, lstOptions) {
 		if content.Err != nil {
@@ -244,10 +251,19 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 				if bstat.Date.IsZero() || bstat.Date.Equal(time.Unix(0, 0)) {
 					bstat.Date = content.Time
 				}
+				var bu madmin.BucketUsageInfo
+				if adminClient != nil {
+					// Create a new MinIO Admin Client
+					duinfo, e := adminClient.DataUsageInfo(globalContext)
+					if e == nil {
+						bu = duinfo.BucketsUsage[stat.BucketName]
+					}
+				}
 
 				printMsg(bucketInfoMessage{
 					Status:     "success",
 					BucketInfo: bstat,
+					Usage:      bu,
 				})
 				continue
 			}
@@ -326,6 +342,7 @@ func (i BucketInfo) Tags() string {
 type bucketInfoMessage struct {
 	Status string `json:"status"`
 	BucketInfo
+	Usage madmin.BucketUsageInfo
 }
 
 func (v bucketInfoMessage) JSON() string {
@@ -341,12 +358,48 @@ func (v bucketInfoMessage) JSON() string {
 	return buf.String()
 }
 
+type histogramDef struct {
+	start, end uint64
+	text       string
+}
+
+var histogramTagsDesc = map[string]histogramDef{
+	"LESS_THAN_1024_B":          {0, 1024, "less than 1024 bytes"},
+	"BETWEEN_1024_B_AND_1_MB":   {1024, 1024 * 1024, "between 1024 bytes and 1 MB"},
+	"BETWEEN_1_MB_AND_10_MB":    {1024 * 1024, 10 * 1024 * 1024, "between 1 MB and 10 MB"},
+	"BETWEEN_10_MB_AND_64_MB":   {10 * 1024 * 1024, 64 * 1024 * 1024, "between 10 MB and 64 MB"},
+	"BETWEEN_64_MB_AND_128_MB":  {64 * 1024 * 1024, 128 * 1024 * 1024, "between 64 MB and 128 MB"},
+	"BETWEEN_128_MB_AND_512_MB": {128 * 1024 * 1024, 512 * 1024 * 1024, "between 128 MB and 512 MB"},
+	"GREATER_THAN_512_MB":       {512 * 1024 * 1024, 0, "greater than 512 MB"},
+}
+
+// Return a sorted list of histograms
+func sortHistogramTags() (orderedTags []string) {
+	orderedTags = make([]string, 0, len(histogramTagsDesc))
+	for tag := range histogramTagsDesc {
+		orderedTags = append(orderedTags, tag)
+	}
+	sort.Slice(orderedTags, func(i, j int) bool {
+		return histogramTagsDesc[orderedTags[i]].start < histogramTagsDesc[orderedTags[j]].start
+	})
+	return
+}
+
+func countDigits(num uint64) (count uint) {
+	for num > 0 {
+		num /= 10
+		count++
+	}
+	return
+}
+
 func (v bucketInfoMessage) String() string {
 	var b strings.Builder
 
 	keyStr := getKey(&ClientContent{URL: v.URL, Type: v.Type})
+	keyStr = strings.TrimSuffix(keyStr, slashSeperator)
 	key := fmt.Sprintf("%-10s: %s", "Name", keyStr)
-	b.WriteString(console.Colorize("Name", key) + "\n")
+	b.WriteString(console.Colorize("Title", key) + "\n")
 	b.WriteString(fmt.Sprintf("%-10s: %s ", "Date", v.Date.Format(printDate)) + "\n")
 	b.WriteString(fmt.Sprintf("%-10s: %-6s \n", "Size", humanize.IBytes(uint64(v.Size))))
 
@@ -357,8 +410,37 @@ func (v bucketInfoMessage) String() string {
 		return "file"
 	}()
 	b.WriteString(fmt.Sprintf("%-10s: %s \n", "Type", fType))
-	b.WriteString(fmt.Sprintf("%-10s:\n", "Metadata"))
-	b.WriteString(prettyPrintBucketMetadata(v.BucketInfo))
+	fmt.Fprintf(&b, "\n")
+
+	fmt.Fprint(&b, console.Colorize("Title", "Properties:\n"))
+	fmt.Fprint(&b, prettyPrintBucketMetadata(v.BucketInfo))
+	fmt.Fprintf(&b, "\n")
+
+	fmt.Fprint(&b, console.Colorize("Title", "Usage:\n"))
+
+	fmt.Fprintf(&b, "%16s: %s\n", "Total size", console.Colorize("Count", humanize.IBytes(v.Usage.Size)))
+	fmt.Fprintf(&b, "%16s: %s\n", "Objects count", console.Colorize("Count", humanize.Comma(int64(v.Usage.ObjectsCount))))
+	fmt.Fprintf(&b, "%16s: %s\n", "Versions count", console.Colorize("Count", humanize.Comma(int64(v.Usage.VersionsCount))))
+	fmt.Fprintf(&b, "\n")
+
+	if len(v.Usage.ObjectSizesHistogram) > 0 {
+		fmt.Fprint(&b, console.Colorize("Title", "Object sizes histogram:\n"))
+
+		var maxDigits uint
+		for _, val := range v.Usage.ObjectSizesHistogram {
+			if d := countDigits(val); d > maxDigits {
+				maxDigits = d
+			}
+		}
+
+		sortedTags := sortHistogramTags()
+		for _, tagName := range sortedTags {
+			val, ok := v.Usage.ObjectSizesHistogram[tagName]
+			if ok {
+				fmt.Fprintf(&b, "   %*d object(s) %s\n", maxDigits, val, histogramTagsDesc[tagName].text)
+			}
+		}
+	}
 
 	return b.String()
 }


### PR DESCRIPTION
This PR also deprecates `mc admin bucket info` and integrates the bucket usage metrics into `mc stat <alias>/<bucket>`

## Description


## Motivation and Context
Integrate bucket metadata into a single command

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
