### PR TITLE
heal: Calculate ETA based on used inodes

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -327,7 +327,7 @@ func estimateHealDiskETA(now time.Time, healDisk madmin.Disk, set setInfo) (rema
 	// calculation if ETA is furtherst or pct is lower
 	healSpeed = float64(healDisk.UsedInodes) / float64(now.Sub(healDisk.HealInfo.Started))
 	if t := time.Duration(float64(set.maxUsedInodes-healDisk.UsedInodes) / healSpeed); t > remainingTime {
-		remainingTime = t
+		remainingTime = (t + remainingTime) / 2
 	}
 	if p := float64(healDisk.UsedInodes) / float64(set.maxUsedInodes); p < pct {
 		pct = p


### PR DESCRIPTION
## Description

The used space ETA can be wrong if a cluster has a mix of 
large objects and small objects.

Add healing finish estimation based on the number of consumed 
inodes in the healing disk compared to other disks in the 
same erasure set.

## Motivation and Context
Better ETA when a cluster has a mix of large and tiny files

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
