### PR TITLE
fix: Correctly print svc accounts list

### DIFF
--- a/cmd/admin-user-svcacct-add.go
+++ b/cmd/admin-user-svcacct-add.go
@@ -81,7 +81,7 @@ func checkAdminUserSvcAcctAddSyntax(ctx *cli.Context) {
 
 // svcAcctMessage container for content message structure
 type svcAcctMessage struct {
-	op            string
+	op            svcAcctOp
 	Status        string          `json:"status"`
 	AccessKey     string          `json:"accessKey,omitempty"`
 	SecretKey     string          `json:"secretKey,omitempty"`
@@ -96,14 +96,26 @@ const (
 	accessFieldMaxLen = 20
 )
 
+type svcAcctOp int
+
+const (
+	svcAccOpAdd = svcAcctOp(iota)
+	svcAccOpList
+	svcAccOpInfo
+	svcAccOpRemove
+	svcAccOpDisable
+	svcAccOpEnable
+	svcAccOpSet
+)
+
 func (u svcAcctMessage) String() string {
 	switch u.op {
-	case "list":
+	case svcAccOpList:
 		// Create a new pretty table with cols configuration
 		return newPrettyTable("  ",
 			Field{"AccessKey", accessFieldMaxLen},
 		).buildRow(u.AccessKey)
-	case "info":
+	case svcAccOpInfo:
 		policyField := ""
 		if u.ImpliedPolicy {
 			policyField = "implied"
@@ -117,16 +129,16 @@ func (u svcAcctMessage) String() string {
 				fmt.Sprintf("Status: %s", u.AccountStatus),
 				fmt.Sprintf("Policy: %s", policyField),
 			}, "\n"))
-	case "rm":
+	case svcAccOpRemove:
 		return console.Colorize("SVCMessage", "Removed service account `"+u.AccessKey+"` successfully.")
-	case "disable":
+	case svcAccOpDisable:
 		return console.Colorize("SVCMessage", "Disabled service account `"+u.AccessKey+"` successfully.")
-	case "enable":
+	case svcAccOpEnable:
 		return console.Colorize("SVCMessage", "Enabled service account `"+u.AccessKey+"` successfully.")
-	case "add":
+	case svcAccOpAdd:
 		return console.Colorize("SVCMessage",
 			fmt.Sprintf("Access Key: %s\nSecret Key: %s", u.AccessKey, u.SecretKey))
-	case "set":
+	case svcAccOpSet:
 		return console.Colorize("SVCMessage", "Edited service account `"+u.AccessKey+"` successfully.")
 	}
 	return ""
@@ -183,7 +195,7 @@ func mainAdminUserSvcAcctAdd(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to add a new service account")
 
 	printMsg(svcAcctMessage{
-		op:            ctx.Command.Name,
+		op:            svcAccOpAdd,
 		AccessKey:     creds.AccessKey,
 		SecretKey:     creds.SecretKey,
 		AccountStatus: "enabled",

--- a/cmd/admin-user-svcacct-disable.go
+++ b/cmd/admin-user-svcacct-disable.go
@@ -77,7 +77,7 @@ func mainAdminUserSvcAcctDisable(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to disable the specified service account")
 
 	printMsg(svcAcctMessage{
-		op:        ctx.Command.Name,
+		op:        svcAccOpDisable,
 		AccessKey: svcAccount,
 	})
 

--- a/cmd/admin-user-svcacct-enable.go
+++ b/cmd/admin-user-svcacct-enable.go
@@ -77,7 +77,7 @@ func mainAdminUserSvcAcctEnable(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to enable the specified service account")
 
 	printMsg(svcAcctMessage{
-		op:        ctx.Command.Name,
+		op:        svcAccOpEnable,
 		AccessKey: svcAccount,
 	})
 

--- a/cmd/admin-user-svcacct-info.go
+++ b/cmd/admin-user-svcacct-info.go
@@ -96,7 +96,7 @@ func mainAdminUserSvcAcctInfo(ctx *cli.Context) error {
 	}
 
 	printMsg(svcAcctMessage{
-		op:            ctx.Command.Name,
+		op:            svcAccOpInfo,
 		AccessKey:     svcAccount,
 		AccountStatus: svcInfo.AccountStatus,
 		ParentUser:    svcInfo.ParentUser,

--- a/cmd/admin-user-svcacct-list.go
+++ b/cmd/admin-user-svcacct-list.go
@@ -78,7 +78,7 @@ func mainAdminUserSvcAcctList(ctx *cli.Context) error {
 
 	for _, svc := range svcList.Accounts {
 		printMsg(svcAcctMessage{
-			op:        ctx.Command.Name,
+			op:        svcAccOpList,
 			AccessKey: svc,
 		})
 	}

--- a/cmd/admin-user-svcacct-rm.go
+++ b/cmd/admin-user-svcacct-rm.go
@@ -73,7 +73,7 @@ func mainAdminUserSvcAcctRemove(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to remove the specified service account")
 
 	printMsg(svcAcctMessage{
-		op:        ctx.Command.Name,
+		op:        svcAccOpRemove,
 		AccessKey: svcAccount,
 	})
 

--- a/cmd/admin-user-svcacct-set.go
+++ b/cmd/admin-user-svcacct-set.go
@@ -98,7 +98,7 @@ func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to edit the specified service account")
 
 	printMsg(svcAcctMessage{
-		op:        ctx.Command.Name,
+		op:        svcAccOpSet,
 		AccessKey: svcAccount,
 	})
 


### PR DESCRIPTION
## Description
Currently, 'mc admin user svcacct list' command shows 
empty output due to a logic issue when printing the list. 
The code is relying on the command name, which is 
changed and can be changed again in the future.

## Motivation and Context
Fixes https://github.com/minio/mc/issues/4423

## How to test this PR?
1. `mc admin user svcacct add myminio foobar foo12345`
2. `mc admin user svcacct list myminio foobar`


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
