### PR TITLE
mc admin user list --json output doesn't include user groups (#4433)

### DIFF
--- a/cmd/admin-user-list.go
+++ b/cmd/admin-user-list.go
@@ -79,6 +79,7 @@ func mainAdminUserList(ctx *cli.Context) error {
 			op:         ctx.Command.Name,
 			AccessKey:  k,
 			PolicyName: v.PolicyName,
+			MemberOf:   v.MemberOf,
 			UserStatus: string(v.Status),
 		})
 	}


### PR DESCRIPTION
Updated output of "mc admin user list".

## Description
This little change just initialized MemberOf field from output structure for user list. The data already comes from minio via Admin API, so no changes to the API or server side is required.

Please note that this change lives text output as is and adjusts only JSON output.

## Motivation and Context
The change can potentially increase performance for some user interfaces made on top of "mc" tool. E.g. if an admin wants to get list of all users and details for them, current interface will require calling "mc admin user list" and "mc admin user info" for each user from the list to get group membership.


## How to test this PR?
```
./mc --json admin user list

{
 "status": "success",
 "accessKey": "user1",
 "policyName": "readonly",
 "userStatus": "enabled",
 "memberOf": [
  "test",
  "users"
 ]
}
{
 "status": "success",
 "accessKey": "user2",
 "policyName": "readonly,readwrite",
 "userStatus": "enabled",
 "memberOf": [
  "users"
 ]
}
{
 "status": "success",
 "accessKey": "admin1",
 "policyName": "readonly,consoleAdmin,readwrite",
 "userStatus": "enabled",
 "memberOf": [
  "admins",
  "test",
  "users"
 ]
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
