### PR TITLE
perf: Add --noclear flag to avoid doing cleanup

### DIFF
--- a/cmd/support-perf-object.go
+++ b/cmd/support-perf-object.go
@@ -90,6 +90,7 @@ func mainAdminSpeedTestObject(ctx *cli.Context, aliasedURL string, outCh chan<- 
 		Concurrency: concurrent,
 		Autotune:    autotune,
 		Bucket:      ctx.String("bucket"), // This is a hidden flag.
+		NoClear:     ctx.Bool("noclear"),
 	})
 
 	if globalJSON {

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -60,6 +60,11 @@ var supportPerfFlags = append([]cli.Flag{
 		Usage:  "provide a custom bucket name to use (NOTE: bucket must be created prior)",
 		Hidden: true, // Hidden for now.
 	},
+	cli.BoolFlag{
+		Name:   "noclear",
+		Usage:  "do not cleanup generated data after running object speedtest",
+		Hidden: true, // Hidden for now.
+	},
 	// Drive test specific flags.
 	cli.StringFlag{
 		Name:   "filesize",

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -62,7 +62,7 @@ var supportPerfFlags = append([]cli.Flag{
 	},
 	cli.BoolFlag{
 		Name:   "noclear",
-		Usage:  "do not cleanup generated data after running object speedtest",
+		Usage:  "do not clear bucket after running object perf test",
 		Hidden: true, // Hidden for now.
 	},
 	// Drive test specific flags.


### PR DESCRIPTION
## Description
This is a quick way to generate a lot of data using speedtest.

## Motivation and Context
Quickly generate data in a cluster

This is a hidden feature, it does not need a documentation.

## How to test this PR?
mc support perf object <alias> --noclear

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
