### PR TITLE
Set theme color for `mc admin user svcacct set` output

### DIFF
--- a/cmd/admin-user-svcacct-set.go
+++ b/cmd/admin-user-svcacct-set.go
@@ -22,9 +22,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go/v2"
 	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/console"
 )
 
 var adminUserSvcAcctSetFlags = []cli.Flag{
@@ -89,6 +91,8 @@ func checkAdminUserSvcAcctSetSyntax(ctx *cli.Context) {
 // mainAdminUserSvcAcctSet is the handle for "mc admin user svcacct set" command.
 func mainAdminUserSvcAcctSet(ctx *cli.Context) error {
 	checkAdminUserSvcAcctSetSyntax(ctx)
+
+	console.SetColor("AccMessage", color.New(color.FgGreen))
 
 	// Get the alias parameter from cli
 	args := ctx.Args()


### PR DESCRIPTION
## Description
Align with output theme for other commands like `enable`, `disable` etc.

## Motivation and Context


## How to test this PR?
`mc admin user svcacct set ALIAS SERVICE-ACCOUNT`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
