### PR TITLE
use humanize.IBytes instead of humanize.Bytes

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -572,17 +572,17 @@ func (s shortBackgroundHealStatusMessage) String() string {
 
 		healPrettyMsg += fmt.Sprintf("Objects Healed: %s/%s (%s), %s/%s (%s)\n",
 			humanize.Comma(int64(itemsHealed)), humanize.Comma(int64(totalItems)), humanize.CommafWithDigits(itemsPct, 1)+"%%",
-			humanize.Bytes(bytesHealed), humanize.Bytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%%")
+			humanize.IBytes(bytesHealed), humanize.IBytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%%")
 
 		if itemsFailed > 0 {
 			itemsPct := math.Min(100, 100*float64(itemsFailed)/float64(totalItems))
 			bytesPct := math.Min(100, 100*float64(bytesFailed)/float64(totalBytes))
 			healPrettyMsg += fmt.Sprintf("Objects Failed: %s/%s (%s), %s/%s (%s)\n",
 				humanize.Comma(int64(itemsFailed)), humanize.Comma(int64(totalItems)), humanize.CommafWithDigits(itemsPct, 1)+"%%",
-				humanize.Bytes(bytesFailed), humanize.Bytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%%")
+				humanize.IBytes(bytesFailed), humanize.IBytes(totalBytes), humanize.CommafWithDigits(bytesPct, 1)+"%%")
 		}
 	} else {
-		healPrettyMsg += fmt.Sprintf("Objects Healed: %s, %s\n", humanize.Comma(int64(itemsHealed)), humanize.Bytes(bytesHealed))
+		healPrettyMsg += fmt.Sprintf("Objects Healed: %s, %s\n", humanize.Comma(int64(itemsHealed)), humanize.IBytes(bytesHealed))
 	}
 
 	if accumulatedElapsedTime > 0 {

--- a/cmd/admin-rebalance-status.go
+++ b/cmd/admin-rebalance-status.go
@@ -119,7 +119,7 @@ func mainAdminRebalanceStatus(ctx *cli.Context) error {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Summary: \n")
-	fmt.Fprintf(&b, "Data: %s (%d objects, %d versions) \n", humanize.Bytes(totalBytes), totalObjects, totalVersions)
+	fmt.Fprintf(&b, "Data: %s (%d objects, %d versions) \n", humanize.IBytes(totalBytes), totalObjects, totalVersions)
 	fmt.Fprintf(&b, "Time: %s (%s to completion)", maxElapsed, maxETA)
 	console.Println(b.String())
 	return nil

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -73,10 +73,10 @@ func GetSysInfo() map[string]string {
 		"host.arch":      runtime.GOARCH,
 		"host.lang":      runtime.Version(),
 		"host.cpus":      strconv.Itoa(runtime.NumCPU()),
-		"mem.used":       humanize.Bytes(memstats.Alloc),
-		"mem.total":      humanize.Bytes(memstats.Sys),
-		"mem.heap.used":  humanize.Bytes(memstats.HeapAlloc),
-		"mem.heap.total": humanize.Bytes(memstats.HeapSys),
+		"mem.used":       humanize.IBytes(memstats.Alloc),
+		"mem.total":      humanize.IBytes(memstats.Sys),
+		"mem.heap.used":  humanize.IBytes(memstats.HeapAlloc),
+		"mem.heap.total": humanize.IBytes(memstats.HeapSys),
 	}
 }
 


### PR DESCRIPTION

## Description
use humanize.IBytes instead of humanize.Bytes

## Motivation and Context
mc always uses IEC units, there is no reason
to choose SI units.

## How to test this PR?
Nothing special, just the units are more appropriate now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
