### PR TITLE
Support --airgap in unregister command

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -582,13 +582,7 @@ func unregisterClusterFromSubnet(alias string, depID string, apiKey string) erro
 	}
 
 	_, e = subnetPostReq(regURL, nil, headers)
-	if e != nil {
-		return e
-	}
-
-	removeSubnetAuthConfig(alias)
-
-	return nil
+	return e
 }
 
 // validateAndSaveLic - validates the given license in minio config


### PR DESCRIPTION
## Description

When passed, the registration information will be removed from minio, without trying to unregister from subnet.

## Motivation and Context

Can be useful when the clutser has already been removed from subnet by admin, or when the mc machine doesn't have connectivity to subnet.

## How to test this PR?

- Register a cluster using `mc license register {alias}`
- Run `mc license unregister {alias}`
  - verify that the registered cluster is gone from subnet
  - verify that `mc license info {alias}` shows AGPL v3 license
- Register the cluster again
- Run `mc license unregister {alias} --airgap`
  - verify that the registered cluster is still present in subnet
  - verify that `mc license info {alias}` shows AGPL v3 license
  
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
