### PR TITLE
avoid converting API types to local forms in 'mc'

### DIFF
--- a/cmd/ilm-tier-info.go
+++ b/cmd/ilm-tier-info.go
@@ -124,26 +124,13 @@ func (t tierInfos) MarshalJSON() ([]byte, error) {
 	for _, tInfo := range t {
 		ts = append(ts, tierInfo{
 			Name:       tInfo.Name,
-			API:        tierInfoAPI(tInfo.Type),
+			API:        tInfo.Type,
 			Type:       tierInfoType(tInfo.Type),
 			Stats:      tInfo.Stats,
 			DailyStats: tInfo.DailyStats,
 		})
 	}
 	return json.Marshal(ts)
-}
-
-func tierInfoAPI(tierType string) string {
-	switch tierType {
-	case madmin.S3.String(), madmin.GCS.String():
-		return tierType
-	case madmin.Azure.String():
-		return "blob"
-	case "internal":
-		return madmin.S3.String()
-	default:
-		return "unknown"
-	}
 }
 
 func tierInfoType(tierType string) string {
@@ -160,7 +147,7 @@ func (t tierInfos) ToRow(i int, ls []int) []string {
 	} else {
 		tierInfo := t[i]
 		row[tierInfoNameHdr] = tierInfo.Name
-		row[tierInfoAPIHdr] = tierInfoAPI(tierInfo.Type)
+		row[tierInfoAPIHdr] = tierInfo.Type
 		row[tierInfoTypeHdr] = tierInfoType(tierInfo.Type)
 		row[tierInfoUsageHdr] = humanize.IBytes(tierInfo.Stats.TotalSize)
 		row[tierInfoObjectsHdr] = strconv.Itoa(tierInfo.Stats.NumObjects)


### PR DESCRIPTION


## Description
avoid converting API types to local forms in 'mc'

## Motivation and Context
keeping the API type to be exactly what they
are supposed to be, instead of calling

azure -> blob

blob is mostly meant for objects and not for the 
API itself, we could have called it as AzureBlob 
but having a cleaner differentiation while 
printing is perfectly normal.

## How to test this PR?
Nothing would change it's a cosmetic UI change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
