### PR TITLE
Add confirm flag to `mc admin update --yes`

### DIFF
--- a/cmd/admin-update.go
+++ b/cmd/admin-update.go
@@ -30,13 +30,20 @@ import (
 	"github.com/minio/pkg/console"
 )
 
+var adminUpdateFlags = append([]cli.Flag{
+	cli.BoolFlag{
+		Name:  "yes, y",
+		Usage: "Confirms the server update",
+	},
+}, subnetCommonFlags...)
+
 var adminServerUpdateCmd = cli.Command{
 	Name:         "update",
 	Usage:        "update all MinIO servers",
 	Action:       mainAdminServerUpdate,
 	OnUsageError: onUsageError,
 	Before:       setGlobalsFromContext,
-	Flags:        globalFlags,
+	Flags:        append(adminUpdateFlags, globalFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 
@@ -106,7 +113,9 @@ func mainAdminServerUpdate(ctx *cli.Context) error {
 
 	updateURL := args.Get(1)
 
-	if isTerminal() {
+	autoConfirm := ctx.Bool("yes")
+
+	if isTerminal() && !autoConfirm {
 		fmt.Printf("You are about to upgrade *MinIO Server*, please confirm [y/N]: ")
 		answer, e := bufio.NewReader(os.Stdin).ReadString('\n')
 		fatalIf(probe.NewError(e), "Unable to parse user input.")

--- a/cmd/admin-update.go
+++ b/cmd/admin-update.go
@@ -30,12 +30,12 @@ import (
 	"github.com/minio/pkg/console"
 )
 
-var adminUpdateFlags = append([]cli.Flag{
+var adminUpdateFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:  "yes, y",
 		Usage: "Confirms the server update",
 	},
-}, subnetCommonFlags...)
+}
 
 var adminServerUpdateCmd = cli.Command{
 	Name:         "update",

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,6 @@ github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbL
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go/v2 v2.0.1 h1:WFfe12P18k9WSEFUZzUaBOQ78vjMBafM1YjgtXkkJoM=
-github.com/minio/madmin-go/v2 v2.0.1/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
 github.com/minio/madmin-go/v2 v2.0.2-0.20221221104141-93e7e5aefaf2 h1:MPWI0f+mXCX9/0t8XBHXHzR8L0yT40NI4fdbvKyy0aU=
 github.com/minio/madmin-go/v2 v2.0.2-0.20221221104141-93e7e5aefaf2/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=


### PR DESCRIPTION
Adds a `--yes` or `-y` flag to `mc admin update` to bypass the new upgrade confirmation prompt

Signed-off-by: Daniel Valdivia <hola@danielvaldivia.com>
