### PR TITLE
fix: ldap commands don't accept config name

### DIFF
--- a/cmd/admin-idp-ldap-add.go
+++ b/cmd/admin-idp-ldap-add.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/minio/cli"
@@ -36,13 +37,13 @@ var adminIDPLdapAddCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET [CFG_NAME] [CFG_PARAMS...]
+  {{.HelpName}} TARGET [CFG_PARAMS...]
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Create a default LDAP IDP configuration (CFG_NAME is omitted).
+  1. Create LDAP IDentity Provider configuration.
      {{.Prompt}} {{.HelpName}} myminio/ \
           server_addr=myldapserver:636 \
           lookup_bind_dn=cn=admin,dc=min,dc=io \
@@ -72,6 +73,11 @@ func mainAdminIDPLDAPAdd(ctx *cli.Context) error {
 	if !strings.Contains(args.Get(1), "=") {
 		cfgName = args.Get(1)
 		input = args[2:]
+	}
+
+	if cfgName != madmin.Default {
+		fatalIf(probe.NewError(errors.New("all config parameters must be of the form \"key=value\"")),
+			"Bad LDAP IDP configuration")
 	}
 
 	inputCfg := strings.Join(input, " ")

--- a/cmd/admin-idp-ldap-disable.go
+++ b/cmd/admin-idp-ldap-disable.go
@@ -32,20 +32,22 @@ var adminIDPLdapDisableCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET [CFG_NAME]
+  {{.HelpName}} TARGET
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Disable the default LDAP IDP configuration (CFG_NAME is omitted).
+  1. Disable the default LDAP IDP configuration.
      {{.Prompt}} {{.HelpName}} play/
-  2. Disable LDAP IDP configuration named "dex_test".
-     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
 func mainAdminIDPLDAPDisable(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
 	isOpenID, enable := false, false
 	return adminIDPEnableDisable(ctx, isOpenID, enable)
 }

--- a/cmd/admin-idp-ldap-enable.go
+++ b/cmd/admin-idp-ldap-enable.go
@@ -32,20 +32,22 @@ var adminIDPLdapEnableCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET [CFG_NAME]
+  {{.HelpName}} TARGET
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Enable the default LDAP IDP configuration (CFG_NAME is omitted).
+  1. Enable the LDAP IDP configuration.
      {{.Prompt}} {{.HelpName}} play/
-  2. Enable LDAP IDP configuration named "dex_test".
-     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
 func mainAdminIDPLDAPEnable(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		showCommandHelpAndExit(ctx, 1)
+	}
+
 	isOpenID, enable := false, true
 	return adminIDPEnableDisable(ctx, isOpenID, enable)
 }

--- a/cmd/admin-idp-ldap-info.go
+++ b/cmd/admin-idp-ldap-info.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"github.com/minio/cli"
+	"github.com/minio/madmin-go/v2"
 )
 
 var adminIDPLdapInfoCmd = cli.Command{
@@ -32,29 +33,22 @@ var adminIDPLdapInfoCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET [CFG_NAME]
+  {{.HelpName}} TARGET
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Get configuration info on the default LDAP IDP configuration (CFG_NAME is omitted).
+  1. Get configuration info on the LDAP IDP configuration.
      {{.Prompt}} {{.HelpName}} play/
-  2. Get configuration info on LDAP IDP configuration named "dex_test".
-     {{.Prompt}} {{.HelpName}} play/ dex_test
 `,
 }
 
 func mainAdminIDPLDAPInfo(ctx *cli.Context) error {
-	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+	if len(ctx.Args()) != 1 {
 		showCommandHelpAndExit(ctx, 1)
 	}
 
-	args := ctx.Args()
-	var cfgName string
-	if len(args) == 2 {
-		cfgName = args.Get(1)
-	}
-
+	var cfgName string = madmin.Default
 	return adminIDPInfo(ctx, false, cfgName)
 }

--- a/cmd/admin-idp-ldap-remove.go
+++ b/cmd/admin-idp-ldap-remove.go
@@ -17,7 +17,10 @@
 
 package cmd
 
-import "github.com/minio/cli"
+import (
+	"github.com/minio/cli"
+	"github.com/minio/madmin-go/v2"
+)
 
 var adminIDPLdapRemoveCmd = cli.Command{
 	Name:         "remove",
@@ -30,27 +33,22 @@ var adminIDPLdapRemoveCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 
 USAGE:
-  {{.HelpName}} TARGET [CFG_NAME]
+  {{.HelpName}} TARGET
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Remove the default LDAP IDP configuration (CFG_NAME is omitted).
+  1. Remove the default LDAP IDP configuration.
      {{.Prompt}} {{.HelpName}} play/
 `,
 }
 
 func mainAdminIDPLDAPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+	if len(ctx.Args()) != 1 {
 		showCommandHelpAndExit(ctx, 1)
 	}
 
-	args := ctx.Args()
-
-	var cfgName string
-	if len(args) == 2 {
-		cfgName = args.Get(1)
-	}
+	var cfgName string = madmin.Default
 	return adminIDPRemove(ctx, false, cfgName)
 }


### PR DESCRIPTION


## Description
LDAP only supports a single configuration on the server, however command line appears to support more - this is fixed in this change.

## Motivation and Context

Fix and improve CLI.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
