### PR TITLE
locks: Use timestamp when elapsed is zero

### DIFF
--- a/cmd/support-top-locks.go
+++ b/cmd/support-top-locks.go
@@ -91,7 +91,14 @@ func (u lockMessage) String() string {
 		typeFieldMaxLen     = 6
 	)
 
-	lockState, timeDiff := getLockDuration(u.Lock.Elapsed)
+	elapsed := u.Lock.Elapsed
+	// elapsed can be zero with older MinIO versions,
+	// so this code is deprecated and can be removed later.
+	if elapsed == 0 {
+		elapsed = time.Now().UTC().Sub(u.Lock.Timestamp)
+	}
+
+	lockState, timeDiff := getLockDuration(elapsed)
 	return console.Colorize(lockState, newPrettyTable("  ",
 		Field{"Time", timeFieldMaxLen},
 		Field{"Type", typeFieldMaxLen},


### PR DESCRIPTION
## Description
Older MinIO server versions return zero elapsed. Use timestamp to 
calculate the elapsed time instead.

## Motivation and Context
mc support top locks shows zero elapsed time for locks, which is wrong when running
mc with older MinIO versions

## How to test this PR?
mc support top locks <alias> with older MinIO version

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
