### PR TITLE
admin-trace: Fix support for tracing scanner calls

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -90,6 +90,7 @@ var traceCallTypes = map[string]func(o *madmin.ServiceTraceOpts) (help string){
 	"internal": func(o *madmin.ServiceTraceOpts) string { o.Internal = true; return "Trace Internal RPC calls" },
 	"s3":       func(o *madmin.ServiceTraceOpts) string { o.S3 = true; return "Trace S3 API calls" },
 	"os":       func(o *madmin.ServiceTraceOpts) string { o.OS = true; return "Trace Operating System calls" },
+	"scanner":  func(o *madmin.ServiceTraceOpts) string { o.Scanner = true; return "Trace Scanner calls" },
 	"healing": func(o *madmin.ServiceTraceOpts) string {
 		o.Healing = true
 		return "Trace Healing operations (alias: heal)"


### PR DESCRIPTION
## Description
`mc admin scanner trace ` fails with unknown call type.  This change adds back `scanner` call type available to admin-trace and admin-scanner-trace subcommands.

## How to test this PR?
1. `mc admin scanner trace ALIAS`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
