### PR TITLE
rb: avoid throwing error for force delete of prefix

### DIFF
--- a/cmd/rb-main.go
+++ b/cmd/rb-main.go
@@ -199,6 +199,15 @@ func deleteBucket(ctx context.Context, url string, isForce bool) *probe.Error {
 			return result.Err.Trace(url)
 		}
 	}
+	// Return early if prefix delete
+	switch c := clnt.(type) {
+	case *S3Client:
+		_, object := c.url2BucketAndObject()
+		if object != "" && isForce {
+			return nil
+		}
+	default:
+	}
 
 	// Remove a bucket without force flag first because force
 	// won't work if a bucket has some locking rules, that's


### PR DESCRIPTION
## Description


## Motivation and Context
Avoid throwing validation errors for prefix delete
With current master:
➜  bucket git:(master) ✗ mc ls sitea/bucket -r
[2023-01-06 10:52:50 PST]     0B STANDARD 18/
[2023-01-06 10:52:50 PST]     0B STANDARD 1oSHoFb8
➜  bucket git:(master) ✗ mc rb --force sitea/bucket/1oSHoFb8    
mc: <ERROR> Failed to remove `sitea/bucket/1oSHoFb8`. Bucket name `bucket/1oSHoFb8` not valid.

With this PR:
➜  mc git:(fxrb) mc rb --force sitea/bucket/1oSHoFb8
Removed `sitea/bucket/1oSHoFb8` successfully.
➜  mc git:(fxrb) mc ls sitea/bucket -r        
[2023-01-06 10:52:50 PST]     0B STANDARD 18/

## How to test this PR?
try to delete prefix via `mc rb --force` 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
