### PR TITLE
Fix Typo in heal output

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -571,15 +571,15 @@ func (s shortBackgroundHealStatusMessage) String() string {
 		bytesPct := math.Min(100, 100*float64(bytesHealed)/float64(totalBytes))
 
 		healPrettyMsg += fmt.Sprintf("Objects Healed: %s/%s (%s), %s/%s (%s)\n",
-			humanize.Comma(int64(itemsHealed)), humanize.Comma(int64(totalItems)), humanize.CommafWithDigits(itemsPct, 1)+"%%",
-			humanize.Bytes(bytesHealed), humanize.Bytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%%")
+			humanize.Comma(int64(itemsHealed)), humanize.Comma(int64(totalItems)), humanize.CommafWithDigits(itemsPct, 1)+"%",
+			humanize.Bytes(bytesHealed), humanize.Bytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%")
 
 		if itemsFailed > 0 {
 			itemsPct := math.Min(100, 100*float64(itemsFailed)/float64(totalItems))
 			bytesPct := math.Min(100, 100*float64(bytesFailed)/float64(totalBytes))
 			healPrettyMsg += fmt.Sprintf("Objects Failed: %s/%s (%s), %s/%s (%s)\n",
-				humanize.Comma(int64(itemsFailed)), humanize.Comma(int64(totalItems)), humanize.CommafWithDigits(itemsPct, 1)+"%%",
-				humanize.Bytes(bytesFailed), humanize.Bytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%%")
+				humanize.Comma(int64(itemsFailed)), humanize.Comma(int64(totalItems)), humanize.CommafWithDigits(itemsPct, 1)+"%",
+				humanize.Bytes(bytesFailed), humanize.Bytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%")
 		}
 	} else {
 		healPrettyMsg += fmt.Sprintf("Objects Healed: %s, %s\n", humanize.Comma(int64(itemsHealed)), humanize.Bytes(bytesHealed))


### PR DESCRIPTION
## Description
Typo (Double percentage) in the output of heal status command

## Motivation and Context
```
mc admin heal ALIAS
Objects Healed: 21,025,364/18,446,224 (100%%), 47 TB/50 TB (93.7%%)
Objects Failed: 1,918/18,446,224 (0.0%%), 115 GB/50 TB (0.2%%)
```

## How to test this PR?
run the mc admin heal command again, you should not see the double percentage

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
