### PR TITLE
Corrected output for command `mc admin info`

### DIFF
--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -80,15 +80,13 @@ func clusterSummaryInfo(info madmin.InfoMessage) clusterInfo {
 				}
 			}
 			pool.endpoints.Add(srv.Endpoint)
-			for _, disk := range srv.Disks {
-				if disk.SetIndex > pool.setsCount {
-					pool.setsCount = disk.SetIndex
-				}
-				if disk.DiskIndex > pool.drivesPerSet {
-					pool.drivesPerSet = disk.DiskIndex
-				}
-
+			if disk.SetIndex > pool.setsCount {
+				pool.setsCount = disk.SetIndex
 			}
+			if disk.DiskIndex > pool.drivesPerSet {
+				pool.drivesPerSet = disk.DiskIndex
+			}
+
 			summary[disk.PoolIndex] = pool
 		}
 	}


### PR DESCRIPTION
## Description
Earlier the pools details specifically the values for erasure sets and disks per erasure set were not displayed with correct values. There was an unnecessary looping through the disks list for server while calculating these values. Removed the same and it produces correct values now.

## Motivation and Context
bug fix to make sure values for erasure sets and disks per erasure set are shown with correct values

## How to test this PR?
Follow the below steps to test the scenario
step-1: start minio with below configurations
./minio server ./data/1p1host{1...13}/disk{1...60} ./data/1p2host{1...7}/disk{1...60}
step-2: start minio client and run the admin info command as below
./mc admin info myminio

Expected output:
●  127.0.0.1:9000
   Uptime: 23 minutes 
   Version: 2023-01-16T23:38:33Z
   Network: 1/1 OK 
   Drives: 1200/1200 OK 
   Pool: 1, 2

Pools:
   1st, Erasure sets: 60, Drives per erasure set: 13
   2nd, Erasure sets: 30, Drives per erasure set: 14

1,200 drives online, 0 drives offline

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
