### PR TITLE
Leave GC to runtime

### DIFF
--- a/cmd/parallel-manager.go
+++ b/cmd/parallel-manager.go
@@ -195,7 +195,10 @@ func (p *ParallelManager) enoughMemForUpload(uploadSize int64) bool {
 	}
 
 	smem := runtime.MemStats{}
-	runtime.GC()
+	if uploadSize > 50<<20 {
+		// GC if upload is bigger than 50MB.
+		runtime.GC()
+	}
 	runtime.ReadMemStats(&smem)
 
 	return estimateNeededMemoryForUpload(uploadSize)+smem.Alloc < p.maxMem


### PR DESCRIPTION
## Description

Running manual GC for every file uploaded is extremely resource intensive on many small files.

Leave GC to the runtime unless dealing with a big file.

Fixes #4580

## How to test this PR?

See linked issue.

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
