### PR TITLE
fix proxy not being used to test connectivity

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -129,18 +129,9 @@ func subnetMFAURL() string {
 }
 
 func checkURLReachable(url string) *probe.Error {
-	clnt := httpClient(10 * time.Second)
-	req, e := http.NewRequest(http.MethodHead, url, nil)
+	_, e := subnetHeadReq(url, nil)
 	if e != nil {
 		return probe.NewError(e).Trace(url)
-	}
-	resp, e := clnt.Do(req)
-	if e != nil {
-		return probe.NewError(e).Trace(url)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return probe.NewError(errors.New(resp.Status)).Trace(url)
 	}
 	return nil
 }
@@ -217,6 +208,14 @@ func subnetReqDo(r *http.Request, headers map[string]string) (string, error) {
 		return respStr, nil
 	}
 	return respStr, fmt.Errorf("Request failed with code %d with error: %s", resp.StatusCode, respStr)
+}
+
+func subnetHeadReq(reqURL string, headers map[string]string) (string, error) {
+	r, e := http.NewRequest(http.MethodHead, reqURL, nil)
+	if e != nil {
+		return "", e
+	}
+	return subnetReqDo(r, headers)
 }
 
 func subnetGetReq(reqURL string, headers map[string]string) (string, error) {


### PR DESCRIPTION
## Description

The code to check SUBNET reachability was using default client without proxy, even when the proxy is set.

## How to test this PR?

- Register a cluster with subnet
- Configure access to subnet only via proxy
- Set the proxy using `mc support proxy set {alias} {proxy-url}`
- Check that subnet related commands like `mc support diag` work fine in online mode (without `--airgap`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
