### PR TITLE
print RestoreInfo to check status of restored objects

### DIFF
--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -40,19 +40,20 @@ import (
 
 // contentMessage container for content message structure.
 type statMessage struct {
-	Status            string            `json:"status"`
-	Key               string            `json:"name"`
-	Date              time.Time         `json:"lastModified"`
-	Size              int64             `json:"size"`
-	ETag              string            `json:"etag"`
-	Type              string            `json:"type,omitempty"`
-	Expires           *time.Time        `json:"expires,omitempty"`
-	Expiration        *time.Time        `json:"expiration,omitempty"`
-	ExpirationRuleID  string            `json:"expirationRuleID,omitempty"`
-	ReplicationStatus string            `json:"replicationStatus,omitempty"`
-	Metadata          map[string]string `json:"metadata,omitempty"`
-	VersionID         string            `json:"versionID,omitempty"`
-	DeleteMarker      bool              `json:"deleteMarker,omitempty"`
+	Status            string             `json:"status"`
+	Key               string             `json:"name"`
+	Date              time.Time          `json:"lastModified"`
+	Size              int64              `json:"size"`
+	ETag              string             `json:"etag"`
+	Type              string             `json:"type,omitempty"`
+	Expires           *time.Time         `json:"expires,omitempty"`
+	Expiration        *time.Time         `json:"expiration,omitempty"`
+	ExpirationRuleID  string             `json:"expirationRuleID,omitempty"`
+	ReplicationStatus string             `json:"replicationStatus,omitempty"`
+	Metadata          map[string]string  `json:"metadata,omitempty"`
+	VersionID         string             `json:"versionID,omitempty"`
+	DeleteMarker      bool               `json:"deleteMarker,omitempty"`
+	Restore           *minio.RestoreInfo `json:"restore,omitempty"`
 }
 
 func (stat statMessage) String() (msg string) {
@@ -84,6 +85,13 @@ func (stat statMessage) String() (msg string) {
 	if stat.Expiration != nil {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s (lifecycle-rule-id: %s) ", "Expiration",
 			stat.Expiration.Local().Format(printDate), stat.ExpirationRuleID) + "\n")
+	}
+	if stat.Restore != nil {
+		msgBuilder.WriteString(fmt.Sprintf("%-10s:", "Restore") + "\n")
+		msgBuilder.WriteString(fmt.Sprintf("  %-10s: %s", "ExpiryTime",
+			stat.Restore.ExpiryTime.Local().Format(printDate)) + "\n")
+		msgBuilder.WriteString(fmt.Sprintf("  %-10s: %t", "Ongoing",
+			stat.Restore.OngoingRestore) + "\n")
 	}
 	maxKeyMetadata := 0
 	maxKeyEncrypted := 0
@@ -160,6 +168,7 @@ func parseStat(c *ClientContent) statMessage {
 	}
 	content.ExpirationRuleID = c.ExpirationRuleID
 	content.ReplicationStatus = c.ReplicationStatus
+	content.Restore = c.Restore
 	return content
 }
 


### PR DESCRIPTION
## Description
Print Restore status in ./mc stat

## Motivation and Context
After creating tier objects are moved to remote node. After that it is possible to restore them locally for a few days.
For now there is no way to check if the object is still from local or remote node.

## How to test this PR?
1. Two instance of minio: hot, cold (localhost:9002)
2. ./mc mb -l cold/tiered
3. ./mc mb -l hot/bucket
4. ./mc admin tier add minio hot TIER1 --endpoint http://localhost:9002 --access-key test --secret-key testtest --bucket tiered --prefix prefix5/
5. ./mc ilm add hot/bucket --transition-days 0 --transition-tier TIER1
6. ./mc cp README.md hot/bucket
7. ./mc stat hot/bucket/README.md
8. ./mc ilm restore hot/bucket/README.md
9. ./mc stat hot/bucket/README.md

The last command should return something like:
```
Restore   :
  ExpiryTime: 2023-04-05 02:00:00 CEST
  Ongoing   : false
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
