### PR TITLE
cp: Descriptive error about why unable to locate the source

### DIFF
--- a/cmd/cp-url-syntax.go
+++ b/cmd/cp-url-syntax.go
@@ -70,7 +70,7 @@ func checkCopySyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[stri
 			if versionID != "" {
 				msg += " (" + versionID + ")"
 			}
-			msg += "."
+			msg += ": " + err.ToGoError().Error()
 			console.Fatalln(msg)
 		}
 	}


### PR DESCRIPTION
## Description
mc cp shows 'Unable to validate source' is not descriptive enough. 
Though it means the object does not exist most of the time. There are 
other reasons such as request skewed time, etc..

Add the reason about why mc cp failed.

## Motivation and Context
Better error message when mc cp fails

## How to test this PR?
mc cp play/bucket/inexistent-object .

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
