### PR TITLE
Fix unconfigured IDP output in `idp info` command

### DIFF
--- a/cmd/idp-openid-subcommands.go
+++ b/cmd/idp-openid-subcommands.go
@@ -412,6 +412,10 @@ func (i idpConfig) JSON() string {
 }
 
 func (i idpConfig) String() string {
+	if len(i.Info) == 0 {
+		return "Not configured."
+	}
+
 	// Determine required width for key column.
 	fieldColWidth := 0
 	for _, kv := range i.Info {


### PR DESCRIPTION
## How to test this PR?

Changed to:

```
$ ./mc idp ldap info myminio 
Not configured.
```

vs previously:

```
 mc idp ldap info myminio
╭╮
││
╰╯
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
