### PR TITLE
Add support of giving a comment to service accounts

### DIFF
--- a/cmd/admin-user-svcacct-add.go
+++ b/cmd/admin-user-svcacct-add.go
@@ -45,6 +45,10 @@ var adminUserSvcAcctAddFlags = []cli.Flag{
 		Name:  "policy",
 		Usage: "path to a JSON policy file",
 	},
+	cli.StringFlag{
+		Name:  "comment",
+		Usage: "personal note for the service account",
+	},
 }
 
 var adminUserSvcAcctAddCmd = cli.Command{
@@ -88,6 +92,7 @@ type svcAcctMessage struct {
 	ParentUser    string          `json:"parentUser,omitempty"`
 	ImpliedPolicy bool            `json:"impliedPolicy,omitempty"`
 	Policy        json.RawMessage `json:"policy,omitempty"`
+	Comment       string          `json:"comment,omitempty"`
 	AccountStatus string          `json:"accountStatus,omitempty"`
 	MemberOf      []string        `json:"memberOf,omitempty"`
 }
@@ -127,6 +132,7 @@ func (u svcAcctMessage) String() string {
 				fmt.Sprintf("AccessKey: %s", u.AccessKey),
 				fmt.Sprintf("ParentUser: %s", u.ParentUser),
 				fmt.Sprintf("Status: %s", u.AccountStatus),
+				fmt.Sprintf("Comment: %s", u.Comment),
 				fmt.Sprintf("Policy: %s", policyField),
 			}, "\n"))
 	case svcAccOpRemove:
@@ -166,6 +172,7 @@ func mainAdminUserSvcAcctAdd(ctx *cli.Context) error {
 	accessKey := ctx.String("access-key")
 	secretKey := ctx.String("secret-key")
 	policyPath := ctx.String("policy")
+	comment := ctx.String("comment")
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
@@ -188,6 +195,7 @@ func mainAdminUserSvcAcctAdd(ctx *cli.Context) error {
 		Policy:     policyBytes,
 		AccessKey:  accessKey,
 		SecretKey:  secretKey,
+		Comment:    comment,
 		TargetUser: user,
 	}
 

--- a/cmd/admin-user-svcacct-info.go
+++ b/cmd/admin-user-svcacct-info.go
@@ -98,6 +98,7 @@ func mainAdminUserSvcAcctInfo(ctx *cli.Context) error {
 	printMsg(svcAcctMessage{
 		op:            svcAccOpInfo,
 		AccessKey:     svcAccount,
+		Comment:       svcInfo.Comment,
 		AccountStatus: svcInfo.AccountStatus,
 		ParentUser:    svcInfo.ParentUser,
 		ImpliedPolicy: svcInfo.ImpliedPolicy,

--- a/cmd/admin-user-svcacct-set.go
+++ b/cmd/admin-user-svcacct-set.go
@@ -34,6 +34,10 @@ var adminUserSvcAcctSetFlags = []cli.Flag{
 		Name:  "policy",
 		Usage: "path to a JSON policy file",
 	},
+	cli.StringFlag{
+		Name:  "comment",
+		Usage: "personal note for the service account",
+	},
 }
 
 var adminUserSvcAcctSetCmd = cli.Command{
@@ -77,6 +81,7 @@ func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 
 	secretKey := ctx.String("secret-key")
 	policyPath := ctx.String("policy")
+	comment := ctx.String("comment")
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
@@ -92,6 +97,7 @@ func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 	opts := madmin.UpdateServiceAccountReq{
 		NewPolicy:    buf,
 		NewSecretKey: secretKey,
+		NewComment:   comment,
 	}
 
 	e := client.UpdateServiceAccount(globalContext, svcAccount, opts)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.4
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v2 v2.0.2-0.20221221104141-93e7e5aefaf2
+	github.com/minio/madmin-go/v2 v2.0.6
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.46
 	github.com/minio/pkg v1.5.6

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbL
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go/v2 v2.0.2-0.20221221104141-93e7e5aefaf2 h1:MPWI0f+mXCX9/0t8XBHXHzR8L0yT40NI4fdbvKyy0aU=
-github.com/minio/madmin-go/v2 v2.0.2-0.20221221104141-93e7e5aefaf2/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
+github.com/minio/madmin-go/v2 v2.0.6 h1:d0cfiH5SkC8vZHgRtcki8j37fb3FF65cTdjUdfBR8ks=
+github.com/minio/madmin-go/v2 v2.0.6/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.41/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=


### PR DESCRIPTION
## Description

DEPENDS on https://github.com/minio/madmin-go/pull/167

mc admin user svcacct add/edit will have a new flag 
called --comment to associate a note to service accounts.

Users can use it to remember why a service account was created.

## Motivation and Context
Add comment to service accounts

## How to test this PR?
1. Start a cluster
2. `./mc admin user add myminio foo foo12345`
3. `./mc admin user svcacct add myminio foo --access-key "svc12345" --secret-key "svc1234567890" --comment "my comment"`
4. `./mc admin user svcacct info myminio svc12345`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [x] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
