### PR TITLE
Remove tags for object versions

### DIFF
--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -48,7 +48,7 @@ var tagListFlags = []cli.Flag{
 	},
 	cli.BoolFlag{
 		Name:  "recursive, r",
-		Usage: "recursivley show tags for all objects of subdirs",
+		Usage: "recursivley show tags for all objects",
 	},
 }
 

--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -46,6 +46,10 @@ var tagListFlags = []cli.Flag{
 		Name:  "versions",
 		Usage: "list tags on all versions for an object",
 	},
+	cli.BoolFlag{
+		Name:  "recursive, r",
+		Usage: "recursivley show tags for all objects of subdirs",
+	},
 }
 
 var tagListCmd = cli.Command{
@@ -85,6 +89,12 @@ EXAMPLES:
 
   6. List the tags assigned to a bucket in JSON format.
      {{.Prompt}} {{.HelpName}} --json s3/testbucket
+
+  7. List the tags recursively for all the objects of subdirs of bucket.
+     {{.Prompt}} {{.HelpName}} --recursive myminio/testbucket
+
+  8. Show the tags recursively for all versions of all objects of subdirs of bucket.
+     {{.Prompt}} {{.HelpName}} --recursive --versions myminio/testbucket
 `,
 }
 
@@ -114,8 +124,12 @@ func (t tagListMessage) String() string {
 	sort.Strings(keys)
 
 	maxKeyLen += 2 // add len(" :")
+	strName := t.URL
+	if strings.TrimSpace(t.VersionID) != "" {
+		strName += " (" + t.VersionID + ")"
+	}
 	strs := []string{
-		fmt.Sprintf("%v%*v %v", console.Colorize("Name", "Name"), maxKeyLen-4, ":", console.Colorize("Name", t.URL+" ("+t.VersionID+")")),
+		fmt.Sprintf("%v%*v %v", console.Colorize("Name", "Name"), maxKeyLen-4, ":", console.Colorize("Name", strName)),
 	}
 
 	for _, key := range keys {
@@ -133,7 +147,7 @@ func (t tagListMessage) String() string {
 }
 
 // parseTagListSyntax performs command-line input validation for tag list command.
-func parseTagListSyntax(ctx *cli.Context) (targetURL, versionID string, timeRef time.Time, withOlderVersions bool) {
+func parseTagListSyntax(ctx *cli.Context) (targetURL, versionID string, timeRef time.Time, withOlderVersions bool, recursive bool) {
 	if len(ctx.Args()) != 1 {
 		showCommandHelpAndExit(ctx, globalErrorExitStatus)
 	}
@@ -142,6 +156,7 @@ func parseTagListSyntax(ctx *cli.Context) (targetURL, versionID string, timeRef 
 	versionID = ctx.String("version-id")
 	withOlderVersions = ctx.Bool("versions")
 	rewind := ctx.String("rewind")
+	recursive = ctx.Bool("recursive")
 
 	if versionID != "" && rewind != "" {
 		fatalIf(errDummy().Trace(), "You cannot specify both --version-id and --rewind flags at the same time")
@@ -175,6 +190,16 @@ func showTags(ctx context.Context, clnt Client, versionID string) {
 	})
 }
 
+func showTagsSingle(ctx context.Context, alias, url, versionID string) *probe.Error {
+	newClnt, err := newClientFromAlias(alias, url)
+	if err != nil {
+		return err
+	}
+
+	showTags(ctx, newClnt, versionID)
+	return nil
+}
+
 func mainListTag(cliCtx *cli.Context) error {
 	ctx, cancelListTag := context.WithCancel(globalContext)
 	defer cancelListTag()
@@ -184,7 +209,7 @@ func mainListTag(cliCtx *cli.Context) error {
 	console.SetColor("Value", color.New(color.FgYellow))
 	console.SetColor("NoTags", color.New(color.FgRed))
 
-	targetURL, versionID, timeRef, withVersions := parseTagListSyntax(cliCtx)
+	targetURL, versionID, timeRef, withVersions, recursive := parseTagListSyntax(cliCtx)
 	if timeRef.IsZero() && withVersions {
 		timeRef = time.Now().UTC()
 	}
@@ -192,18 +217,32 @@ func mainListTag(cliCtx *cli.Context) error {
 	clnt, err := newClient(targetURL)
 	fatalIf(err, "Unable to initialize target "+targetURL)
 
-	if timeRef.IsZero() && !withVersions {
-		showTags(ctx, clnt, versionID)
-	} else {
-		for content := range clnt.List(ctx, ListOptions{TimeRef: timeRef, WithOlderVersions: withVersions}) {
-			if content.Err != nil {
-				fatalIf(content.Err.Trace(), "Unable to list target "+targetURL)
-			}
-			// If a dir found, dot do anything
-			if content.Type.IsDir() {
-				continue
-			}
-			showTags(ctx, clnt, content.VersionID)
+	alias, urlStr, _ := mustExpandAlias(targetURL)
+	if timeRef.IsZero() && !withVersions && !recursive {
+		err := showTagsSingle(ctx, alias, urlStr, versionID)
+		fatalIf(err.Trace(), "Unable to show tags on `%s`", targetURL)
+		return nil
+	}
+
+	for content := range clnt.List(ctx, ListOptions{TimeRef: timeRef, WithOlderVersions: withVersions, Recursive: recursive}) {
+		if content.Err != nil {
+			fatalIf(content.Err.Trace(), "Unable to list target "+targetURL)
+			continue
+		}
+
+		// Skip if its delete marker
+		if content.IsDeleteMarker {
+			continue
+		}
+
+		if !recursive && alias+getKey(content) != getStandardizedURL(targetURL) {
+			break
+		}
+
+		err := showTagsSingle(ctx, alias, content.URL.String(), content.VersionID)
+		if err != nil {
+			errorIf(err.Trace(clnt.GetURL().String()), "Invalid URL")
+			continue
 		}
 	}
 

--- a/cmd/tag-list.go
+++ b/cmd/tag-list.go
@@ -199,6 +199,10 @@ func mainListTag(cliCtx *cli.Context) error {
 			if content.Err != nil {
 				fatalIf(content.Err.Trace(), "Unable to list target "+targetURL)
 			}
+			// If a dir found, dot do anything
+			if content.Type.IsDir() {
+				continue
+			}
 			showTags(ctx, clnt, content.VersionID)
 		}
 	}


### PR DESCRIPTION
## Description
Earlier there was an issue where with `--versions` option where the tags were removed for the bucket level again and again, no of subdirs times under the bucket. This PR fixes the issue and also introduces `--recursive` option for removing the tags for objects/versions of subdirs recursively (if need be).

## Motivation and Context


## How to test this PR?
Follow the below steps for verifying the changes
Step-1: Create a bucket with subdirs and enable versioning
Step-2: Load multiple versions of object to the subdirs of the bucket
Step-3: Set tags for different versions of the bucket objects
Step-3: Use `mc tag remove ALIAS/BUCKET --recursive --versions` and it should remove tags for all objects and all their versions in all subdirs
Step-4: Use command `mc tag remove ALIAS/BUCKET --recursive` and it should remove tags for all objects and only its top version in all subdirs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
