### PR TITLE
cleanup mc to use 'go' errs to be 'e'

### DIFF
--- a/cmd/admin-bucket-remote-bandwidth.go
+++ b/cmd/admin-bucket-remote-bandwidth.go
@@ -126,9 +126,8 @@ func printTable(report madmin.Report, bits bool, iec bool) {
 		index++
 	}
 	if len(report.Report.BucketStats) > 0 {
-		err := tbl.DisplayTable(cellText)
-		if err != nil {
-			console.Error(err)
+		if e := tbl.DisplayTable(cellText); e != nil {
+			console.Error(e)
 		}
 	}
 }

--- a/cmd/admin-config-export.go
+++ b/cmd/admin-config-export.go
@@ -67,7 +67,7 @@ func (u configExportMessage) String() string {
 	bio := bufio.NewReader(bytes.NewReader(u.Value))
 	var lines []string
 	for {
-		s, err := bio.ReadString('\n')
+		s, e := bio.ReadString('\n')
 		// Make lines displaying environment variables bold.
 		if strings.HasPrefix(s, "# MINIO_") {
 			s = strings.TrimPrefix(s, "# ")
@@ -77,10 +77,10 @@ func (u configExportMessage) String() string {
 		} else {
 			lines = append(lines, s)
 		}
-		if err == io.EOF {
+		if e == io.EOF {
 			break
 		}
-		fatalIf(probe.NewError(err), "Unable to marshal to string.")
+		fatalIf(probe.NewError(e), "Unable to marshal to string.")
 	}
 	return strings.Join(lines, "")
 }

--- a/cmd/admin-config-get.go
+++ b/cmd/admin-config-get.go
@@ -77,7 +77,7 @@ func (u configGetMessage) String() string {
 	bio := bufio.NewReader(bytes.NewReader(u.value))
 	var lines []string
 	for {
-		s, err := bio.ReadString('\n')
+		s, e := bio.ReadString('\n')
 		// Make lines displaying environment variables bold.
 		if strings.HasPrefix(s, "# MINIO_") {
 			s = strings.TrimPrefix(s, "# ")
@@ -87,10 +87,10 @@ func (u configGetMessage) String() string {
 		} else {
 			lines = append(lines, s)
 		}
-		if err == io.EOF {
+		if e == io.EOF {
 			break
 		}
-		fatalIf(probe.NewError(err), "Unable to marshal to string.")
+		fatalIf(probe.NewError(e), "Unable to marshal to string.")
 	}
 	return strings.Join(lines, "")
 }

--- a/cmd/admin-heal-ui.go
+++ b/cmd/admin-heal-ui.go
@@ -291,8 +291,8 @@ func (ui *uiData) printItemsJSON(s *madmin.HealTaskStatus) (err error) {
 
 	for _, item := range s.Items {
 		h := newHRI(&item)
-		jsonBytes, err := json.MarshalIndent(makeHR(h), "", " ")
-		fatalIf(probe.NewError(err), "Unable to marshal to JSON.")
+		jsonBytes, e := json.MarshalIndent(makeHR(h), "", " ")
+		fatalIf(probe.NewError(e), "Unable to marshal to JSON.")
 		console.Println(string(jsonBytes))
 	}
 	return nil
@@ -321,8 +321,8 @@ func (ui *uiData) printStatsJSON(s *madmin.HealTaskStatus) {
 	summary.Size = ui.BytesScanned
 	summary.ElapsedTime = int64(ui.HealDuration.Round(time.Second).Seconds())
 
-	jBytes, err := json.MarshalIndent(summary, "", " ")
-	fatalIf(probe.NewError(err), "Unable to marshal to JSON.")
+	jBytes, e := json.MarshalIndent(summary, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal to JSON.")
 	console.Println(string(jBytes))
 }
 

--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -226,8 +226,8 @@ func generateSetsStatus(disks []madmin.Disk) map[setIndex]setInfo {
 func generateServersStatus(disks []madmin.Disk) map[string]serverInfo {
 	m := make(map[string]serverInfo)
 	for _, d := range disks {
-		u, err := url.Parse(d.Endpoint)
-		if err != nil {
+		u, e := url.Parse(d.Endpoint)
+		if e != nil {
 			continue
 		}
 		endpoint := u.Host
@@ -666,8 +666,8 @@ func mainAdminHeal(ctx *cli.Context) error {
 	// Return the background heal status when the user
 	// doesn't pass a bucket or --recursive flag.
 	if bucket == "" && !ctx.Bool("recursive") {
-		bgHealStatus, berr := adminClnt.BackgroundHealStatus(globalContext)
-		fatalIf(probe.NewError(berr), "Failed to get the status of the background heal.")
+		bgHealStatus, e := adminClnt.BackgroundHealStatus(globalContext)
+		fatalIf(probe.NewError(e), "Unable to get background heal status.")
 		if ctx.Bool("verbose") {
 			printMsg(verboseBackgroundHealStatusMessage{
 				Status:         "success",
@@ -701,14 +701,14 @@ func mainAdminHeal(ctx *cli.Context) error {
 	forceStart := ctx.Bool("force-start")
 	forceStop := ctx.Bool("force-stop")
 	if forceStop {
-		_, _, herr := adminClnt.Heal(globalContext, bucket, prefix, opts, "", forceStart, forceStop)
-		fatalIf(probe.NewError(herr), "Failed to stop heal sequence.")
+		_, _, e := adminClnt.Heal(globalContext, bucket, prefix, opts, "", forceStart, forceStop)
+		fatalIf(probe.NewError(e), "Unable to stop healing.")
 		printMsg(stopHealMessage{Status: "success", Alias: aliasedURL})
 		return nil
 	}
 
-	healStart, _, herr := adminClnt.Heal(globalContext, bucket, prefix, opts, "", forceStart, false)
-	fatalIf(probe.NewError(herr), "Failed to start heal sequence.")
+	healStart, _, e := adminClnt.Heal(globalContext, bucket, prefix, opts, "", forceStart, false)
+	fatalIf(probe.NewError(e), "Unable to start healing.")
 
 	ui := uiData{
 		Bucket:                bucket,

--- a/cmd/admin-idp-ldap-policy-attach.go
+++ b/cmd/admin-idp-ldap-policy-attach.go
@@ -92,10 +92,7 @@ func mainAdminIDPLdapPolicyAttach(ctx *cli.Context) error {
 		User:     user,
 		Group:    group,
 	}
-
-	if err := req.IsValid(); err != nil {
-		fatalIf(probe.NewError(err), "Invalid policy attach arguments.")
-	}
+	fatalIf(probe.NewError(req.IsValid()), "Invalid policy attach arguments.")
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)

--- a/cmd/admin-idp-ldap-policy-detach.go
+++ b/cmd/admin-idp-ldap-policy-detach.go
@@ -83,8 +83,8 @@ func mainAdminIDPLdapPolicyDetach(ctx *cli.Context) error {
 	group := ctx.String("group")
 
 	if user == "" && group == "" {
-		err := errors.New("at least one of --user or --group is required.")
-		fatalIf(probe.NewError(err), "Missing flag in command")
+		e := errors.New("at least one of --user or --group is required.")
+		fatalIf(probe.NewError(e), "Missing flag in command")
 	}
 
 	args := ctx.Args()

--- a/cmd/admin-logs.go
+++ b/cmd/admin-logs.go
@@ -86,15 +86,15 @@ type logMessage struct {
 // JSON - jsonify loginfo
 func (l logMessage) JSON() string {
 	l.Status = "success"
-	logJSON, err := json.MarshalIndent(&l, "", " ")
-	fatalIf(probe.NewError(err), "Unable to marshal into JSON.")
+	logJSON, e := json.MarshalIndent(&l, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
 
 	return string(logJSON)
 }
 
 func getLogTime(lt string) string {
-	tm, err := time.Parse(time.RFC3339Nano, lt)
-	if err != nil {
+	tm, e := time.Parse(time.RFC3339Nano, lt)
+	if e != nil {
 		return lt
 	}
 	return tm.Format(logTimeFormat)

--- a/cmd/admin-policy-info.go
+++ b/cmd/admin-policy-info.go
@@ -107,14 +107,11 @@ func mainAdminPolicyInfo(ctx *cli.Context) error {
 
 	policyFile := ctx.String("policy-file")
 	if policyFile != "" {
-		f, err := os.Create(policyFile)
-		if err != nil {
-			fatalIf(probe.NewError(err).Trace(args...), "Could not open given policy file")
-		}
-		_, err = f.Write(pinfo.Policy)
-		if err != nil {
-			fatalIf(probe.NewError(err).Trace(args...), "Could not write to given policy file")
-		}
+		f, e := os.Create(policyFile)
+		fatalIf(probe.NewError(e).Trace(args...), "Could not open given policy file")
+
+		_, e = f.Write(pinfo.Policy)
+		fatalIf(probe.NewError(e).Trace(args...), "Could not write to given policy file")
 	}
 
 	printMsg(userPolicyMessage{

--- a/cmd/admin-prometheus-generate.go
+++ b/cmd/admin-prometheus-generate.go
@@ -18,7 +18,6 @@
 package cmd
 
 import (
-	"fmt"
 	"net/url"
 	"time"
 
@@ -74,10 +73,9 @@ type PrometheusConfig struct {
 
 // String colorized prometheus config yaml.
 func (c PrometheusConfig) String() string {
-	b, err := yaml.Marshal(c)
-	if err != nil {
-		return fmt.Sprintf("error creating config string: %s", err)
-	}
+	b, e := yaml.Marshal(c)
+	fatalIf(probe.NewError(e), "Unable to generate Prometheus config")
+
 	return console.Colorize("yaml", string(b))
 }
 
@@ -95,10 +93,9 @@ type StatConfig struct {
 
 // String colorized stat config yaml.
 func (t StatConfig) String() string {
-	b, err := yaml.Marshal(t)
-	if err != nil {
-		return fmt.Sprintf("error creating config string: %s", err)
-	}
+	b, e := yaml.Marshal(t)
+	fatalIf(probe.NewError(e), "Unable to generate Prometheus config")
+
 	return console.Colorize("yaml", string(b))
 }
 

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -103,9 +103,7 @@ func printPrometheusMetrics(ctx *cli.Context) error {
 func (pm prometheusMetricsReader) JSON() string {
 	mfChan := make(chan *dto.MetricFamily)
 	go func() {
-		if err := prom2json.ParseReader(pm.Reader, mfChan); err != nil {
-			fatalIf(probe.NewError(err), "error reading metrics:")
-		}
+		fatalIf(probe.NewError(prom2json.ParseReader(pm.Reader, mfChan)), "Unable to parse Prometheus metrics.")
 	}()
 	result := []*prom2json.Family{}
 	for mf := range mfChan {
@@ -119,9 +117,8 @@ func (pm prometheusMetricsReader) JSON() string {
 // String - returns the string representation of the prometheus metrics
 func (pm prometheusMetricsReader) String() string {
 	respBytes, e := io.ReadAll(pm.Reader)
-	if e != nil {
-		fatalIf(probe.NewError(e), "error reading metrics:")
-	}
+	fatalIf(probe.NewError(e), "Unable to read Prometheus metrics.")
+
 	return string(respBytes)
 }
 
@@ -132,8 +129,8 @@ type prometheusMetricsReader struct {
 
 func mainSupportMetrics(ctx *cli.Context) error {
 	checkSupportMetricsSyntax(ctx)
-	if err := printPrometheusMetrics(ctx); err != nil {
-		fatalIf(probe.NewError(err), "Error in listing prometheus metrics")
-	}
+
+	fatalIf(probe.NewError(printPrometheusMetrics(ctx)), "Unable to list prometheus metrics.")
+
 	return nil
 }

--- a/cmd/admin-rebalance-start.go
+++ b/cmd/admin-rebalance-start.go
@@ -43,7 +43,7 @@ USAGE:
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
-EXAMPLES:
+xEXAMPLES:
   1. Start rebalance on a MinIO deployment with alias myminio
      {{.Prompt}} {{.HelpName}} myminio
 `,
@@ -57,8 +57,8 @@ type rebalanceStartMsg struct {
 
 func (r rebalanceStartMsg) JSON() string {
 	r.Status = "success"
-	b, err := json.MarshalIndent(r, "", " ")
-	fatalIf(probe.NewError(err), "Unable to marshal to JSON")
+	b, e := json.MarshalIndent(r, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal to JSON")
 	return string(b)
 }
 

--- a/cmd/admin-rebalance-stop.go
+++ b/cmd/admin-rebalance-stop.go
@@ -56,8 +56,8 @@ type rebalanceStopMsg struct {
 
 func (r rebalanceStopMsg) JSON() string {
 	r.Status = "success"
-	b, err := json.MarshalIndent(r, "", " ")
-	fatalIf(probe.NewError(err), "Unable to marshal to JSON")
+	b, e := json.MarshalIndent(r, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal to JSON")
 	return string(b)
 }
 

--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -32,8 +32,8 @@ type fsComplete struct{}
 
 // predictPathWithTilde completes an FS path which starts with a `~/`
 func (fs fsComplete) predictPathWithTilde(a complete.Args) []string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil || homeDir == "" {
+	homeDir, e := os.UserHomeDir()
+	if e != nil || homeDir == "" {
 		return nil
 	}
 	// Clean the home directory path

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -139,9 +139,9 @@ func (s prettyStdout) Write(input []byte) (int, error) {
 	bufLen := s.buffer.Len()
 
 	// Copy all buffer content to the writer (stdout)
-	n, err := s.buffer.WriteTo(s.writer)
-	if err != nil {
-		return 0, err
+	n, e := s.buffer.WriteTo(s.writer)
+	if e != nil {
+		return 0, e
 	}
 
 	if int(n) != bufLen {

--- a/cmd/config-fix.go
+++ b/cmd/config-fix.go
@@ -273,8 +273,8 @@ func fixConfigLocation() {
 		// If there is a config at legacyLoc+".exe", rename it.
 		legacyLoc := mcCustomConfigDir + ".exe"
 		unusedLoc := mcCustomConfigDir + ".unused"
-		s, err := os.Stat(legacyLoc)
-		if err != nil || !s.IsDir() {
+		s, e := os.Stat(legacyLoc)
+		if e != nil || !s.IsDir() {
 			return
 		}
 		_ = os.Rename(legacyLoc, unusedLoc)
@@ -283,24 +283,24 @@ func fixConfigLocation() {
 
 	// mc was called with '.exe';
 	// config can have changed location.
-	_, err := os.Stat(mcCustomConfigDir)
-	wantExists := !os.IsNotExist(err)
+	_, e := os.Stat(mcCustomConfigDir)
+	wantExists := !os.IsNotExist(e)
 
 	legFileName := mcCustomConfigDir + ".exe"
-	stat, err := os.Stat(legFileName)
-	legExists := !os.IsNotExist(err) && stat.IsDir()
+	stat, e := os.Stat(legFileName)
+	legExists := !os.IsNotExist(e) && stat.IsDir()
 	switch {
 	case legExists && wantExists:
 		// Both exist and mc was called with legacy path (.exe)
 		// Rename the 'mc' config and move the legacy location one to where we want it.
 		backupdir := fmt.Sprintf("%s.unused\\", mcCustomConfigDir)
 		_ = os.RemoveAll(backupdir)
-		err := os.Rename(mcCustomConfigDir, backupdir)
-		fatalIf(probe.NewError(err), fmt.Sprintln("Renaming unused config", mcCustomConfigDir, "->", backupdir, "failed. Please rename/remove file."))
+		e := os.Rename(mcCustomConfigDir, backupdir)
+		fatalIf(probe.NewError(e), fmt.Sprintln("Renaming unused config", mcCustomConfigDir, "->", backupdir, "failed. Please rename/remove file."))
 		fallthrough
 	case !wantExists && legExists:
-		err := os.Rename(legFileName, mcCustomConfigDir)
-		fatalIf(probe.NewError(err), fmt.Sprintln("Migrating config location", legFileName, "->", mcCustomConfigDir, "failed. Please move config file."))
+		e := os.Rename(legFileName, mcCustomConfigDir)
+		fatalIf(probe.NewError(e), fmt.Sprintln("Migrating config location", legFileName, "->", mcCustomConfigDir, "failed. Please move config file."))
 	default:
 		// Legacy does not exist.
 	}

--- a/cmd/cp-main_contrib.go
+++ b/cmd/cp-main_contrib.go
@@ -62,8 +62,8 @@ func getMetaDataEntry(metadataString string) (map[string]string, *probe.Error) {
 	p := 0
 
 	for ; ; p++ {
-		ch, _, err := r.ReadRune()
-		if err != nil {
+		ch, _, e := r.ReadRune()
+		if e != nil {
 			// eof
 			if ps == QSTRING || ps == DQSTRING || pt == KEY {
 				return nil, probe.NewError(ErrInvalidMetadata)

--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -191,9 +191,9 @@ func du(ctx context.Context, urlStr string, timeRef time.Time, withVersions bool
 	}
 
 	if depth != 0 {
-		u, err := url.Parse(targetURL)
-		if err != nil {
-			panic(err)
+		u, e := url.Parse(targetURL)
+		if e != nil {
+			panic(e)
 		}
 
 		printMsg(duMessage{

--- a/cmd/ilm-rule-add.go
+++ b/cmd/ilm-rule-add.go
@@ -59,10 +59,8 @@ EXAMPLES:
          --noncurrent-transition-days "45" --noncurrent-transition-tier "MINIOTIER-1" \
          myminio/mybucket/
 
-
   2. Add a lifecycle rule with an expiration action for all objects in mybucket.
      {{.Prompt}} {{.HelpName}} --expire-days "200" myminio/mybucket
-
 
   3. Add a lifecycle rule with an expiration and a noncurrent version expiration action for all objects with prefix doc/ in mybucket.
      {{.Prompt}} {{.HelpName}} --prefix "doc/" --expire-days "300" --noncurrent-expire-days "100" \

--- a/cmd/ilm-tier-add.go
+++ b/cmd/ilm-tier-add.go
@@ -178,10 +178,8 @@ func fetchTierConfig(ctx *cli.Context, tierName string, tierType madmin.TierType
 			minioOpts = append(minioOpts, madmin.MinIORegion(region))
 		}
 
-		minioCfg, err := madmin.NewTierMinIO(tierName, endpoint, accessKey, secretKey, bucket, minioOpts...)
-		if err != nil {
-			fatalIf(probe.NewError(err), "Invalid configuration for MinIO tier")
-		}
+		minioCfg, e := madmin.NewTierMinIO(tierName, endpoint, accessKey, secretKey, bucket, minioOpts...)
+		fatalIf(probe.NewError(e), "Invalid configuration for MinIO tier")
 
 		return minioCfg
 
@@ -227,10 +225,8 @@ func fetchTierConfig(ctx *cli.Context, tierName string, tierType madmin.TierType
 		if ctx.IsSet("use-aws-role") {
 			s3Opts = append(s3Opts, madmin.S3AWSRole())
 		}
-		s3Cfg, err := madmin.NewTierS3(tierName, accessKey, secretKey, bucket, s3Opts...)
-		if err != nil {
-			fatalIf(probe.NewError(err), "Invalid configuration for AWS S3 compatible remote tier")
-		}
+		s3Cfg, e := madmin.NewTierS3(tierName, accessKey, secretKey, bucket, s3Opts...)
+		fatalIf(probe.NewError(e), "Invalid configuration for AWS S3 compatible remote tier")
 
 		return s3Cfg
 	case madmin.Azure:
@@ -261,10 +257,8 @@ func fetchTierConfig(ctx *cli.Context, tierName string, tierType madmin.TierType
 			azOpts = append(azOpts, madmin.AzurePrefix(prefix))
 		}
 
-		azCfg, err := madmin.NewTierAzure(tierName, accountName, accountKey, bucket, azOpts...)
-		if err != nil {
-			fatalIf(probe.NewError(err), "Invalid configuration for Azure Blob Storage remote tier")
-		}
+		azCfg, e := madmin.NewTierAzure(tierName, accountName, accountKey, bucket, azOpts...)
+		fatalIf(probe.NewError(e), "Invalid configuration for Azure Blob Storage remote tier")
 
 		return azCfg
 	case madmin.GCS:
@@ -285,15 +279,11 @@ func fetchTierConfig(ctx *cli.Context, tierName string, tierType madmin.TierType
 		}
 
 		credsPath := ctx.String("credentials-file")
-		credsBytes, err := os.ReadFile(credsPath)
-		if err != nil {
-			fatalIf(probe.NewError(err), "Failed to read credentials file")
-		}
+		credsBytes, e := os.ReadFile(credsPath)
+		fatalIf(probe.NewError(e), "Failed to read credentials file")
 
-		gcsCfg, err := madmin.NewTierGCS(tierName, credsBytes, bucket, gcsOpts...)
-		if err != nil {
-			fatalIf(probe.NewError(err), "Invalid configuration for Google Cloud Storage remote tier")
-		}
+		gcsCfg, e := madmin.NewTierGCS(tierName, credsBytes, bucket, gcsOpts...)
+		fatalIf(probe.NewError(e), "Invalid configuration for Google Cloud Storage remote tier")
 
 		return gcsCfg
 	}

--- a/cmd/ilm-tier-edit.go
+++ b/cmd/ilm-tier-edit.go
@@ -127,10 +127,9 @@ func mainAdminTierEdit(ctx *cli.Context) error {
 	case accountKey != "": // Azure tier
 		creds.SecretKey = accountKey
 	case credsPath != "": // GCS tier
-		credsBytes, err := os.ReadFile(credsPath)
-		if err != nil {
-			fatalIf(probe.NewError(err), "Failed to read credentials file")
-		}
+		credsBytes, e := os.ReadFile(credsPath)
+		fatalIf(probe.NewError(e), "Unable to read credentials file at %s", credsPath)
+
 		creds.CredsJSON = credsBytes
 	default:
 		fatalIf(errInvalidArgument().Trace(args.Tail()...), "Insufficient credential information supplied to update remote tier target credentials")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -335,10 +335,10 @@ func installAutoCompletion() {
 				"Supported shells are: bash, zsh, fish")
 	}
 
-	err := completeinstall.Install(filepath.Base(os.Args[0]))
+	e := completeinstall.Install(filepath.Base(os.Args[0]))
 	var printMsg string
-	if err != nil && strings.Contains(err.Error(), "* already installed") {
-		errStr := err.Error()[strings.Index(err.Error(), "\n")+1:]
+	if e != nil && strings.Contains(e.Error(), "* already installed") {
+		errStr := e.Error()[strings.Index(e.Error(), "\n")+1:]
 		re := regexp.MustCompile(`[::space::]*\*.*` + shellName + `.*`)
 		relatedMsg := re.FindStringSubmatch(errStr)
 		if len(relatedMsg) > 0 {
@@ -351,7 +351,7 @@ func installAutoCompletion() {
 		if completeinstall.IsInstalled(filepath.Base(os.Args[0])) || completeinstall.IsInstalled("mc") {
 			console.Infoln("autocompletion is enabled.", printMsg)
 		} else {
-			fatalIf(probe.NewError(err), "Unable to install auto-completion.")
+			fatalIf(probe.NewError(e), "Unable to install auto-completion.")
 		}
 	} else {
 		console.Infoln("enabled autocompletion in your '" + shellName + "' rc file. Please restart your shell.")

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -557,8 +557,8 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 		// If the passed source URL points to fs, fetch the absolute src path
 		// to correctly calculate targetPath
 		if sourceAlias == "" {
-			tmpSrcURL, err := filepath.Abs(sourceURLFull)
-			if err == nil {
+			tmpSrcURL, e := filepath.Abs(sourceURLFull)
+			if e == nil {
 				sourceURLFull = tmpSrcURL
 			}
 		}

--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -225,19 +225,19 @@ func (p *ParallelManager) stopAndWait() {
 const cgroupLimitFile = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 
 func cgroupLimit(limitFile string) (limit uint64) {
-	buf, err := os.ReadFile(limitFile)
-	if err != nil {
+	buf, e := os.ReadFile(limitFile)
+	if e != nil {
 		return 9223372036854771712
 	}
-	limit, err = strconv.ParseUint(string(buf), 10, 64)
-	if err != nil {
+	limit, e = strconv.ParseUint(string(buf), 10, 64)
+	if e != nil {
 		return 9223372036854771712
 	}
 	return limit
 }
 
 func availableMemory() (available uint64) {
-	available = 8 << 30 // Default to 8 GiB when we can't find the limits.
+	available = 4 << 30 // Default to 4 GiB when we can't find the limits.
 
 	if runtime.GOOS == "linux" {
 		available = cgroupLimit(cgroupLimitFile)
@@ -252,12 +252,13 @@ func availableMemory() (available uint64) {
 
 	} // for all other platforms limits are based on virtual memory.
 
-	memStats, err := mem.VirtualMemory()
-	if err != nil {
-		return
+	memStats, _ := mem.VirtualMemory()
+	if memStats.Available > 0 {
+		available = memStats.Available
 	}
 
-	available = memStats.Available / 2
+	// Always use 50% of available memory.
+	available = available / 2
 	return
 }
 

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -19,10 +19,8 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
-	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -141,16 +139,9 @@ func (pr PingResult) String() string {
 	return s.String()
 }
 
-// Endpoint - container to hold server info
-type Endpoint struct {
-	Scheme string `json:"scheme"`
-	Host   string `json:"host"`
-	Port   string `json:"port"`
-}
-
 // EndPointStats - container to hold server ping stats
 type EndPointStats struct {
-	Endpoint  Endpoint `json:"endpoint"`
+	Endpoint  *url.URL `json:"endpoint"`
 	Min       string   `json:"min"`
 	Max       string   `json:"max"`
 	Average   string   `json:"average"`
@@ -214,11 +205,10 @@ func ping(ctx context.Context, cliCtx *cli.Context, anonClient *madmin.Anonymous
 	}
 
 	for result := range anonClient.Alive(ctx, madmin.AliveOpts{}, servers...) {
-		host, port, _ := extractHostPort(result.Endpoint.String())
-		endPoint := Endpoint{result.Endpoint.Scheme, host, port}
-		stat := getPingInfo(cliCtx, result, endPointMap)
+		stat := pingStats(cliCtx, result, endPointMap)
+
 		endPointStat := EndPointStats{
-			Endpoint:  endPoint,
+			Endpoint:  result.Endpoint,
 			Min:       trimToTwoDecimal(time.Duration(stat.min)),
 			Max:       trimToTwoDecimal(time.Duration(stat.max)),
 			Average:   trimToTwoDecimal(time.Duration(stat.avg)),
@@ -281,7 +271,7 @@ func pad(s, p string, count int, left bool) string {
 	return string(ret)
 }
 
-func getPingInfo(cliCtx *cli.Context, result madmin.AliveResult, serverMap map[string]serverStats) serverStats {
+func pingStats(cliCtx *cli.Context, result madmin.AliveResult, serverMap map[string]serverStats) serverStats {
 	var errorString string
 	var sum, avg, dns uint64
 	min := uint64(math.MaxUint64)
@@ -331,43 +321,6 @@ func getPingInfo(cliCtx *cli.Context, result madmin.AliveResult, serverMap map[s
 		dns = uint64(result.DNSResolveTime.Nanoseconds())
 	}
 	return serverStats{min, max, sum, avg, dns, errorCount, errorString, counter}
-}
-
-// extractHostPort - extracts host/port from many address formats
-// such as, ":9000", "localhost:9000", "http://localhost:9000/"
-func extractHostPort(hostAddr string) (string, string, error) {
-	var addr string
-
-	if hostAddr == "" {
-		return "", "", errors.New("unable to process empty address")
-	}
-
-	// Simplify the work of url.Parse() and always send a url with
-	if !strings.HasPrefix(hostAddr, "http://") && !strings.HasPrefix(hostAddr, "https://") {
-		hostAddr = "//" + hostAddr
-	}
-
-	// Parse address to extract host and scheme field
-	u, err := url.Parse(hostAddr)
-	if err != nil {
-		return "", "", err
-	}
-
-	addr = u.Host
-	// At this point, addr can be one of the following form:
-	//  ":9000"
-	//  "localhost:9000"
-	//  "localhost" <- in this case, we check for scheme
-
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		if !strings.Contains(err.Error(), "missing port in address") {
-			return "", "", err
-		}
-		host = addr
-	}
-
-	return host, port, nil
 }
 
 // mainPing is entry point for ping command.

--- a/cmd/replicate-add.go
+++ b/cmd/replicate-add.go
@@ -75,7 +75,7 @@ var replicateAddFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "path",
 		Value: "auto",
-		Usage: "bucket path lookup supported by the server. Valid options are '[on,off,auto]'",
+		Usage: "bucket path lookup supported by the server. Valid options are ['auto', 'on', 'off']'",
 	},
 	cli.StringFlag{
 		Name:  "region",
@@ -83,11 +83,11 @@ var replicateAddFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "bandwidth",
-		Usage: "Set bandwidth limit in bits per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
+		Usage: "set bandwidth limit in bits per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
 	},
 	cli.BoolFlag{
 		Name:  "sync",
-		Usage: "enable synchronous replication for this target. Default is async",
+		Usage: "enable synchronous replication for this target. default is async",
 	},
 	cli.UintFlag{
 		Name:  "healthcheck-seconds",
@@ -108,35 +108,35 @@ var replicateAddCmd = cli.Command{
 	Before:       setGlobalsFromContext,
 	Flags:        append(globalFlags, replicateAddFlags...),
 	CustomHelpTemplate: `NAME:
- {{.HelpName}} - {{.Usage}}
+  {{.HelpName}} - {{.Usage}}
 
 USAGE:
- {{.HelpName}} TARGET
+  {{.HelpName}} TARGET
 
 FLAGS:
- {{range .VisibleFlags}}{{.}}
- {{end}}
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
 EXAMPLES:
- 1. Add replication configuration rule on bucket "mybucket" for alias "myminio" to replicate all operations in an active-active replication setup.
-    {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket \
-        --priority 1 
+  1. Add replication configuration rule on bucket "mybucket" for alias "myminio" to replicate all operations in an active-active replication setup.
+     {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket \
+         --priority 1 
 
- 2. Add replication configuration rule on bucket "mybucket" for alias "myminio" to replicate all objects with tags
-    "key1=value1, key2=value2" to targetbucket synchronously with bandwidth set to 2 gigabits per second. 
-    {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket  \
-        --tags "key1=value1&key2=value2" --bandwidth "2G" --sync \
-        --priority 1
+  2. Add replication configuration rule on bucket "mybucket" for alias "myminio" to replicate all objects with tags
+     "key1=value1, key2=value2" to targetbucket synchronously with bandwidth set to 2 gigabits per second. 
+     {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket  \
+         --tags "key1=value1&key2=value2" --bandwidth "2G" --sync \
+         --priority 1
 
- 3. Disable a replication configuration rule on bucket "mybucket" for alias "myminio".
-    {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket  \
-        --tags "key1=value1&key2=value2" \
-        --priority 1 --disable
+  3. Disable a replication configuration rule on bucket "mybucket" for alias "myminio".
+     {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket  \
+         --tags "key1=value1&key2=value2" \
+         --priority 1 --disable
 
- 4. Add replication configuration rule with existing object replication, delete marker replication and versioned deletes
-    enabled on bucket "mybucket" for alias "myminio".
-    {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket  \
-        --replicate "existing-objects,delete,delete-marker" \
-        --priority 1
+  4. Add replication configuration rule with existing object replication, delete marker replication and versioned deletes
+     enabled on bucket "mybucket" for alias "myminio".
+     {{.Prompt}} {{.HelpName}} myminio/mybucket --remote-bucket https://foobar:foo12345@minio.siteb.example.com/targetbucket  \
+         --replicate "existing-objects,delete,delete-marker" \
+         --priority 1
 `,
 }
 
@@ -184,7 +184,7 @@ func extractCredentialURL(argURL string) (accessKey, secretKey string, u *url.UR
 	if hostKeys.MatchString(argURL) {
 		parts := hostKeys.FindStringSubmatch(argURL)
 		if len(parts) != 5 {
-			fatalIf(errInvalidArgument().Trace(argURL), "Unsupported remote target format, please check --help")
+			fatalIf(errInvalidArgument().Trace(argURL), "unsupported remote target format, please check --help")
 		}
 		accessKey = parts[2]
 		secretKey = parts[3]
@@ -192,11 +192,11 @@ func extractCredentialURL(argURL string) (accessKey, secretKey string, u *url.UR
 	}
 	var e error
 	if parsedURL == "" {
-		fatalIf(errInvalidArgument().Trace(argURL), "No valid credentials were detected")
+		fatalIf(errInvalidArgument().Trace(argURL), "no valid credentials were detected")
 	}
 	u, e = url.Parse(parsedURL)
 	if e != nil {
-		fatalIf(errInvalidArgument().Trace(parsedURL), "Unsupported URL format %v", e)
+		fatalIf(errInvalidArgument().Trace(parsedURL), "unsupported URL format %v", e)
 	}
 
 	return accessKey, secretKey, u
@@ -206,13 +206,13 @@ func extractCredentialURL(argURL string) (accessKey, secretKey string, u *url.UR
 func fetchRemoteTarget(cli *cli.Context) (sourceBucket string, bktTarget *madmin.BucketTarget) {
 	args := cli.Args()
 	if !cli.IsSet("remote-bucket") {
-		fatalIf(probe.NewError(fmt.Errorf("missing Remote target configuration")), "Unable to parse remote target")
+		fatalIf(probe.NewError(fmt.Errorf("missing Remote target configuration")), "unable to parse remote target")
 	}
 	_, sourceBucket = url2Alias(args[0])
 	p := cli.String("path")
 	if !isValidPath(p) {
 		fatalIf(errInvalidArgument().Trace(p),
-			"Unrecognized bucket path style. Valid options are `[on,off, auto]`.")
+			"unrecognized bucket path style. Valid options are `[on, off, auto]`.")
 	}
 
 	tgtURL := cli.String("remote-bucket")
@@ -221,15 +221,12 @@ func fetchRemoteTarget(cli *cli.Context) (sourceBucket string, bktTarget *madmin
 	if u.Path != "" {
 		tgtBucket = path.Clean(u.Path[1:])
 	}
-	if e := s3utils.CheckValidBucketName(tgtBucket); e != nil {
-		fatalIf(probe.NewError(e).Trace(tgtURL), "Invalid target bucket specified")
-	}
+	fatalIf(probe.NewError(s3utils.CheckValidBucketName(tgtBucket)).Trace(tgtURL), "invalid target bucket")
 
 	bandwidthStr := cli.String("bandwidth")
-	bandwidth, err := getBandwidthInBytes(bandwidthStr)
-	if err != nil {
-		fatalIf(errInvalidArgument().Trace(bandwidthStr), "Invalid bandwidth number")
-	}
+	bandwidth, e := getBandwidthInBytes(bandwidthStr)
+	fatalIf(probe.NewError(e).Trace(bandwidthStr), "invalid bandwidth value")
+
 	console.SetColor(cred, color.New(color.FgYellow, color.Italic))
 	creds := &madmin.Credentials{AccessKey: accessKey, SecretKey: secretKey}
 	disableproxy := cli.Bool("disable-proxy")
@@ -275,18 +272,19 @@ func mainReplicateAdd(cliCtx *cli.Context) error {
 
 	// Create a new MinIO Admin Client
 	admclient, cerr := newAdminClient(aliasedURL)
-	fatalIf(cerr, "Unable to initialize admin connection.")
+	fatalIf(cerr, "unable to initialize admin connection.")
 
 	sourceBucket, bktTarget := fetchRemoteTarget(cliCtx)
 	arn, e := admclient.SetRemoteTarget(globalContext, sourceBucket, bktTarget)
-	if e != nil {
-		fatalIf(probe.NewError(e).Trace(args...), "Unable to configure remote target")
-	}
+	fatalIf(probe.NewError(e).Trace(args...), "unable to configure remote target")
+
 	// Create a new Client
 	client, err := newClient(aliasedURL)
-	fatalIf(err, "Unable to initialize connection.")
+	fatalIf(err, "unable to initialize connection.")
+
 	rcfg, err := client.GetReplication(ctx)
-	fatalIf(err.Trace(args...), "Unable to get replication configuration")
+	fatalIf(err.Trace(args...), "unable to fetch replication configuration")
+
 	ruleStatus := enableStatus
 	if cliCtx.Bool(disableStatus) {
 		ruleStatus = disableStatus
@@ -307,7 +305,8 @@ func mainReplicateAdd(cliCtx *cli.Context) error {
 		case "existing-objects":
 			existingReplicationStatus = enableStatus
 		default:
-			fatalIf(probe.NewError(fmt.Errorf("invalid value for --replicate flag %s", cliCtx.String("replicate"))), `--replicate flag takes one or more comma separated string with values "delete", "delete-marker", "metadata-sync", "existing-objects" or "" to disable these settings`)
+			fatalIf(probe.NewError(fmt.Errorf("invalid value for --replicate flag %s", cliCtx.String("replicate"))),
+				`--replicate flag takes one or more comma separated string with values "delete", "delete-marker", "metadata-sync", "existing-objects" or "" to disable these settings`)
 		}
 	}
 
@@ -324,7 +323,8 @@ func mainReplicateAdd(cliCtx *cli.Context) error {
 		ReplicaSync:             replicaSync,
 		ExistingObjectReplicate: existingReplicationStatus,
 	}
-	fatalIf(client.SetReplication(ctx, &rcfg, opts), "Could not add replication rule")
+	fatalIf(client.SetReplication(ctx, &rcfg, opts), "unable to add replication rule")
+
 	printMsg(replicateAddMessage{
 		Op:  cliCtx.Command.Name,
 		URL: aliasedURL,

--- a/cmd/sql-main.go
+++ b/cmd/sql-main.go
@@ -328,9 +328,9 @@ func getCSVHeader(sourceURL string, encKeyDB map[string][]prefixSSEPair) ([]stri
 		}
 	}
 	br := bufio.NewReader(r)
-	line, _, err := br.ReadLine()
-	if err != nil {
-		return nil, probe.NewError(err)
+	line, _, e := br.ReadLine()
+	if e != nil {
+		return nil, probe.NewError(e)
 	}
 	return strings.Split(string(line), ","), nil
 }

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -114,25 +114,25 @@ func checkAdminProfileSyntax(ctx *cli.Context) {
 // working directory is a different partition. To allow all situations to
 // be handled appropriately use this function instead of os.Rename()
 func moveFile(sourcePath, destPath string) error {
-	inputFile, err := os.Open(sourcePath)
-	if err != nil {
-		return err
+	inputFile, e := os.Open(sourcePath)
+	if e != nil {
+		return e
 	}
 
-	outputFile, err := os.Create(destPath)
-	if err != nil {
+	outputFile, e := os.Create(destPath)
+	if e != nil {
 		inputFile.Close()
-		return err
+		return e
 	}
 	defer outputFile.Close()
 
-	_, err = io.Copy(outputFile, inputFile)
-	inputFile.Close()
-	if err != nil {
-		return err
+	if _, e = io.Copy(outputFile, inputFile); e != nil {
+		inputFile.Close()
+		return e
 	}
 
 	// The copy was successful, so now delete the original file
+	inputFile.Close()
 	return os.Remove(sourcePath)
 }
 

--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -97,8 +97,8 @@ type tagListMessage struct {
 }
 
 func (t tagListMessage) JSON() string {
-	tagJSONbytes, err := json.MarshalIndent(t, "", "  ")
-	fatalIf(probe.NewError(err), "Unable to marshal into JSON for "+t.URL)
+	tagJSONbytes, e := json.MarshalIndent(t, "", "  ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON for "+t.URL)
 	return string(tagJSONbytes)
 }
 

--- a/cmd/tofu.go
+++ b/cmd/tofu.go
@@ -158,9 +158,9 @@ func promptTrustSelfSignedCert(ctx context.Context, endpoint, alias string) (*x5
 // fetchPeerCertificate uses the given transport to fetch the peer
 // certificate from the given endpoint.
 func fetchPeerCertificate(ctx context.Context, endpoint string) (*x509.Certificate, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
+	req, e := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if e != nil {
+		return nil, e
 	}
 	client := http.Client{
 		Transport: &http.Transport{
@@ -169,9 +169,9 @@ func fetchPeerCertificate(ctx context.Context, endpoint string) (*x509.Certifica
 			},
 		},
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
+	resp, e := client.Do(req)
+	if e != nil {
+		return nil, e
 	}
 	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
 		return nil, fmt.Errorf("Unable to read remote TLS certificate")

--- a/cmd/update-main.go
+++ b/cmd/update-main.go
@@ -322,8 +322,8 @@ func getDownloadURL(customReleaseURL string, releaseTag string) (downloadURL str
 		return mcReleaseURL + "archive/mc." + releaseTag
 	}
 
-	u, err := url.Parse(customReleaseURL)
-	if err != nil {
+	u, e := url.Parse(customReleaseURL)
+	if e != nil {
 		return mcReleaseURL + "archive/mc." + releaseTag
 	}
 


### PR DESCRIPTION

## Description
cleanup mc to use 'go' errs to be 'e'

## Motivation and Context
by design we have agreed to follow

go errors to be 'e'
probe.Error to be 'err'

in 'mc' fix it everywhere this is not
followed appropriately.

## How to test this PR?
Nothing should change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
