### PR TITLE
stat: Fix output when stat a prefix which has other prefixes

### DIFF
--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -34,6 +34,13 @@ func (e APINotImplemented) Error() string {
 	return "`" + e.API + "` is not supported for `" + e.APIType + "`."
 }
 
+// InvalidArgument - passed argument is invalid for this operation
+type InvalidArgument struct{}
+
+func (e InvalidArgument) Error() string {
+	return "invalid argument"
+}
+
 // GenericBucketError - generic bucket operations error
 type GenericBucketError struct {
 	Bucket string

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -2753,9 +2753,12 @@ func (c *S3Client) DeleteEncryption(ctx context.Context) *probe.Error {
 // GetBucketInfo gets info about a bucket
 func (c *S3Client) GetBucketInfo(ctx context.Context) (BucketInfo, *probe.Error) {
 	var b BucketInfo
-	bucket, _ := c.url2BucketAndObject()
+	bucket, object := c.url2BucketAndObject()
 	if bucket == "" {
 		return b, probe.NewError(BucketNameEmpty{})
+	}
+	if object != "" {
+		return b, probe.NewError(InvalidArgument{})
 	}
 	content, err := c.bucketStat(ctx, bucket)
 	if err != nil {


### PR DESCRIPTION
## Description

`mc stat <alias>/<bucket>/<dir>/` can show bucket meta-information 
when `<dir>/` contains a prefix as well.

Bucket stat info is called inside the listing loop code, which is wrong 
and causes bad performance issue which some prefixes are found 
during stat command.


## Motivation and Context
Fix stat output in some cases

## How to test this PR?
mc mb play/testbucket/
mc cp file play/testbucket/dir1/
mc cp file play/testbucket/dir1/dir2/
mc stat play/testbucket/dir1/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
