### PR TITLE
fix: windows stat command

### DIFF
--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -225,7 +225,7 @@ func statURL(ctx context.Context, targetURL, versionID string, timeRef time.Time
 		url := targetAlias + getKey(content)
 		standardizedURL := getStandardizedURL(targetURL)
 
-		if !isRecursive && !strings.HasPrefix(url, standardizedURL) && !filepath.IsAbs(url) {
+		if !isRecursive && !strings.HasPrefix(filepath.FromSlash(url), standardizedURL) && !filepath.IsAbs(url) {
 			return errTargetNotFound(targetURL).Trace(url, standardizedURL)
 		}
 


### PR DESCRIPTION
## Description

Less intrusive fix for #4483

```
λ mc stat play/testbucket
Name      : testbucket
Size      : N/A
Type      : folder

Properties:
  Versioning: Un-versioned
  Location: us-east-1
  Anonymous: Disabled
  ILM: Disabled

Usage:
      Total size: 90 MiB
   Objects count: 8,323
  Versions count: 0

Object sizes histogram:
   2906 object(s) less than 1024 bytes
   5412 object(s) between 1024 bytes and 1 MB
      5 object(s) between 1 MB and 10 MB
      0 object(s) between 10 MB and 64 MB
      0 object(s) between 64 MB and 128 MB
      0 object(s) between 128 MB and 512 MB
      0 object(s) greater than 512 MB

λ mc stat play/testbucket/go.mod
Name      : go.mod
Date      : 2023-03-16 10:58:41 CET
Size      : 4.9 KiB
ETag      : 53b4f05ef284bc3e17ac8fa7e9379386
Type      : file
Metadata  :
  X-Amz-Meta-Custom: Разнообразный
  Content-Type     : application/octet-stream

```

## Types of changes
- [x] Bug fix 

## Checklist:
- [x] Fixes a regression https://github.com/minio/mc/pull/3614
