### PR TITLE
Support setting subnet url via env var in dev mode

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -81,6 +81,10 @@ func subnetOfflinePublicKey() string {
 
 func subnetBaseURL() string {
 	if globalDevMode {
+		subnetURLDev := os.Getenv("SUBNET_URL_DEV")
+		if len(subnetURLDev) > 0 {
+			return subnetURLDev
+		}
 		return "http://localhost:9000"
 	}
 


### PR DESCRIPTION
## Description

By default, the `mc support` commands expect subnet to be running on localhost (http://localhost:9000) in dev mode.

Enhance this behavior to allow setting the subnet URL via the environment variable SUBNET_URL_DEV (only in dev mode)

## Motivation and Context

Ability to test with a non-local instance of SUBNET during development.

## How to test this PR?

- export the env variable `SUBNET_URL_DEV` pointing to a remote instance of SUBNET
- perform registration using `mc license register` in dev mode
- test support commands e.g. `mc support diag` in dev mode
- verify that the registration/uploads are getting reflected in the remote instance of SUBNET

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
