### PR TITLE
bug: panic on nil pointer dereference for "mc admin heal" when disk i…

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -380,7 +380,7 @@ func (s verboseBackgroundHealStatusMessage) String() string {
 					stateText = console.Colorize("DiskFailed", d.State)
 				}
 				fmt.Fprintf(&msg, "  +  %s : %s\n", d.DrivePath, stateText)
-				if d.Healing {
+				if d.Healing && d.HealInfo != nil {
 					now := time.Now().UTC()
 					scanSpeed := float64(d.UsedSpace) / float64(now.Sub(d.HealInfo.Started))
 					remainingTime := time.Duration(float64(setsStatus[setIndex{d.PoolIndex, d.SetIndex}].maxUsedSpace-d.UsedSpace) / scanSpeed)


### PR DESCRIPTION
## Description

When a disk is "unformatted", it seems the .HealInfo struct is not set, but .Healing is true. This state causes a panic when the program try to dereference .HealInfo pointer.

the patch check this case, and avoid display of "Estimated" time.

note: maybe 

the backtrace:

```
   panic: runtime error: invalid memory address or nil pointer dereference
   [signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0xebb61f]

   goroutine 1 [running]:
   github.com/minio/mc/cmd.verboseBackgroundHealStatusMessage.String({{0x1292f87, 0x7}, {{0x0, 0x0, 0x0}, 0x12, {0x0, 0x0, 0x0}, {0xc0004e6000, ...}, ...}, ...})
      /home/thierry/git/mc/cmd/admin-heal.go:385 +0x12df
   github.com/minio/mc/cmd.printMsg({0x14925b0?, 0xc0000ccc80?})
      /home/thierry/git/mc/cmd/print.go:38 +0x11c
   github.com/minio/mc/cmd.mainAdminHeal(0xc000103ba0)
      /home/thierry/git/mc/cmd/admin-heal.go:641 +0x6c6
   github.com/minio/cli.HandleAction({0x10cf280?, 0x1342598?}, 0x4?)
      /home/thierry/go/pkg/mod/github.com/minio/cli@v1.24.2/app.go:490 +0x5a
   github.com/minio/cli.Command.Run({{0x128d6f4, 0x4}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x12d092e, 0x2c}, {0x0, ...}, ...}, ...)
      /home/thierry/go/pkg/mod/github.com/minio/cli@v1.24.2/command.go:242 +0x997
   github.com/minio/cli.(*App).RunAsSubcommand(0xc0004bb880, 0xc000103860)
      /home/thierry/go/pkg/mod/github.com/minio/cli@v1.24.2/app.go:380 +0xd27
   github.com/minio/cli.Command.startApp({{0x128e817, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x12a517a, 0x14}, {0x0, ...}, ...}, ...)
      /home/thierry/go/pkg/mod/github.com/minio/cli@v1.24.2/command.go:346 +0xb7f
   github.com/minio/cli.Command.Run({{0x128e817, 0x5}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x12a517a, 0x14}, {0x0, ...}, ...}, ...)
      /home/thierry/go/pkg/mod/github.com/minio/cli@v1.24.2/command.go:117 +0x418
   github.com/minio/cli.(*App).Run(0xc0004ba700, {0xc0000400a0, 0x5, 0x5})
      /home/thierry/go/pkg/mod/github.com/minio/cli@v1.24.2/app.go:260 +0xb07
   github.com/minio/mc/cmd.Main({0xc0000400a0?, 0x5, 0x5})
      /home/thierry/git/mc/cmd/main.go:141 +0x3ec
   main.main()
      /home/thierry/git/mc/main.go:28 +0x32
```

## Motivation and Context

bug fix

## How to test this PR?

- create a minio node with 2 server and 2 disk
- erase one disk
- run "mc admin heal <ref> --verbose" as loop until the "unformatted" state appear.
- a panic appear without the patch

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
