### PR TITLE
Redact secretKey

### DIFF
--- a/cmd/alias-set.go
+++ b/cmd/alias-set.go
@@ -256,7 +256,7 @@ func BuildS3Config(ctx context.Context, url, accessKey, secretKey, api, path str
 	// Probe S3 signature version
 	api, err := probeS3Signature(ctx, accessKey, secretKey, url, peerCert)
 	if err != nil {
-		return nil, err.Trace(url, accessKey, secretKey, api, path)
+		return nil, err.Trace(url, accessKey, api, path)
 	}
 
 	s3Config.Signature = api


### PR DESCRIPTION
## Description
secretKey should not appear in logs.

## Motivation and Context
Users may copy/paste logs inadvertently sharing privileges access information.

## How to test this PR?
secretKey should not appear when running mc commands with debug e.g. `mc alias set ALIAS URL ACCESSKEY SECRETKEY  --debug`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
