### PR TITLE
Load Subnet proxy and API key from the env if found

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -66,8 +66,9 @@ mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 			Usage: "use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
 		},
 		cli.StringFlag{
-			Name:  "api-key",
-			Usage: "API Key of the account on SUBNET",
+			Name:   "api-key",
+			Usage:  "API Key of the account on SUBNET",
+			EnvVar: "_MC_SUBNET_API_KEY",
 		},
 	}
 )
@@ -215,7 +216,7 @@ func subnetReqDo(r *http.Request, headers map[string]string) (string, error) {
 	if resp.StatusCode == http.StatusOK {
 		return respStr, nil
 	}
-	return respStr, fmt.Errorf("Request failed with code %d and error: %s", resp.StatusCode, respStr)
+	return respStr, fmt.Errorf("Request failed with code %d with error: %s", resp.StatusCode, respStr)
 }
 
 func subnetGetReq(reqURL string, headers map[string]string) (string, error) {
@@ -293,8 +294,19 @@ func setGlobalSubnetProxyFromConfig(alias string) error {
 		return nil
 	}
 
+	var (
+		proxy     string
+		supported bool
+	)
+
+	if env, ok := os.LookupEnv("_MC_SUBNET_PROXY_URL"); ok {
+		proxy = env
+		supported = env != ""
+	} else {
+		proxy, supported = getKeyFromSubnetConfig(alias, "proxy")
+	}
+
 	// get the subnet proxy config from MinIO if available
-	proxy, supported := getKeyFromSubnetConfig(alias, "proxy")
 	if supported && len(proxy) > 0 {
 		proxyURL, e := url.Parse(proxy)
 		if e != nil {

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -208,8 +208,8 @@ func execSupportProfile(ctx *cli.Context, client *madmin.AdminClient, alias stri
 	if !globalAirgapped {
 		_, e := uploadFileToSubnet(alias, profileFile, reqURL, headers)
 		if e != nil {
-			failureClr.Println("\nUnable to upload profile file to SUBNET.", e.Error())
-			successClr.Printf("It has been saved locally at '%s'\n", profileFile)
+			failureClr.Println("\nUnable to upload profile file to SUBNET:", e.Error())
+			successClr.Printf("Profiling data are saved locally at '%s'\n", profileFile)
 			return
 		}
 		successClr.Println("uploaded successfully to SUBNET.")


### PR DESCRIPTION
## Description

Avoid sending calls to MinIO cluser to fetch for Subnet proxy
 and API key if specified in the environment


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
