### PR TITLE
stat: fix printing bucket usage info

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -2848,6 +2848,7 @@ func (c *S3Client) GetBucketInfo(ctx context.Context) (BucketInfo, *probe.Error)
 	if err != nil {
 		return b, err.Trace(bucket)
 	}
+	b.Key = bucket
 	b.URL = content.URL
 	b.Size = content.Size
 	b.Type = content.Type


### PR DESCRIPTION
## Description
A recent regression was introduced after refactoring some 
code related to mc stat command but the usage is not correctly 
showing anymore. The reason is that the new code relies on bucket 
info key field to get the bucket stats from the data usage. This commit 
fixes the behavior by populating Key field in bucket info structure.

## Motivation and Context
Fix 'mc stat <alias>/<bucket>' output

## How to test this PR?
- Create a bucket and populate it with objects
- mc stat <alias>/<bucket>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
