### PR TITLE
Use --api-key flag on register when provided

### DIFF
--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -175,14 +175,11 @@ func mainLicenseRegister(ctx *cli.Context) error {
 		fatalIf(probe.NewError(e), "Error in fetching subnet API Key")
 		if len(apiKey) > 0 {
 			alreadyRegistered = true
-			if len(accAPIKey) == 0 {
-				accAPIKey = apiKey
-			}
+			accAPIKey = apiKey
 		}
 	} else {
 		apiKey := getSubnetAPIKeyFromConfig(alias)
-		lic := getSubnetLicenseFromConfig(alias)
-		if len(apiKey) > 0 || len(lic) > 0 {
+		if len(apiKey) > 0 {
 			alreadyRegistered = true
 		}
 	}

--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -170,12 +170,20 @@ func mainLicenseRegister(ctx *cli.Context) error {
 	regInfo := getClusterRegInfo(getAdminInfo(aliasedURL), clusterName)
 
 	alreadyRegistered := false
-	apiKey, _, e := getSubnetCreds(alias)
-	fatalIf(probe.NewError(e), "Error in fetching subnet API Key")
-	if len(apiKey) > 0 {
-		alreadyRegistered = true
-		if len(accAPIKey) == 0 {
-			accAPIKey = apiKey
+	if len(accAPIKey) == 0 {
+		apiKey, _, e := getSubnetCreds(alias)
+		fatalIf(probe.NewError(e), "Error in fetching subnet API Key")
+		if len(apiKey) > 0 {
+			alreadyRegistered = true
+			if len(accAPIKey) == 0 {
+				accAPIKey = apiKey
+			}
+		}
+	} else {
+		apiKey := getSubnetAPIKeyFromConfig(alias)
+		lic := getSubnetLicenseFromConfig(alias)
+		if len(apiKey) > 0 || len(lic) > 0 {
+			alreadyRegistered = true
 		}
 	}
 
@@ -189,7 +197,7 @@ func mainLicenseRegister(ctx *cli.Context) error {
 		lrm.URL = subnetOfflineRegisterURL(regToken)
 	} else {
 		lrm.Type = "online"
-		_, _, e = registerClusterOnSubnet(regInfo, alias, accAPIKey)
+		_, _, e := registerClusterOnSubnet(regInfo, alias, accAPIKey)
 		fatalIf(probe.NewError(e), "Could not register cluster with SUBNET:")
 
 		lrm.Action = "registered"


### PR DESCRIPTION
## Description

When `--api-key` is provided in the `mc license register` command, the existing key and the license stored on the config can be ignored since they can be expired.

## Motivation and Context

Some of the older deployments may have an expired license and no api-key. They needs to ignored when `--api-key` flag is provided.

## How to test this PR?
Register a new deployment using `mc license register ALIAS --api-key=API_KEY`
Check if it is successfule.

Update a deployment using `mc license register ALIAS` but with no api-key
Check if the deployment is updated succesfully.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
