### PR TITLE
rm: --dry-run with --versions to print versions modtime

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -361,7 +361,7 @@ func removeSingle(url, versionID string, opts removeOpts) error {
 			printMsg(msg)
 		}
 	} else {
-		printDryRunMsg(content)
+		printDryRunMsg(content, opts.withVersions)
 	}
 	return nil
 }
@@ -381,12 +381,12 @@ type removeOpts struct {
 	encKeyDB          map[string][]prefixSSEPair
 }
 
-func printDryRunMsg(content *ClientContent) {
+func printDryRunMsg(content *ClientContent, printModTime bool) {
 	if globalJSON {
 		return
 	}
-	if content.VersionID != "" {
-		fmt.Println("DRYRUN: Removing ", content.URL.Path, "version:", content.VersionID)
+	if printModTime {
+		fmt.Println("DRYRUN: Removing ", content.VersionID, content.Time.Format(printDate), content.URL.Path)
 		return
 	}
 	fmt.Println("DRYRUN: Removing ", content.URL.Path)
@@ -472,7 +472,7 @@ func listAndRemove(url string, opts removeOpts) error {
 					}
 
 					if opts.isFake {
-						printDryRunMsg(content)
+						printDryRunMsg(content, true)
 						continue
 					}
 
@@ -568,7 +568,7 @@ func listAndRemove(url string, opts removeOpts) error {
 				}
 			}
 		} else {
-			printDryRunMsg(content)
+			printDryRunMsg(content, opts.withVersions)
 		}
 	}
 
@@ -593,7 +593,7 @@ func listAndRemove(url string, opts removeOpts) error {
 			}
 
 			if opts.isFake {
-				printDryRunMsg(content)
+				printDryRunMsg(content, true)
 				continue
 			}
 


### PR DESCRIPTION
## Description
--dry-run is always used to check the list of objects/versions 
to remove before actually remove them. However, when 
combined with --older-than, --newer-than flags, the output 
is not useful to inspect. This PR adds the modtime of each version.

## Motivation and Context
Better UX

## How to test this PR?
mc rm --recursive --versions --non-current --older-than 10d <alias>/<bucket>/dir/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
