### PR TITLE
Upgrade madmin-go to 2.0.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.4
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v2 v2.0.17-0.20230318001302-4f013bfc73a4
+	github.com/minio/madmin-go/v2 v2.0.18
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.49
 	github.com/minio/pkg v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -515,10 +515,8 @@ github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbL
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go/v2 v2.0.15 h1:da/wvVryJXDpkE/gck+tsHfmd9XInaWvJmDKp/sBwuk=
-github.com/minio/madmin-go/v2 v2.0.15/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
-github.com/minio/madmin-go/v2 v2.0.17-0.20230318001302-4f013bfc73a4 h1:p9HPxBaX4u/VjpsqY04i9S8K4rmcskOyqK3vcxh11I8=
-github.com/minio/madmin-go/v2 v2.0.17-0.20230318001302-4f013bfc73a4/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
+github.com/minio/madmin-go/v2 v2.0.18 h1:5kME44CIL7RlNm99hg6EU0K5AiIX0RtVHFu0nMEWmNE=
+github.com/minio/madmin-go/v2 v2.0.18/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.41/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=


### PR DESCRIPTION
## Description

Upgrade madmin-go to 2.0.18

## Motivation and Context

Capture full cpu frequency stats in health info

## How to test this PR?

- Build minio with https://github.com/minio/minio/pull/16961
- Start minio server and set alias for it
- Generate health report using `mc support diag {alias} --airgap`
- Extract the generated report and verify that it contains a new node `sys -> cpus -> freq_stats` containing list of frequency stats for all the cpu cores.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
