### PR TITLE
add HiddenAliases to avoid printing aliases when deprecated

### DIFF
--- a/cmd/admin-scanner-status.go
+++ b/cmd/admin-scanner-status.go
@@ -63,6 +63,7 @@ var adminScannerInfoFlags = []cli.Flag{
 var adminScannerInfo = cli.Command{
 	Name:            "status",
 	Aliases:         []string{"info"},
+	HiddenAliases:   true,
 	Usage:           "summarize scanner events on MinIO server in real-time",
 	Action:          mainAdminScannerInfo,
 	OnUsageError:    onUsageError,

--- a/cmd/replicate-reset-main.go
+++ b/cmd/replicate-reset-main.go
@@ -26,13 +26,14 @@ var replicateResyncSubcommands = []cli.Command{
 
 var replicateResyncCmd = cli.Command{
 	Name:            "resync",
-	Usage:           "replicate back all previously replicated objects",
+	Usage:           "re-replicate all previously replicated objects",
 	HideHelpCommand: true,
 	Action:          mainReplicateResync,
 	Before:          setGlobalsFromContext,
 	Flags:           globalFlags,
 	Subcommands:     replicateResyncSubcommands,
 	Aliases:         []string{"reset"},
+	HiddenAliases:   true,
 }
 
 // mainReplicateResync is the handle for "mc replicate resync" command.

--- a/cmd/replicate-update.go
+++ b/cmd/replicate-update.go
@@ -63,13 +63,14 @@ var replicateUpdateFlags = []cli.Flag{
 }
 
 var replicateUpdateCmd = cli.Command{
-	Name:         "update",
-	Aliases:      []string{"edit"},
-	Usage:        "modify an existing server side replication configuration rule",
-	Action:       mainReplicateUpdate,
-	OnUsageError: onUsageError,
-	Before:       setGlobalsFromContext,
-	Flags:        append(globalFlags, replicateUpdateFlags...),
+	Name:          "update",
+	Aliases:       []string{"edit"},
+	HiddenAliases: true,
+	Usage:         "modify an existing server side replication configuration rule",
+	Action:        mainReplicateUpdate,
+	OnUsageError:  onUsageError,
+	Before:        setGlobalsFromContext,
+	Flags:         append(globalFlags, replicateUpdateFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/support-top-drive.go
+++ b/cmd/support-top-drive.go
@@ -38,6 +38,7 @@ var supportTopDriveFlags = []cli.Flag{
 var supportTopDriveCmd = cli.Command{
 	Name:            "drive",
 	Aliases:         []string{"disk"},
+	HiddenAliases:   true,
 	Usage:           "show real-time drive metrics",
 	Action:          mainSupportTopDrive,
 	OnUsageError:    onUsageError,

--- a/cmd/top-api-spinner.go
+++ b/cmd/top-api-spinner.go
@@ -197,12 +197,16 @@ func (m *traceUI) View() string {
 			totalTX += stats.loadAPIBytesTX()
 			totalCalls += stats.loadAPICall()
 		}
-		msg := fmt.Sprintf("\n========\nTotal: %d CALLS, %s RX, %s TX - in %.02fs",
+
+		msg := fmt.Sprintf("\nSummary:\n\nTotal: %d CALLS, %s RX, %s TX",
 			totalCalls,
 			humanize.IBytes(totalRX),
 			humanize.IBytes(totalTX),
-			lastReqTime.Sub(m.startTime).Seconds(),
 		)
+		if !m.startTime.IsZero() {
+			msg += fmt.Sprintf(" - in %.02fs", lastReqTime.Sub(m.startTime).Seconds())
+		}
+
 		s.WriteString(msg)
 		s.WriteString("\n")
 	}

--- a/cmd/top-drives-spinner.go
+++ b/cmd/top-drives-spinner.go
@@ -277,5 +277,5 @@ func (m *topDriveUI) View() string {
 	if !m.quitting {
 		s.WriteString(fmt.Sprintf("\n%s \u25C0 Pool %d \u25B6 | Sort By: %s (u,t,r,w,d,A,U)", m.spinner.View(), m.pool+1, m.sortBy))
 	}
-	return s.String()
+	return s.String() + "\n"
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/klauspost/compress v1.15.12
 	github.com/mattn/go-ieproxy v0.0.1
 	github.com/mattn/go-isatty v0.0.16
-	github.com/minio/cli v1.24.0
+	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.4
 	github.com/minio/filepath v1.0.0
 	github.com/minio/madmin-go/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/minio/cli v1.24.0 h1:QrSIs7iISwaFmTlGFAR9cSpkZn7/tTaFsj5oAUCC47I=
-github.com/minio/cli v1.24.0/go.mod h1:bYxnK0uS629N3Bq+AOZZ+6lwF77Sodk4+UL9vNuXhOY=
+github.com/minio/cli v1.24.2 h1:J+fCUh9mhPLjN3Lj/YhklXvxj8mnyE/D6FpFduXJ2jg=
+github.com/minio/cli v1.24.2/go.mod h1:bYxnK0uS629N3Bq+AOZZ+6lwF77Sodk4+UL9vNuXhOY=
 github.com/minio/colorjson v1.0.4 h1:sNJYTb2uNswdqmGARg9wrogCX8+GRZzEacYbJT86e00=
 github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbLMDKdb9M=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=


### PR DESCRIPTION


## Description
add HiddenAliases to avoid printing aliases when deprecated

## Motivation and Context
also make sure `mc support top api/drives` output is 
correct with cleaner newlines added upon exit.

## How to test this PR?
Nothing should change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
