### PR TITLE
allow aliases to be `/` at the end and handle such cases

### DIFF
--- a/cmd/admin-cluster-bucket-export.go
+++ b/cmd/admin-cluster-bucket-export.go
@@ -87,11 +87,11 @@ func mainClusterBucketExport(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(aliasedURL), "Unable to export bucket metadata.")
 
 	if bucket == "" {
-		bucket = "cluster"
+		bucket = "bucket"
 	}
 
 	// Create bucket metadata zip file
-	tmpFile, e := os.CreateTemp("", fmt.Sprintf("%s-metadata-", bucket))
+	tmpFile, e := os.CreateTemp("", fmt.Sprintf("%s-%s-metadata-", aliasedURL, bucket))
 	fatalIf(probe.NewError(e), "Unable to download file data.")
 
 	ext := "zip"
@@ -104,7 +104,7 @@ func mainClusterBucketExport(ctx *cli.Context) error {
 	tmpFile.Close()
 
 	// We use 4 bytes of the 32 bytes to identify the file.
-	downloadPath := fmt.Sprintf("%s-metadata.%s", bucket, ext)
+	downloadPath := fmt.Sprintf("%s-%s-metadata.%s", aliasedURL, bucket, ext)
 	fi, e := os.Stat(downloadPath)
 	if e == nil && !fi.IsDir() {
 		e = moveFile(downloadPath, downloadPath+"."+time.Now().Format(dateTimeFormatFilename))

--- a/cmd/admin-cluster-bucket-import.go
+++ b/cmd/admin-cluster-bucket-import.go
@@ -54,7 +54,7 @@ FLAGS:
   {{end}}
 EXAMPLES:
   1. Recover bucket metadata for all buckets from previously saved bucket metadata backup.
-     {{.Prompt}} {{.HelpName}} myminio /backups/cluster-metadata.zip
+     {{.Prompt}} {{.HelpName}} myminio /backups/myminio-bucket-metadata.zip
 `,
 }
 

--- a/cmd/admin-cluster-iam-export.go
+++ b/cmd/admin-cluster-iam-export.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/fatih/color"
@@ -67,7 +68,9 @@ func mainClusterIAMExport(ctx *cli.Context) error {
 
 	// Get the alias parameter from cli
 	args := ctx.Args()
-	aliasedURL := args.Get(0)
+	aliasedURL := filepath.ToSlash(args.Get(0))
+	aliasedURL = filepath.Clean(aliasedURL)
+
 	console.SetColor("File", color.New(color.FgWhite, color.Bold))
 
 	// Create a new MinIO Admin Client

--- a/cmd/admin-cluster-iam-import.go
+++ b/cmd/admin-cluster-iam-import.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/klauspost/compress/zip"
 	"github.com/minio/cli"
@@ -66,7 +67,9 @@ func mainClusterIAMImport(ctx *cli.Context) error {
 
 	// Get the alias parameter from cli
 	args := ctx.Args()
-	aliasedURL := args.Get(0)
+	aliasedURL := filepath.ToSlash(args.Get(0))
+	aliasedURL = filepath.Clean(aliasedURL)
+
 	var r io.Reader
 	var sz int64
 	f, e := os.Open(args.Get(1))


### PR DESCRIPTION

## Description
allow aliases to be `/` at the end and handle such cases

## Motivation and Context
import/export should honor aliases with `/` at the end, provide this flexibility.

## How to test this PR?
`mc admin cluster iam export alias/`  fails with `/` at the end.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
