### PR TITLE
Deprecate older idp commands

### DIFF
--- a/cmd/admin-idp-info.go
+++ b/cmd/admin-idp-info.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go/v2"
 )
 
 var adminIDPInfoCmd = cli.Command{
@@ -30,44 +29,13 @@ var adminIDPInfoCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Hidden:       true,
 	Flags:        globalFlags,
-	CustomHelpTemplate: `NAME:
-  {{.HelpName}} - {{.Usage}}
+	CustomHelpTemplate: `This command is DEPRECATED.
 
-USAGE:
-  {{.HelpName}} TARGET ID_TYPE [CFG_NAME]
-
-  ID_TYPE must be one of 'ldap' or 'openid'.
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
-
-FLAGS:
-   {{range .VisibleFlags}}{{.}}
-  {{end}}
-EXAMPLES:
-  1. Show configuration info for default (un-named) openid configuration.
-     {{.Prompt}} {{.HelpName}} play/ openid
-  2. Show configuration info for openid configuration named "dex_test".
-     {{.Prompt}} {{.HelpName}} play/ openid dex_test
-  3. Show configuration info for ldap.
-     {{.Prompt}} {{.HelpName}} play/ ldap
+Please use "mc admin idp ldap|openid" instead.
 `,
 }
 
-func mainAdminIDPGet(ctx *cli.Context) error {
-	if len(ctx.Args()) < 2 || len(ctx.Args()) > 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-	isOpenID := idpType == madmin.OpenidIDPCfg
-
-	var cfgName string
-	if len(args) == 3 {
-		cfgName = args.Get(2)
-	}
-
-	return adminIDPInfo(ctx, isOpenID, cfgName)
+func mainAdminIDPGet(_ *cli.Context) error {
+	deprecatedError("mc admin idp ldap|openid")
+	return nil
 }

--- a/cmd/admin-idp-list.go
+++ b/cmd/admin-idp-list.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go/v2"
 )
 
 var adminIDPLsCmd = cli.Command{
@@ -31,39 +30,13 @@ var adminIDPLsCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Hidden:       true,
 	Flags:        globalFlags,
-	CustomHelpTemplate: `NAME:
-  {{.HelpName}} - {{.Usage}}
+	CustomHelpTemplate: `This command is DEPRECATED.
 
-USAGE:
-  {{.HelpName}} TARGET ID_TYPE
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
-
-FLAGS:
-  {{range .VisibleFlags}}{{.}}
-  {{end}}
-EXAMPLES:
-  1. List the available openid configurations.
-     {{.Prompt}} {{.HelpName}} play/ openid
-  2. List the available ldap configurations.
-     {{.Prompt}} {{.HelpName}} play/ ldap
+Please use  "mc admin idp ldap|openid" instead.
 `,
 }
 
-func mainAdminIDPList(ctx *cli.Context) error {
-	if len(ctx.Args()) != 2 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	isOpenID := false
-	if idpType == madmin.OpenidIDPCfg {
-		isOpenID = true
-	}
-
-	return adminIDPListCommon(ctx, isOpenID)
+func mainAdminIDPList(_ *cli.Context) error {
+	deprecatedError("mc admin idp ldap|openid")
+	return nil
 }

--- a/cmd/admin-idp-remove.go
+++ b/cmd/admin-idp-remove.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go/v2"
 )
 
 var adminIDPRmCmd = cli.Command{
@@ -31,35 +30,13 @@ var adminIDPRmCmd = cli.Command{
 	Hidden:       true,
 	OnUsageError: onUsageError,
 	Flags:        globalFlags,
-	CustomHelpTemplate: `NAME:
-  {{.HelpName}} - {{.Usage}}
+	CustomHelpTemplate: `This command is DEPRECATED.
 
-USAGE:
-  {{.HelpName}} TARGET IDP_TYPE CFG_NAME
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
-
-FLAGS:
-  {{range .VisibleFlags}}{{.}}
-  {{end}}
-EXAMPLES:
-  1. Remove an OpenID configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ openid myidp
-  2. Remove default LDAP configuration from the server.
-     {{.Prompt}} {{.HelpName}} play/ ldap _
+Please use "mc admin idp ldap|openid" instead.
 `,
 }
 
-func mainAdminIDPRemove(ctx *cli.Context) error {
-	if len(ctx.Args()) != 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	cfgName := args.Get(2)
-	return adminIDPRemove(ctx, idpType == madmin.OpenidIDPCfg, cfgName)
+func mainAdminIDPRemove(_ *cli.Context) error {
+	deprecatedError("mc admin idp ldap|openid")
+	return nil
 }

--- a/cmd/admin-idp-set.go
+++ b/cmd/admin-idp-set.go
@@ -18,13 +18,7 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-
 	"github.com/minio/cli"
-	"github.com/minio/madmin-go/v2"
-	"github.com/minio/mc/pkg/probe"
 )
 
 var adminIDPSetCmd = cli.Command{
@@ -35,90 +29,13 @@ var adminIDPSetCmd = cli.Command{
 	Hidden:       true,
 	OnUsageError: onUsageError,
 	Flags:        globalFlags,
-	CustomHelpTemplate: `NAME:
-  {{.HelpName}} - {{.Usage}}
+	CustomHelpTemplate: `This command is DEPRECATED.
 
-USAGE:
-  {{.HelpName}} TARGET ID_TYPE [CFG_NAME] [CFG_PARAMS...]
-
-  ID_TYPE must be one of 'ldap' or 'openid'.
-
-  **DEPRECATED**: This command will be removed in a future version. Please use
-  "mc admin idp ldap|openid" instead.
-
-FLAGS:
-  {{range .VisibleFlags}}{{.}}
-  {{end}}
-EXAMPLES:
-  1. Create/Update the default OpenID IDP configuration (CFG_NAME is omitted).
-     {{.Prompt}} {{.HelpName}} play/ openid \
-          client_id=minio-client-app \
-          client_secret=minio-client-app-secret \
-          config_url="http://localhost:5556/dex/.well-known/openid-configuration" \
-          scopes="openid,groups" \
-          redirect_uri="http://127.0.0.1:10000/oauth_callback" \
-          role_policy="consoleAdmin"
-  2. Create/Update configuration for OpenID IDP configuration named "dex_test".
-     {{.Prompt}} {{.HelpName}} play/ openid dex_test \
-          client_id=minio-client-app \
-          client_secret=minio-client-app-secret \
-          config_url="http://localhost:5556/dex/.well-known/openid-configuration" \
-          scopes="openid,groups" \
-          redirect_uri="http://127.0.0.1:10000/oauth_callback" \
-          role_policy="consoleAdmin"
-  3. Create/Update the LDAP IDP configuration (CFG_NAME must be empty for LDAP).
-     {{.Prompt}} {{.HelpName}} play/ ldap \
-          server_addr=ldap.corp.min.io:686 \
-          lookup_bind_dn=cn=readonly,ou=service_account,dc=min,dc=io \
-          lookup_bind_password=mysecretpassword \
-          user_dn_search_base_dn=dc=min,dc=io \
-          user_dn_search_filter="(uid=%s)" \
-          group_search_base_dn=ou=swengg,dc=min,dc=io \
-          group_search_filter="(&(objectclass=groupofnames)(member=%d))"
-
+Please use commands under 'mc admin idp ldap|openid' instead.
 `,
 }
 
-func validateIDType(idpType string) {
-	if !madmin.ValidIDPConfigTypes.Contains(idpType) {
-		fatalIf(probe.NewError(errors.New("invalid IDP type")),
-			fmt.Sprintf("IDP type must be one of %v", madmin.ValidIDPConfigTypes))
-	}
-}
-
-func mainAdminIDPSet(ctx *cli.Context) error {
-	if len(ctx.Args()) < 3 {
-		showCommandHelpAndExit(ctx, 1)
-	}
-
-	args := ctx.Args()
-
-	aliasedURL := args.Get(0)
-
-	// Create a new MinIO Admin Client
-	client, err := newAdminClient(aliasedURL)
-	fatalIf(err, "Unable to initialize admin connection.")
-
-	idpType := args.Get(1)
-	validateIDType(idpType)
-
-	var cfgName string
-	input := args[2:]
-	if !strings.Contains(args.Get(2), "=") {
-		cfgName = args.Get(2)
-		input = args[3:]
-	}
-
-	inputCfg := strings.Join(input, " ")
-
-	restart, e := client.AddOrUpdateIDPConfig(globalContext, idpType, cfgName, inputCfg, false)
-	fatalIf(probe.NewError(e), "Unable to set IDP config for '%s' to server", idpType)
-
-	// Print set config result
-	printMsg(configSetMessage{
-		targetAlias: aliasedURL,
-		restart:     restart,
-	})
-
+func mainAdminIDPSet(_ *cli.Context) error {
+	deprecatedError("mc admin idp ldap|openid")
 	return nil
 }


### PR DESCRIPTION
## Description

- Now returns an error with a message to use the newer commands.

## Motivation and Context

Towards cleaning up older interfaces.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
