### PR TITLE
Print custom info in trace

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -436,6 +436,7 @@ func mainAdminTrace(ctx *cli.Context) error {
 	console.SetColor("ErrStatus", color.New(color.Bold, color.FgRed))
 
 	console.SetColor("Response", color.New(color.FgGreen))
+	console.SetColor("Extra", color.New(color.FgBlue))
 	console.SetColor("Body", color.New(color.FgYellow))
 	for _, c := range colors {
 		console.SetColor(fmt.Sprintf("Node%d", c), color.New(c))
@@ -471,19 +472,20 @@ func mainAdminTrace(ctx *cli.Context) error {
 
 // Short trace record
 type shortTraceMsg struct {
-	Status     string        `json:"status"`
-	Host       string        `json:"host"`
-	Time       time.Time     `json:"time"`
-	Client     string        `json:"client"`
-	CallStats  *callStats    `json:"callStats,omitempty"`
-	Duration   time.Duration `json:"duration"`
-	FuncName   string        `json:"api"`
-	Path       string        `json:"path"`
-	Query      string        `json:"query"`
-	StatusCode int           `json:"statusCode"`
-	StatusMsg  string        `json:"statusMsg"`
-	Type       string        `json:"type"`
-	Error      string        `json:"error"`
+	Status     string            `json:"status"`
+	Host       string            `json:"host"`
+	Time       time.Time         `json:"time"`
+	Client     string            `json:"client"`
+	CallStats  *callStats        `json:"callStats,omitempty"`
+	Duration   time.Duration     `json:"duration"`
+	FuncName   string            `json:"api"`
+	Path       string            `json:"path"`
+	Query      string            `json:"query"`
+	StatusCode int               `json:"statusCode"`
+	StatusMsg  string            `json:"statusMsg"`
+	Type       string            `json:"type"`
+	Error      string            `json:"error"`
+	Extra      map[string]string `json:"extra"`
 	trcType    madmin.TraceType
 }
 
@@ -530,6 +532,7 @@ type verboseTrace struct {
 	ResponseInfo *responseInfo          `json:"response,omitempty"`
 	CallStats    *callStats             `json:"callStats,omitempty"`
 	HealResult   *madmin.HealResultItem `json:"healResult,omitempty"`
+	Extra        map[string]string      `json:"extra,omitempty"`
 
 	trcType madmin.TraceType
 }
@@ -548,6 +551,7 @@ func shortTrace(ti madmin.ServiceTraceInfo) shortTraceMsg {
 	s.Host = t.NodeName
 	s.Duration = t.Duration
 	s.StatusMsg = t.Message
+	s.Extra = t.Custom
 
 	switch t.TraceType {
 	case madmin.TraceS3, madmin.TraceInternal:
@@ -657,6 +661,7 @@ func (t traceMessage) JSON() string {
 		Error:      t.Trace.Error,
 		HealResult: t.Trace.HealResult,
 		Message:    t.Trace.Message,
+		Extra:      t.Trace.Custom,
 	}
 
 	if t.Trace.HTTP != nil {
@@ -715,20 +720,26 @@ func (t traceMessage) String() string {
 	if trc.NodeName != "" {
 		nodeNameStr = fmt.Sprintf("%s ", colorizedNodeName(trc.NodeName))
 	}
-
+	extra := ""
+	if len(t.Trace.Custom) > 0 {
+		for k, v := range t.Trace.Custom {
+			extra = fmt.Sprintf("%s %s=%s", extra, k, v)
+		}
+		extra = console.Colorize("Extra", extra)
+	}
 	switch trc.TraceType {
 	case madmin.TraceS3, madmin.TraceInternal:
 		if trc.HTTP == nil {
 			return ""
 		}
 	case madmin.TraceBootstrap:
-		fmt.Fprintf(b, "%s %s [%s] %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[%s %s]", strings.ToUpper(trc.TraceType.String()), trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.Message)
+		fmt.Fprintf(b, "%s %s [%s] %s%s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[%s %s]", strings.ToUpper(trc.TraceType.String()), trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.Message, extra)
 		return b.String()
 	default:
 		if trc.Error != "" {
-			fmt.Fprintf(b, "%s %s [%s] %s err='%s' %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[%s %s]", strings.ToUpper(trc.TraceType.String()), trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.Path, console.Colorize("ErrStatus", trc.Error), trc.Duration)
+			fmt.Fprintf(b, "%s %s [%s] %s%s err='%s' %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[%s %s]", strings.ToUpper(trc.TraceType.String()), trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.Path, extra, console.Colorize("ErrStatus", trc.Error), trc.Duration)
 		} else {
-			fmt.Fprintf(b, "%s %s [%s] %s %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[%s %s]", strings.ToUpper(trc.TraceType.String()), trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.Path, trc.Duration)
+			fmt.Fprintf(b, "%s %s [%s] %s%s %s", nodeNameStr, console.Colorize("Request", fmt.Sprintf("[%s %s]", strings.ToUpper(trc.TraceType.String()), trc.FuncName)), trc.Time.Local().Format(traceTimeFormat), trc.Path, extra, trc.Duration)
 		}
 		return b.String()
 	}
@@ -768,6 +779,9 @@ func (t traceMessage) String() string {
 	for k, v := range rs.Headers {
 		fmt.Fprintf(b, "%s%s", nodeNameStr, console.Colorize("RespHeaderKey",
 			fmt.Sprintf("%s: ", k))+console.Colorize("HeaderValue", fmt.Sprintf("%s\n", strings.Join(v, ","))))
+	}
+	if len(extra) > 0 {
+		fmt.Fprintf(b, "%s%s\n", nodeNameStr, extra)
 	}
 	fmt.Fprintf(b, "%s%s\n", nodeNameStr, console.Colorize("Body", string(rs.Body)))
 	fmt.Fprint(b, nodeNameStr)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.4
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v2 v2.0.11
+	github.com/minio/madmin-go/v2 v2.0.13-0.20230220143547-e6641ef0b8d5
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.47
 	github.com/minio/pkg v1.6.1
@@ -116,7 +116,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.4.0
 	google.golang.org/genproto v0.0.0-20230131230820-1c016267d619 // indirect
 	google.golang.org/grpc v1.52.3 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,8 @@ github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbL
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go/v2 v2.0.11 h1:Ct905UAMJ43EAwKCi8xy5PzWPWyYL5YCQ441E9LYXTA=
-github.com/minio/madmin-go/v2 v2.0.11/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
+github.com/minio/madmin-go/v2 v2.0.13-0.20230220143547-e6641ef0b8d5 h1:IZa7nXFFDdOigg2wufK51C6oTB5q9c6LCV969u3L0YY=
+github.com/minio/madmin-go/v2 v2.0.13-0.20230220143547-e6641ef0b8d5/go.mod h1:5aFi/VLWBHC2DEFfGIlUmAeJhaF4ZAjuYpEWZFU14Zw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.41/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=


### PR DESCRIPTION
## Description

Print Custom trace fields in JSON and  `mc admin trace -v`.

Example:

![image](https://user-images.githubusercontent.com/5663952/220146080-8378b50b-3041-45e1-aee6-f6749d17e713.png)

## How to test this PR?

Test with https://github.com/minio/minio/pull/16668

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
