### PR TITLE
Ensure perf results file has an extension

### DIFF
--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -483,8 +483,8 @@ func writeJSONObjToZip(zipWriter *zip.Writer, obj interface{}, filename string) 
 
 // compress MinIO performance output
 func zipPerfResult(perfOutput PerfTestOutput, resultFilename string, regInfo ClusterRegistrationInfo) (string, error) {
-	// Create profile zip file
-	tmpArchive, e := os.CreateTemp("", "mc-perf-")
+	// Create perf results zip file
+	tmpArchive, e := os.CreateTemp("", "mc-perf-*.zip")
 
 	if e != nil {
 		return "", e


### PR DESCRIPTION
## Description

The perf results file is created as a temporary file which is then uploaded to SUBNET. This file doesn't have any extension by default, because of which it can't be extracted after downloading from SUBNET.

Enure that it has the `.zip` extension when creating the temp file to avoid this issue.

## Motivation and Context

Improved download experience on SUBNET

## How to test this PR?

- Register a cluster with SUBNET
- Run `mc support perf {alias}`
- Visit the `Performance` tab on deployment page for the cluster in SUBNET
- Click on the `Download` button and verify that the file being downloaded has a `.zip` extension

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
