### PR TITLE
subnet: Avoid general hard timeout for requests

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -175,7 +175,7 @@ func subnetAPIKeyAuthHeaders(apiKey string) subnetHeaders {
 }
 
 func getSubnetClient() *http.Client {
-	client := httpClient(10 * time.Second)
+	client := httpClient(0)
 	if globalSubnetProxyURL != nil {
 		client.Transport.(*http.Transport).Proxy = http.ProxyURL(globalSubnetProxyURL)
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -425,10 +426,13 @@ func getClient(aliasURL string) *madmin.AdminClient {
 	return client
 }
 
-func httpClient(timeout time.Duration) *http.Client {
+func httpClient(reqTimeout time.Duration) *http.Client {
 	return &http.Client{
-		Timeout: timeout,
+		Timeout: reqTimeout,
 		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: 10 * time.Second,
+			}).DialContext,
 			Proxy: ieproxy.GetProxyFunc(),
 			TLSClientConfig: &tls.Config{
 				RootCAs: globalRootCAs,
@@ -437,6 +441,9 @@ func httpClient(timeout time.Duration) *http.Client {
 				// Can't use TLSv1.1 because of RC4 cipher usage
 				MinVersion: tls.VersionTLS12,
 			},
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 10 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
## Description
There is a ten seconds timeout deadline for subnet requests. T
his is now wrong after introducing Subnet inspect upload feature. 
One user can see deadline timeout error when trying to upload 
a large inspect file.

Disabling the timeout for all subnet operations for now.

We can introduce context.Context in subnet calls later in 
order to configure a deadline per use case.


## Motivation and Context
Fixing 
```
mc: <ERROR> Unable to upload inspect data to SUBNET portal: Post "https://subnet.min.io/api/inspect/upload?filename=inspect-data.enc": context deadline exceeded (Client.Timeout exceeded while awaiting hea
ders)  
```

## How to test this PR?
Setup a MinIO cluster and register it in Subnet
Upload many files under a bucket
mc support inspect "<alias>/bucket/**"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
