### PR TITLE
Fix parsing --response-duration in trace command

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -86,7 +86,7 @@ var adminTraceFlags = []cli.Flag{
 		Name:  "filter-response",
 		Usage: "trace calls only with response bytes greater than this threshold, use with filter-size",
 	},
-	cli.BoolFlag{
+	cli.DurationFlag{
 		Name:  "response-duration",
 		Usage: "trace calls only with response duration greater than this threshold (e.g. `5ms`)",
 	},


### PR DESCRIPTION
## Description

--response-duration is not working. The reason is that it is defined
erroneously as a boolean flag and not duration.


## Motivation and Context
Fix mc admin trace --response-duration call

## How to test this PR?
mc admin trace --response-duration 1s play

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
