### PR TITLE
Improve output readability for `mc stat` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mc
 .idea/
 mc.RELEASE*
 mc.gz
+.DS_Store

--- a/cmd/client-fs_darwin.go
+++ b/cmd/client-fs_darwin.go
@@ -35,7 +35,7 @@ var (
 )
 
 // IsGetEvent checks if the event return is a get event.
-func IsGetEvent(event notify.Event) bool {
+func IsGetEvent(_ notify.Event) bool {
 	return false
 }
 

--- a/cmd/pipe_unsupported.go
+++ b/cmd/pipe_unsupported.go
@@ -21,11 +21,6 @@ package cmd
 
 import "os"
 
-// func increasePipeBufferSize(f *os.File, desiredPipeSize int) error {
-// 	// this is not supported on non-Linux platforms.
-// 	return nil
-// }
-
 func increasePipeBufferSize(_ *os.File, _ int) error {
 	// this is not supported on non-Linux platforms.
 	return nil

--- a/cmd/pipe_unsupported.go
+++ b/cmd/pipe_unsupported.go
@@ -21,7 +21,12 @@ package cmd
 
 import "os"
 
-func increasePipeBufferSize(f *os.File, desiredPipeSize int) error {
+// func increasePipeBufferSize(f *os.File, desiredPipeSize int) error {
+// 	// this is not supported on non-Linux platforms.
+// 	return nil
+// }
+
+func increasePipeBufferSize(_ *os.File, _ int) error {
 	// this is not supported on non-Linux platforms.
 	return nil
 }

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -107,16 +107,14 @@ func (stat statMessage) String() (msg string) {
 			}
 		}
 	}
-	encryptionTypeSlice := strings.Split(stat.Key, "/")
-	encryptionType := strings.ToUpper(encryptionTypeSlice[len(encryptionTypeSlice)-1])
+
 	if maxKeyEncrypted > 0 {
-		switch encryptionType {
-		case "S3":
-			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s\n", "Encryption", encryptionType))
-		case "KMS":
-			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s\n", "Encryption", encryptionType))
-		case "SSE-C":
-			msgBuilder.WriteString(fmt.Sprintf("%-10s: %s\n", "Encryption", encryptionType))
+		if keyID, ok := stat.Metadata["X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id"]; ok {
+			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s (%s)\n", "Encryption", "KMS", keyID))
+		} else if _, ok := stat.Metadata["X-Amz-Server-Side-Encryption-Customer-Key-Md5"]; ok {
+			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s\n", "Encryption", "C"))
+		} else {
+			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s\n", "Encryption", "S3"))
 		}
 	}
 

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -117,14 +117,8 @@ func (stat statMessage) String() (msg string) {
 		}
 	}
 
-	if maxKeyEncrypted > 0 {
-		msgBuilder.WriteString(fmt.Sprintf("%-10s:", "Encrypted") + "\n")
-		for k, v := range stat.Metadata {
-			if strings.HasPrefix(strings.ToLower(k), serverEncryptionKeyPrefix) {
-				msgBuilder.WriteString(fmt.Sprintf("  %-*.*s: %s ", maxKeyEncrypted, maxKeyEncrypted, k, v) + "\n")
-			}
-		}
-	}
+	msgBuilder.WriteString(fmt.Sprintf("%-10s: %s\n", "Server side encryption", strings.ToUpper(strings.Split(stat.Key, "/")[1])))
+
 	if stat.ReplicationStatus != "" {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Replication Status", stat.ReplicationStatus))
 	}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -107,6 +107,19 @@ func (stat statMessage) String() (msg string) {
 			}
 		}
 	}
+	encryptionTypeSlice := strings.Split(stat.Key, "/")
+	encryptionType := strings.ToUpper(encryptionTypeSlice[len(encryptionTypeSlice)-1])
+	if maxKeyEncrypted > 0 {
+		switch encryptionType {
+		case "S3":
+			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s\n", "Encryption", encryptionType))
+		case "KMS":
+			msgBuilder.WriteString(fmt.Sprintf("%-10s: SSE-%s\n", "Encryption", encryptionType))
+		case "SSE-C":
+			msgBuilder.WriteString(fmt.Sprintf("%-10s: %s\n", "Encryption", encryptionType))
+		}
+	}
+
 	if maxKeyMetadata > 0 {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s:", "Metadata") + "\n")
 		for k, v := range stat.Metadata {
@@ -116,8 +129,6 @@ func (stat statMessage) String() (msg string) {
 			}
 		}
 	}
-
-	msgBuilder.WriteString(fmt.Sprintf("%-10s: %s\n", "Server side encryption", strings.ToUpper(strings.Split(stat.Key, "/")[1])))
 
 	if stat.ReplicationStatus != "" {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Replication Status", stat.ReplicationStatus))


### PR DESCRIPTION
Description

This PR adjusts the output of the mc stat command to display the server-side encryption information in a more understandable manner.

Motivation and Context

This PR aims to aims to adjust the output from:
```
>mc stat -r play/abdul
Name      : abdul/kms
Date      : 2023-06-12 06:58:38 PDT
Size      : 27 B
ETag      : d40ed931ae5772ee918abb5fb18d0ad2
Type      : file
Metadata  :
  Content-Type: application/octet-stream
Encrypted :
  X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id: arn:aws:kms:my-minio-key
  X-Amz-Server-Side-Encryption               : aws:kms

Name      : abdul/s3
Date      : 2023-06-12 06:58:53 PDT
Size      : 27 B
ETag      : 5848d6f7d2172580f07b1ed8d7b56e9a
Type      : file
Metadata  :
  Content-Type: application/octet-stream
Encrypted :
  X-Amz-Server-Side-Encryption: AES256

Name      : abdul/unencrypted
Date      : 2023-06-12 06:58:02 PDT
Size      : 27 B
ETag      : 5848d6f7d2172580f07b1ed8d7b56e9a
Type      : file
Metadata  :
  Content-Type: application/octet-stream


>mc stat -r play/abdul --encrypt-key "play/abdul=MzJieXRlc2xvbmdzZWNyZWFiY2RlZmcJZ2l2ZW5uMjE="
Name      : abdul/sse-c
Date      : 2023-06-12 07:00:33 PDT
Size      : 27 B
ETag      : 77f1f1f52aac4f62e57b8e6e973ee603
Type      : file
Metadata  :
  Content-Type: application/octet-stream
Encrypted :
  X-Amz-Server-Side-Encryption-Customer-Key-Md5  : i5MnXlnfBFzo+X31rRClNw==
  X-Amz-Server-Side-Encryption-Customer-Algorithm: AES256
```

To this:
```
$ ./mc stat -r play/abdul --encrypt-key "play/abdul=MzJieXRlc2xvbmdzZWNyZWFiY2RlZmcJZ2l2ZW5uMjE="
Name      : abdul/test2
Date      : 2023-06-13 10:42:34 PDT 
Size      : 0 B    
ETag      : 982b9d404db37a97dc7c9f49bb312cc7 
Type      : file 
Encryption: SSE-C
Metadata  :
  Content-Type: application/octet-stream

$ ./mc stat -r play/abdul 
Name      : abdul/test
Date      : 2023-06-13 10:29:13 PDT 
Size      : 0 B    
ETag      : d41d8cd98f00b204e9800998ecf8427e 
Type      : file 
Encryption: SSE-S3
Metadata  :
  Content-Type: application/octet-stream 

Name      : abdul/test1
Date      : 2023-06-13 10:29:56 PDT 
Size      : 0 B    
ETag      : 79204d0af4ecf4741d48f10c0e9a690b 
Type      : file 
Encryption: SSE-KMS (arn:aws:kms:my-minio-key)
Metadata  :
  Content-Type: application/octet-stream 
```

How to test this PR?
- Checkout this branch locally.
- Build the modified mc client.
- Run the following commands to test the mc stat output:
  `./mc stat play/abdul`
  `./mc stat -r play/abdul --encrypt-key "play/abdul=MzJieXRlc2xvbmdzZWNyZWFiY2RlZmcJZ2l2ZW5uMjE="` 


Types of changes:
 New feature (non-breaking change which adds functionality)