### PR TITLE
Improve Consistency in mc Command Behavior

### DIFF
--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -104,8 +104,8 @@ EXAMPLES:
 
 // checkCatSyntax - validate all the passed arguments
 func checkCatSyntax(ctx *cli.Context) {
-	if len(ctx.Args()) == 0 {
-		cli.ShowCommandHelpAndExit(ctx, "cat", 1) // last argument is exit code
+	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+		showCommandHelpAndExit(ctx, 1) // last argument is exit code
 	}
 }
 

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -104,7 +104,7 @@ EXAMPLES:
 
 // checkCatSyntax - validate all the passed arguments
 func checkCatSyntax(ctx *cli.Context) {
-	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
+	if len(ctx.Args()) == 0 {
 		showCommandHelpAndExit(ctx, 1) // last argument is exit code
 	}
 }

--- a/cmd/cat-main.go
+++ b/cmd/cat-main.go
@@ -102,6 +102,13 @@ EXAMPLES:
 `,
 }
 
+// checkCatSyntax - validate all the passed arguments
+func checkCatSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) == 0 {
+		cli.ShowCommandHelpAndExit(ctx, "cat", 1) // last argument is exit code
+	}
+}
+
 // prettyStdout replaces some non printable characters
 // with <hex> format to be better viewable by the user
 type prettyStdout struct {
@@ -163,6 +170,8 @@ type catOpts struct {
 
 // parseCatSyntax performs command-line input validation for cat command.
 func parseCatSyntax(ctx *cli.Context) catOpts {
+	// Validate command-line arguments.
+	checkCatSyntax(ctx)
 	var o catOpts
 	o.args = ctx.Args()
 

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -169,21 +169,20 @@ func pipe(ctx *cli.Context, targetURL string, encKeyDB map[string][]prefixSSEPai
 	return err.Trace(targetURL)
 }
 
-// check pipe input arguments.
+// checkPipeSyntax - validate arguments passed by user
 func checkPipeSyntax(ctx *cli.Context) {
-	if len(ctx.Args()) > 1 {
+	if len(ctx.Args()) != 1 {
 		showCommandHelpAndExit(ctx, 1) // last argument is exit code.
 	}
 }
 
 // mainPipe is the main entry point for pipe command.
 func mainPipe(ctx *cli.Context) error {
+	// validate pipe input arguments.
+	checkPipeSyntax(ctx)
 	// Parse encryption keys per command.
 	encKeyDB, err := getEncKeys(ctx)
 	fatalIf(err, "Unable to parse encryption keys.")
-
-	// validate pipe input arguments.
-	checkPipeSyntax(ctx)
 
 	meta := map[string]string{}
 	if attr := ctx.String("attr"); attr != "" {

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -535,10 +535,13 @@ function test_cat_stdin()
 
     start_time=$(get_time)
     object_name="mc-test-object-$RANDOM"
-    echo "testcontent" | "${MC_CMD[@]}" cat > stdin.output
+    bucket_name=bucket_name="mc-test-bucket-$RANDOM"
+    "${MC_CMD[@]}" mb "${SERVER_ALIAS}/${bucket_name}"
+    echo "testcontent" | "${MC_CMD[@]}" pipe "${SERVER_ALIAS}/${bucket_name}/${object_name}"
+    "${MC_CMD[@]}" cat "${SERVER_ALIAS}/${bucket_name}/${object_name}" > stdout.output
     assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure $? "unable to redirect stdin to stdout using 'mc cat'"
-    assert_success "$start_time" "${FUNCNAME[0]}" check_md5sum "42ed9fb3563d8e9c7bb522be443033f4" stdin.output
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm stdin.output
+    assert_success "$start_time" "${FUNCNAME[0]}" check_md5sum "42ed9fb3563d8e9c7bb522be443033f4" stdout.output
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm stdout.output
 
     log_success "$start_time" "${FUNCNAME[0]}"
 }

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -535,7 +535,7 @@ function test_cat_stdin()
 
     start_time=$(get_time)
     object_name="mc-test-object-$RANDOM"
-    bucket_name=bucket_name="mc-test-bucket-$RANDOM"
+    bucket_name="mc-test-bucket-$RANDOM"
     "${MC_CMD[@]}" mb "${SERVER_ALIAS}/${bucket_name}"
     echo "testcontent" | "${MC_CMD[@]}" pipe "${SERVER_ALIAS}/${bucket_name}/${object_name}"
     "${MC_CMD[@]}" cat "${SERVER_ALIAS}/${bucket_name}/${object_name}" > stdout.output


### PR DESCRIPTION
## Description
Modified the argument handling of 'mc cat' and 'mc pipe' commands to display help text when no arguments are passed, aligning them with the behavior of other mc commands.

## Motivation and Context
`mc stat` and `mc pipe` commands are executed without any arguments, instead of returning the expected help message or error notification, the commands cause the program to hang.

## How to test this PR?
- checkout to the branch `mc-command-consistency-fix`
- Build the program
- run `/mc cat` and `/mc pipe`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


