### PR TITLE
Show groups with their policy details while listing users

### DIFF
--- a/cmd/admin-user-add.go
+++ b/cmd/admin-user-add.go
@@ -83,15 +83,21 @@ func checkAdminUserAddSyntax(ctx *cli.Context) {
 	}
 }
 
+// userGroup container for content message structure
+type userGroup struct {
+	Name     string   `json:"name,omitempty"`
+	Policies []string `json:"policies,omitempty"`
+}
+
 // userMessage container for content message structure
 type userMessage struct {
 	op         string
-	Status     string   `json:"status"` // TODO: remove this?
-	AccessKey  string   `json:"accessKey,omitempty"`
-	SecretKey  string   `json:"secretKey,omitempty"`
-	PolicyName string   `json:"policyName,omitempty"`
-	UserStatus string   `json:"userStatus,omitempty"`
-	MemberOf   []string `json:"memberOf,omitempty"`
+	Status     string      `json:"status"` // TODO: remove this?
+	AccessKey  string      `json:"accessKey,omitempty"`
+	SecretKey  string      `json:"secretKey,omitempty"`
+	PolicyName string      `json:"policyName,omitempty"`
+	UserStatus string      `json:"userStatus,omitempty"`
+	MemberOf   []userGroup `json:"memberOf,omitempty"`
 }
 
 func (u userMessage) String() string {
@@ -108,12 +114,16 @@ func (u userMessage) String() string {
 			Field{"PolicyName", policyFieldMaxLen},
 		).buildRow(u.UserStatus, u.AccessKey, u.PolicyName)
 	case "info":
+		memberOf := []string{}
+		for _, group := range u.MemberOf {
+			memberOf = append(memberOf, group.Name)
+		}
 		return console.Colorize("UserMessage", strings.Join(
 			[]string{
 				fmt.Sprintf("AccessKey: %s", u.AccessKey),
 				fmt.Sprintf("Status: %s", u.UserStatus),
 				fmt.Sprintf("PolicyName: %s", u.PolicyName),
-				fmt.Sprintf("MemberOf: %s", strings.Join(u.MemberOf, ",")),
+				fmt.Sprintf("MemberOf: %s", memberOf),
 			}, "\n"))
 	case "remove":
 		return console.Colorize("UserMessage", "Removed user `"+u.AccessKey+"` successfully.")


### PR DESCRIPTION
## Description
Currently while listing users there is no way to find out what policies are being inherited due to group membership of the user. We need to get details of group to map the details.
This change enables listing of user with their group having policies list as well in `--json` output.

## Motivation and Context


## How to test this PR?
Step-1: Create a new user and group. Assign custom policies to user and group both
Step-2: Add user to the newly created group
Step-3: List users
```
$ mc admin user list myminio
enabled    foobar1               testpolicy,testpo...
```
```
$ mc admin user list myminio --json
{
 "status": "success",
 "accessKey": "foobar1",
 "policyName": "testpolicy,testpolicy1",
 "userStatus": "enabled",
 "memberOf": [
  {
   "name": "newgroup",
   "policies": [
    "consoleAdmin",
    "readwrite"
   ]
  }
 ]
}
```

Step-4: Get details of individual user
```
$ mc admin user info myminio foobar1
AccessKey: foobar1
Status: enabled
PolicyName: testpolicy,testpolicy1
MemberOf: [newgroup]
```
```
$ mc admin user info myminio foobar1 --json
{
 "status": "success",
 "accessKey": "foobar1",
 "policyName": "testpolicy,testpolicy1",
 "userStatus": "enabled",
 "memberOf": [
  {
   "name": "newgroup",
   "policies": [
    "consoleAdmin",
    "readwrite"
   ]
  }
 ]
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
