### PR TITLE
fix: hide duration flag its not useful for users

### DIFF
--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -35,18 +35,18 @@ import (
 
 var supportPerfFlags = append([]cli.Flag{
 	cli.StringFlag{
-		Name:  "duration",
-		Usage: "duration the entire perf tests are run",
-		Value: "10s",
+		Name:  "size",
+		Usage: "size of the object used for uploads/downloads",
+		Value: "64MiB",
 	},
 	cli.BoolFlag{
 		Name:  "verbose, v",
 		Usage: "display per-server stats",
 	},
 	cli.StringFlag{
-		Name:   "size",
-		Usage:  "size of the object used for uploads/downloads",
-		Value:  "64MiB",
+		Name:   "duration",
+		Usage:  "maximum duration each perf tests are run",
+		Value:  "10s",
 		Hidden: true,
 	},
 	cli.IntFlag{
@@ -97,12 +97,12 @@ USAGE:
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
-
 EXAMPLES:
   1. Upload object storage, network, and drive performance analysis for cluster with alias 'myminio' to SUBNET
      {{.Prompt}} {{.HelpName}} myminio
+
   2. Run object storage, network, and drive performance tests on cluster with alias 'myminio', save and upload to SUBNET manually
-     {{.Prompt}} {{.HelpName}} --airgap myminio
+     {{.Prompt}} {{.HelpName}} myminio --airgap
 `,
 }
 


### PR DESCRIPTION
## Description
fix: hide duration flag its not useful for users

## Motivation and Context
simplify `mc support perf` tool

## How to test this PR?
Nothing should change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
