### PR TITLE
mc rm: disallow --purge with flags other than --force

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -234,7 +234,10 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 		fatalIf(errDummy().Trace(),
 			"You cannot specify --purge with --recursive.")
 	}
-
+	if isForceDel && (isNoncurrentVersion || isVersions || cliCtx.IsSet("older-than") || cliCtx.IsSet("newer-than") || versionID != "") {
+		fatalIf(errDummy().Trace(),
+			"You cannot specify --purge flag with any flag(s) other than --force.")
+	}
 	for _, url := range cliCtx.Args() {
 		// clean path for aliases like s3/.
 		// Note: UNC path using / works properly in go 1.9.2 even though it breaks the UNC specification.


### PR DESCRIPTION
## Description


## Motivation and Context
--purge flag works at prefix level and not applicable with other flags that filter object version(s) from the listing 

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
