### PR TITLE
Improve message when profile upload fails

### DIFF
--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -203,15 +203,17 @@ func execSupportProfile(ctx *cli.Context, client *madmin.AdminClient, alias stri
 
 	saveProfileFile(data)
 
-	clr := color.New(color.FgGreen, color.Bold)
+	successClr := color.New(color.FgGreen, color.Bold)
+	failureClr := color.New(color.FgRed, color.Bold)
 	if !globalAirgapped {
 		_, e := uploadFileToSubnet(alias, profileFile, reqURL, headers)
-		fatalIf(probe.NewError(e), "Unable to upload profile file to SUBNET portal")
-		if len(apiKey) > 0 {
-			setSubnetAPIKey(alias, apiKey)
+		if e != nil {
+			failureClr.Println("\nUnable to upload profile file to SUBNET.", e.Error())
+			successClr.Printf("It has been saved locally at '%s'\n", profileFile)
+			return
 		}
-		clr.Println("uploaded successfully to SUBNET.")
+		successClr.Println("uploaded successfully to SUBNET.")
 	} else {
-		clr.Printf("saved successfully at '%s'\n", profileFile)
+		successClr.Printf("saved successfully at '%s'\n", profileFile)
 	}
 }


### PR DESCRIPTION
## Description

When profile upload to SUBNET fails because of any error, currently just the error message is shown, creating an impression that the profile file was not saved anywhere. (we delete the file only if upload goes through, otherwise it is stored locally)

Improve the message(s) printed on terminal in case of such failure, clearly indicating that the file has been stored locally.

## Motivation and Context

More meaningful output in case of error.

## How to test this PR?

- Register a cluster with subnet
- Run the `mc support profile {alias}` and verify that it works fine and uploads the profile file to SUBNET (it becomes visible in the `Profile` tab on the deployment page)
- Modify following line in `support-profile.go` to replace `"profile"` with `"profile1"` (this will try to upload to a wrong URL and hence will simulate upload error)
`uploadURL := subnetUploadURL("profile", profileFile)`
- Build `mc` with this modified code and run the profile command again.
- Verify that apart from the upload error message, it also tells the user that the profile file has been stored locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
