### PR TITLE
added ability to use sts web identity token with mc cli - useful for …

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -158,11 +158,16 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 		var api *minio.Client
 		var found bool
 		if api, found = clientCache[confSum]; !found {
-			// if Signature version '4' use NewV4 directly.
-			creds := credentials.NewStaticV4(config.AccessKey, config.SecretKey, config.SessionToken)
-			// if Signature version '2' use NewV2 directly.
-			if strings.ToUpper(config.Signature) == "S3V2" {
-				creds = credentials.NewStaticV2(config.AccessKey, config.SecretKey, "")
+			var creds *credentials.Credentials
+			if len(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")) > 0 {
+				creds = credentials.NewIAM("https://sts.amazonaws.com")
+			} else {
+				// if Signature version '4' use NewV4 directly.
+				creds = credentials.NewStaticV4(config.AccessKey, config.SecretKey, config.SessionToken)
+				// if Signature version '2' use NewV2 directly.
+				if strings.ToUpper(config.Signature) == "S3V2" {
+					creds = credentials.NewStaticV2(config.AccessKey, config.SecretKey, "")
+				}
 			}
 
 			var transport http.RoundTripper


### PR DESCRIPTION
## Description
Enable the use of the web iditnty token wiht then AWS_WEB_IDENTITY_TOKEN_FILE env var is set. This makes mc useable on EKS pods that are setup for IRSA

## Motivation and Context
Need to be able to use MC with AWS s3 while on EKS with IRSA

## How to test this PR?

` mc ls --debug s3/my-bucket
mc: <DEBUG> GET /my-bucket/?location= HTTP/1.1
Host: s3.amazonaws.com
User-Agent: MinIO (linux; amd64) minio-go/v6.0.58 mc/2023-02-26T17:19:58Z
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20230226/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=**REDACTED**
X-Amz-Content-Sha256: UNSIGNED-PAYLOAD
X-Amz-Date: 20230226T172405Z
X-Amz-Security-Token: 
Accept-Encoding: gzip

mc: <DEBUG> HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Sun, 26 Feb 2023 17:24:06 GMT
Server: AmazonS3
X-Amz-Id-2: Wjy8SlC2U/xfecQ9ycMNOtmxLQzGO29rBrSSYlRbCPaSoZ/SB/a52AnK0mkTp/Zzwif/yaVOR/A=
X-Amz-Request-Id: 6AB8K1GJ4Q505NJ4

mc: <DEBUG> Response Time:  267.234699ms

mc: <DEBUG> HEAD / HTTP/1.1
Host: my-bucket.s3.dualstack.us-west-2.amazonaws.com
User-Agent: MinIO (linux; amd64) minio-go/v6.0.58 mc/2023-02-26T17:19:58Z
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20230226/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=**REDACTED**
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20230226T172405Z
X-Amz-Security-Token: token-was-here

mc: <DEBUG> HTTP/1.1 200 OK
Connection: close
Content-Type: application/xml
Date: Sun, 26 Feb 2023 17:24:06 GMT
Server: AmazonS3
X-Amz-Access-Point-Alias: false
X-Amz-Bucket-Region: us-west-2
X-Amz-Id-2: vD7ELktSQB0PwZPELb8l9GOfFYpJBmrMdCNhOXtByzm09ieYN8ro8eQGAoLDrlfwnIXMeybPvSA=
X-Amz-Request-Id: 6AB30PRBCVX6MZVJ

mc: <DEBUG> Response Time:  38.557679ms

mc: <DEBUG> HEAD / HTTP/1.1
Host: my-bucket.s3.dualstack.us-west-2.amazonaws.com
User-Agent: MinIO (linux; amd64) minio-go/v6.0.58 mc/2023-02-26T17:19:58Z
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20230226/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=**REDACTED**
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20230226T172405Z
X-Amz-Security-Token: token-was-here

mc: <DEBUG> HTTP/1.1 200 OK
Connection: close
Content-Type: application/xml
Date: Sun, 26 Feb 2023 17:24:06 GMT
Server: AmazonS3
X-Amz-Access-Point-Alias: false
X-Amz-Bucket-Region: us-west-2
X-Amz-Id-2: SGdIC9ZD7VuALId2KgvkF19JwbLw47Eg6eSES6K23gXJQGlDNgDskP0EwhYLLAORtg9QdOaCXJg=
X-Amz-Request-Id: 6AB1VRAJH3MG5T2S

mc: <DEBUG> Response Time:  14.156585ms

mc: <DEBUG> GET /?delimiter=%2F&encoding-type=url&fetch-owner=true&list-type=2&prefix= HTTP/1.1
Host: my-bucket.s3.dualstack.us-west-2.amazonaws.com
User-Agent: MinIO (linux; amd64) minio-go/v6.0.58 mc/2023-02-26T17:19:58Z
Authorization: AWS4-HMAC-SHA256 Credential=**REDACTED**/20230226/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=**REDACTED**
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20230226T172405Z
X-Amz-Security-Token: token-was-here
Accept-Encoding: gzip

mc: <DEBUG> HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Sun, 26 Feb 2023 17:24:06 GMT
Server: AmazonS3
X-Amz-Bucket-Region: us-west-2
X-Amz-Id-2: gMxxNRQGbFFbnV2UgD48O1woZscn3/sLwBz4WY5u7Zne1RJw57W/WipXByhEGccqCIi2EdAEENk=
X-Amz-Request-Id: 6AB8YMCRJ293DKV9

mc: <DEBUG> Response Time:  167.303954ms

[2023-02-26 15:29:11 UTC]  2.6MiB mc-irsa-???-profit.png
`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
