### PR TITLE
Print 'Cancel upon user request' when the global context is cancelled

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -84,11 +84,12 @@ func fatal(err *probe.Error, msg string, data ...interface{}) {
 	msg = fmt.Sprintf(msg, data...)
 	errmsg := err.String()
 	if !globalDebug {
-		e := err.ToGoError()
-		if errors.Is(e, context.Canceled) {
-			// This will replace context canceled error message
-			// that the user is seeing to a better one.
+		var e error
+		if errors.Is(globalContext.Err(), context.Canceled) {
+			// mc is getting killed
 			e = errors.New("Canceling upon user request")
+		} else {
+			e = err.ToGoError()
 		}
 		errmsg = e.Error()
 	}
@@ -159,11 +160,12 @@ func errorIf(err *probe.Error, msg string, data ...interface{}) {
 	}
 	msg = fmt.Sprintf(msg, data...)
 	if !globalDebug {
-		e := err.ToGoError()
-		if errors.Is(e, context.Canceled) {
-			// This will replace context canceled error message
-			// that the user is seeing to a better one.
+		var e error
+		if errors.Is(globalContext.Err(), context.Canceled) {
+			// mc is getting killed
 			e = errors.New("Canceling upon user request")
+		} else {
+			e = err.ToGoError()
 		}
 		console.Errorln(fmt.Sprintf("%s %s", msg, e))
 		return


### PR DESCRIPTION
## Description
The code creates new context and cancels them and it is not 
correct to show 'Cancel upon user request' when an error 
is context.Cancelled.

Fix this by requiring globalContext error to be context.Cancelled. 
The global context is only cancelled after receiving a signal.

## Motivation and Context
Fix this error message: 'Cancel upon user request' error message
when the user did not really kill mc

## How to test this PR?
Not trivial

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
