### PR TITLE
Upload inspect data to SUBNET

### DIFF
--- a/cmd/support-inspect.go
+++ b/cmd/support-inspect.go
@@ -39,7 +39,10 @@ import (
 	"github.com/minio/pkg/console"
 )
 
-const defaultPublicKey = "MIIBCgKCAQEAs/128UFS9A8YSJY1XqYKt06dLVQQCGDee69T+0Tip/1jGAB4z0/3QMpH0MiS8Wjs4BRWV51qvkfAHzwwdU7y6jxU05ctb/H/WzRj3FYdhhHKdzear9TLJftlTs+xwj2XaADjbLXCV1jGLS889A7f7z5DgABlVZMQd9BjVAR8ED3xRJ2/ZCNuQVJ+A8r7TYPGMY3wWvhhPgPk3Lx4WDZxDiDNlFs4GQSaESSsiVTb9vyGe/94CsCTM6Cw9QG6ifHKCa/rFszPYdKCabAfHcS3eTr0GM+TThSsxO7KfuscbmLJkfQev1srfL2Ii2RbnysqIJVWKEwdW05ID8ryPkuTuwIDAQAB"
+const (
+	defaultPublicKey      = "MIIBCgKCAQEAs/128UFS9A8YSJY1XqYKt06dLVQQCGDee69T+0Tip/1jGAB4z0/3QMpH0MiS8Wjs4BRWV51qvkfAHzwwdU7y6jxU05ctb/H/WzRj3FYdhhHKdzear9TLJftlTs+xwj2XaADjbLXCV1jGLS889A7f7z5DgABlVZMQd9BjVAR8ED3xRJ2/ZCNuQVJ+A8r7TYPGMY3wWvhhPgPk3Lx4WDZxDiDNlFs4GQSaESSsiVTb9vyGe/94CsCTM6Cw9QG6ifHKCa/rFszPYdKCabAfHcS3eTr0GM+TThSsxO7KfuscbmLJkfQev1srfL2Ii2RbnysqIJVWKEwdW05ID8ryPkuTuwIDAQAB"
+	inspectOutputFilename = "inspect-data.enc"
+)
 
 var supportInspectFlags = append(subnetCommonFlags,
 	cli.BoolFlag{
@@ -184,8 +187,8 @@ func mainSupportInspect(ctx *cli.Context) error {
 		return nil
 	}
 
-	uploadURL := subnetUploadURL("inspect", tmpFile.Name())
-	reqURL, headers := prepareSubnetUploadURL(uploadURL, alias, tmpFile.Name(), apiKey)
+	uploadURL := subnetUploadURL("inspect", inspectOutputFilename)
+	reqURL, headers := prepareSubnetUploadURL(uploadURL, alias, inspectOutputFilename, apiKey)
 
 	_, e = uploadFileToSubnet(alias, tmpFile.Name(), reqURL, headers)
 	if e != nil {
@@ -202,8 +205,8 @@ func mainSupportInspect(ctx *cli.Context) error {
 func saveInspectDataFile(key []byte, tmpFile *os.File) {
 	var keyHex string
 
+	downloadPath := inspectOutputFilename
 	// Choose a name and move the inspect data to its final destination
-	downloadPath := "inspect-data.enc"
 	if key != nil {
 		// Create an id that is also crc.
 		var id [4]byte


### PR DESCRIPTION
## Description

Now the default behavior would be to upload the inspect data output file
(*.enc) to subnet. In case the upload fails for some reason, it will be
saved to the current directory as before.

## Motivation and Context

Upload required inspect data to SUBNET for sharing with engineers

## How to test this PR?

- Run `mc support inspect {target}` 
- Verify that it doesn't save the inspect data file locally and prints a message `uploaded successfully to SUBNET.`
- Run `mc support inspect {target} --airgap`
- Verify that it saves the inspect data file locally as `inspect-data.enc` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
