### PR TITLE
Improve errInvalidAlias

### DIFF
--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -56,7 +56,7 @@ var errInvalidAliasedURL = func(URL string) *probe.Error {
 type invalidAliasErr error
 
 var errInvalidAlias = func(alias string) *probe.Error {
-	msg := "Alias `" + alias + "` should have alphanumeric characters such as [helloWorld0, hello_World0, ...]"
+	msg := "Alias `" + alias + "` should have alphanumeric characters such as [helloWorld0, hello_World0, ...] and begin with a letter"
 	return probe.NewError(invalidAliasErr(errors.New(msg)))
 }
 


### PR DESCRIPTION

## Description
Adds text to errInvalidAlias clarifying need for alias name to begin with a letter

## Motivation and Context
Alias names may contain numeric and _ characters, but can only begin with a letter. Current error doesn't specify this.
<img width="889" alt="Screen Shot 2023-03-30 at 10 14 17 AM" src="https://user-images.githubusercontent.com/65002498/228913832-2a85f10f-d7ec-40c1-83e6-aec5dbbf7386.png">


## How to test this PR?
Use `mc alias set` to set an alias beginning with a number or _. Observe updated error.
![Screen Shot 2023-03-30 at 10 16 32 AM](https://user-images.githubusercontent.com/65002498/228914389-8776627c-6975-40cf-a3fd-a2a3b0f8ca29.png)


## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
