### PR TITLE
Allow `support proxy set|remove` without registration

### DIFF
--- a/cmd/support-proxy-remove.go
+++ b/cmd/support-proxy-remove.go
@@ -76,8 +76,6 @@ func mainSupportProxyRemove(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
-	alias, _ := url2Alias(aliasedURL)
-	validateClusterRegistered(alias, true)
 
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)

--- a/cmd/support-proxy-set.go
+++ b/cmd/support-proxy-set.go
@@ -79,8 +79,6 @@ func mainSupportProxySet(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
-	alias, _ := url2Alias(aliasedURL)
-	validateClusterRegistered(alias, true)
 
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)


### PR DESCRIPTION
## Description

As it might be required to set proxy for registration itself, it is not right to validate that the cluster is already registered.

## Motivation and Context

Allow users to run `mc support proxy set` for setting proxy before registration.

## How to test this PR?

- Ensure that your cluster is not registered
- Run `mc support proxy set {alias} {proxy}`
- Verify that it doesn't fail asking to register the cluster first
- Run `mc support proxy remove {alias}`
- Verify that it doesn't fail asking to register the cluster first

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
