### PR TITLE
Added option `--exclude-folders`

### DIFF
--- a/cmd/tag-set.go
+++ b/cmd/tag-set.go
@@ -89,7 +89,7 @@ EXAMPLES:
   6. Assign tags recursively to all versions of all objects of subdirs of bucket.
      {{.Prompt}} {{.HelpName}} myminio/testbucket --recursive --versions "key1=value1&key2=value2&key3=value3"
 
-  7. Assign tags to all the objects of bucket, exclusing subdirs
+  7. Assign tags to all the objects on a bucket, excluding folders
      {{.Prompt}} {{.HelpName}} myminio/testbucket --exclude-folders --recursive "key1=value1&key2=value2&key3=value3"
 `,
 }
@@ -137,7 +137,7 @@ func parseSetTagSyntax(ctx *cli.Context) (targetURL, versionID string, timeRef t
 	}
 
 	if excludeFolders && !recursive {
-		fatalIf(errDummy().Trace(), "Flag --exclude-folders can be used with --recursive only")
+		fatalIf(errDummy().Trace(), "'--exclude-folders' must be used with --recursive only")
 	}
 
 	timeRef = parseRewindFlag(rewind)


### PR DESCRIPTION
## Description
This flag works in conjunction with `--recursive` and sets tags for all the bucket objects minus the subdirs.

## Motivation and Context
User should be able to set tags for all the objects of the bucket excluding the subdirs, at once.

## How to test this PR?
- Create a bucket which contains few object and subdirs (with objects under them) as well.
- `mc tag set ALIAS/BUCKET "key=val" --exclude-folders --recursive`

The tags should be set for top level bucket objects only and not the subdir objects.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
