### PR TITLE
admin update: Add a prompt for confirmation

### DIFF
--- a/cmd/admin-update.go
+++ b/cmd/admin-update.go
@@ -18,7 +18,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
@@ -102,6 +105,17 @@ func mainAdminServerUpdate(ctx *cli.Context) error {
 	fatalIf(err, "Unable to initialize admin connection.")
 
 	updateURL := args.Get(1)
+
+	if isTerminal() {
+		fmt.Printf("You are about to upgrade *MinIO Server*, please confirm [y/N]: ")
+		answer, e := bufio.NewReader(os.Stdin).ReadString('\n')
+		fatalIf(probe.NewError(e), "Unable to parse user input.")
+		answer = strings.TrimSpace(answer)
+		if answer = strings.ToLower(answer); answer != "y" && answer != "yes" {
+			fmt.Println("Upgrade aborted!")
+			return nil
+		}
+	}
 
 	// Update the specified MinIO server, optionally also
 	// with the provided update URL.


### PR DESCRIPTION
## Description
In terminal mode, add an yes/no question before upgrading 
MinIO cluster using 'mc admin update' command.

## Motivation and Context
Add a prompt msg to clearly state that this command is about
upgrading a MinIO cluster.

## How to test this PR?
./mc admin update play

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
