### PR TITLE
Add name and description for service accounts

### DIFF
--- a/cmd/admin-user-svcacct-info.go
+++ b/cmd/admin-user-svcacct-info.go
@@ -98,7 +98,8 @@ func mainAdminUserSvcAcctInfo(ctx *cli.Context) error {
 	printMsg(acctMessage{
 		op:            svcAccOpInfo,
 		AccessKey:     svcAccount,
-		Comment:       svcInfo.Comment,
+		Name:          svcInfo.Name,
+		Description:   svcInfo.Description,
 		AccountStatus: svcInfo.AccountStatus,
 		ParentUser:    svcInfo.ParentUser,
 		ImpliedPolicy: svcInfo.ImpliedPolicy,

--- a/cmd/admin-user-svcacct-set.go
+++ b/cmd/admin-user-svcacct-set.go
@@ -35,8 +35,12 @@ var adminUserSvcAcctSetFlags = []cli.Flag{
 		Usage: "path to a JSON policy file",
 	},
 	cli.StringFlag{
-		Name:  "comment",
-		Usage: "personal note for the service account",
+		Name:  "name",
+		Usage: "name for the service account",
+	},
+	cli.StringFlag{
+		Name:  "description",
+		Usage: "description for the service account",
 	},
 }
 
@@ -81,7 +85,8 @@ func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 
 	secretKey := ctx.String("secret-key")
 	policyPath := ctx.String("policy")
-	comment := ctx.String("comment")
+	name := ctx.String("name")
+	description := ctx.String("description")
 
 	// Create a new MinIO Admin Client
 	client, err := newAdminClient(aliasedURL)
@@ -95,9 +100,10 @@ func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 	}
 
 	opts := madmin.UpdateServiceAccountReq{
-		NewPolicy:    buf,
-		NewSecretKey: secretKey,
-		NewComment:   comment,
+		NewPolicy:      buf,
+		NewSecretKey:   secretKey,
+		NewName:        name,
+		NewDescription: description,
 	}
 
 	e := client.UpdateServiceAccount(globalContext, svcAccount, opts)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.4
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v2 v2.1.1
+	github.com/minio/madmin-go/v2 v2.1.3
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.52
 	github.com/minio/pkg v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/minio/colorjson v1.0.4/go.mod h1:ZgE8vYon4xC4yfBPclP/2gqMRYw+p+xRsBbL
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
 github.com/minio/madmin-go v1.6.6/go.mod h1:ATvkBOLiP3av4D++2v1UEHC/QzsGtgXD5kYvvRYzdKs=
-github.com/minio/madmin-go/v2 v2.1.1 h1:qUdJP31MD3ThPOmvfRby0J5ZJdAw5XK67LxTkUI9DWA=
-github.com/minio/madmin-go/v2 v2.1.1/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
+github.com/minio/madmin-go/v2 v2.1.3 h1:9pkUgAujfm/SaFei4a1LwpS2et1/qGvRjFqFbRWa6xA=
+github.com/minio/madmin-go/v2 v2.1.3/go.mod h1:8bL1RMNkblIENFSgGYjeHrzUx9PxROb7OqfNuMU9ivE=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.41/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=


### PR DESCRIPTION

## Description

- Adds "--name" and "--description" options to add/edit service account subcommands.

- Removes "--comment" option for a service account as the term may be confusing.


## Motivation and Context

See https://github.com/minio/minio/pull/17172

## How to test this PR?

Try out the new options.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
