### PR TITLE
mirror: Honor --fake for target bucket removal

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -928,7 +928,7 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 
 			if d.Diff == differInSecond {
 				diffBucket := strings.TrimPrefix(d.SecondURL, dstClt.GetURL().String())
-				if isRemove {
+				if !isFake && isRemove {
 					aliasedDstBucket := path.Join(dstURL, diffBucket)
 					err := deleteBucket(ctx, aliasedDstBucket, false)
 					mj.status.fatalIf(err, "Failed to start mirroring.")


### PR DESCRIPTION
## Description
When site wide mirroring is activated, it is possible that --remove 
would remove a bucket in the target location due to a forgotten 
--fake check. This commit fixes the behavior.

## Motivation and Context
Honor --fake to avoid buckets removal in target in site wide mirror

## How to test this PR?
mkdir /tmp/backup && ./mc mirror -a --overwrite --fake --remove myminio/ /tmp/backup 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
