### PR TITLE
 mirror: Fix removal of FS target without a trailing slash

### DIFF
--- a/cmd/client-errors.go
+++ b/cmd/client-errors.go
@@ -115,39 +115,46 @@ type GenericFileError struct {
 	Path string
 }
 
+// PathNotADirectory - this path does not correspond to a directory
+type PathNotADirectory GenericFileError
+
+func (e PathNotADirectory) Error() string {
+	return "Requested path `" + e.Path + "` not a directory"
+}
+
 // PathNotFound (ENOENT) - file not found.
 type PathNotFound GenericFileError
 
 func (e PathNotFound) Error() string {
-	return "Requested file `" + e.Path + "` not found"
+	return "Requested path `" + e.Path + "` not found"
 }
 
 // PathIsNotRegular (ENOTREG) - file is not a regular file.
 type PathIsNotRegular GenericFileError
 
 func (e PathIsNotRegular) Error() string {
-	return "Requested file `" + e.Path + "` is not a regular file."
+	return "Requested path `" + e.Path + "` is not a regular file."
 }
 
 // PathInsufficientPermission (EPERM) - permission denied.
 type PathInsufficientPermission GenericFileError
 
 func (e PathInsufficientPermission) Error() string {
-	return "Insufficient permissions to access this file `" + e.Path + "`"
+	return "Insufficient permissions to access this path `" + e.Path + "`"
 }
 
 // BrokenSymlink (ENOTENT) - file has broken symlink.
 type BrokenSymlink GenericFileError
 
 func (e BrokenSymlink) Error() string {
-	return "Requested file `" + e.Path + "` has broken symlink"
+	return "Requested path `" + e.Path + "` has broken symlink"
 }
 
 // TooManyLevelsSymlink (ELOOP) - file has too many levels of symlinks.
 type TooManyLevelsSymlink GenericFileError
 
 func (e TooManyLevelsSymlink) Error() string {
-	return "Requested file `" + e.Path + "` has too many levels of symlinks"
+	return "Requested path `" + e.Path + "` has too many levels of symlinks"
 }
 
 // EmptyPath (EINVAL) - invalid argument.

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -661,6 +661,65 @@ func (f *fsClient) Remove(_ context.Context, isIncomplete, _, _, _ bool, content
 	return resultCh
 }
 
+// ListBuckets returns the list of directories inside a base path
+func (f *fsClient) ListBuckets(_ context.Context) ([]*ClientContent, *probe.Error) {
+	// save pathURL and file path for further usage.
+	pathURL := *f.PathURL
+	path := pathURL.Path
+
+	st, e := os.Stat(path)
+	if e != nil {
+		if os.IsNotExist(e) {
+			return nil, probe.NewError(PathNotFound{Path: path})
+		}
+		return nil, probe.NewError(e)
+	}
+
+	if !st.Mode().IsDir() {
+		return nil, probe.NewError(PathNotADirectory{Path: path})
+	}
+
+	// List directories (buckets) inside path in a sorted way
+	files, e := readDir(path)
+	if e != nil {
+		return nil, probe.NewError(e)
+	}
+
+	bucketsList := make([]*ClientContent, 0, len(files))
+
+	for _, file := range files {
+		fi := file
+		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+			fp := filepath.Join(path, fi.Name())
+			fi, e = os.Stat(fp)
+			if e != nil {
+				// Ignore all errors on symlinks
+				continue
+			}
+		}
+
+		if isIgnoredFile(fi.Name()) {
+			continue
+		}
+
+		if !fi.Mode().IsDir() {
+			continue
+		}
+
+		pathURL = *f.PathURL
+		pathURL.Path = filepath.Join(pathURL.Path, fi.Name())
+
+		bucketsList = append(bucketsList, &ClientContent{
+			URL:  pathURL,
+			Time: fi.ModTime(),
+			Type: fi.Mode(),
+			Err:  nil,
+		})
+	}
+
+	return bucketsList, nil
+}
+
 // List - list files and folders.
 func (f *fsClient) List(_ context.Context, opts ListOptions) <-chan *ClientContent {
 	contentCh := make(chan *ClientContent, 1)

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1812,6 +1812,19 @@ func (c *S3Client) listVersionsRoutine(ctx context.Context, b, o string, opts Li
 	}
 }
 
+// ListBuckets - list buckets
+func (c *S3Client) ListBuckets(ctx context.Context) ([]*ClientContent, *probe.Error) {
+	buckets, err := c.api.ListBuckets(ctx)
+	if err != nil {
+		return nil, probe.NewError(err)
+	}
+	bucketsList := make([]*ClientContent, 0, len(buckets))
+	for _, b := range buckets {
+		bucketsList = append(bucketsList, c.bucketInfo2ClientContent(b))
+	}
+	return bucketsList, nil
+}
+
 // List - list at delimited path, if not recursive.
 func (c *S3Client) List(ctx context.Context, opts ListOptions) <-chan *ClientContent {
 	c.Lock()

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -106,6 +106,7 @@ type Client interface {
 	// Bucket operations
 	MakeBucket(ctx context.Context, region string, ignoreExisting, withLock bool) *probe.Error
 	RemoveBucket(ctx context.Context, forceRemove bool) *probe.Error
+	ListBuckets(ctx context.Context) ([]*ClientContent, *probe.Error)
 
 	// Object lock config
 	SetObjectLockConfig(ctx context.Context, mode minio.RetentionMode, validity uint64, unit minio.ValidityUnit) *probe.Error

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -917,7 +917,7 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 
 	if mirrorSrcBuckets || createDstBuckets {
 		// Synchronize buckets using dirDifference function
-		for d := range dirDifference(ctx, srcClt, dstClt) {
+		for d := range bucketDifference(ctx, srcClt, dstClt) {
 			if d.Error != nil {
 				if mj.opts.activeActive {
 					errorIf(d.Error, "Failed to start mirroring.. retrying")


### PR DESCRIPTION
[BREAKING CHANGE]:

mc mirror with inexisting target FS dir will error out

## Description
mc mirror --remove s3-alias/ /path/to/dir will cause removal 
of /path/to/dir when this latter does not have a trailing slash

## Motivation and Context
Fix bug in removing a local FS directory without a slash in the name

## How to test this PR?
mc mirror alias fs-path

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
