### PR TITLE
Enhance user info output with authentication info

### DIFF
--- a/cmd/admin-user-add.go
+++ b/cmd/admin-user-add.go
@@ -91,13 +91,14 @@ type userGroup struct {
 
 // userMessage container for content message structure
 type userMessage struct {
-	op         string
-	Status     string      `json:"status"` // TODO: remove this?
-	AccessKey  string      `json:"accessKey,omitempty"`
-	SecretKey  string      `json:"secretKey,omitempty"`
-	PolicyName string      `json:"policyName,omitempty"`
-	UserStatus string      `json:"userStatus,omitempty"`
-	MemberOf   []userGroup `json:"memberOf,omitempty"`
+	op             string
+	Status         string      `json:"status"` // TODO: remove this?
+	AccessKey      string      `json:"accessKey,omitempty"`
+	SecretKey      string      `json:"secretKey,omitempty"`
+	PolicyName     string      `json:"policyName,omitempty"`
+	UserStatus     string      `json:"userStatus,omitempty"`
+	MemberOf       []userGroup `json:"memberOf,omitempty"`
+	Authentication string      `json:"authentication,omitempty"`
 }
 
 func (u userMessage) String() string {
@@ -118,13 +119,16 @@ func (u userMessage) String() string {
 		for _, group := range u.MemberOf {
 			memberOf = append(memberOf, group.Name)
 		}
-		return console.Colorize("UserMessage", strings.Join(
-			[]string{
-				fmt.Sprintf("AccessKey: %s", u.AccessKey),
-				fmt.Sprintf("Status: %s", u.UserStatus),
-				fmt.Sprintf("PolicyName: %s", u.PolicyName),
-				fmt.Sprintf("MemberOf: %s", memberOf),
-			}, "\n"))
+		lines := []string{
+			fmt.Sprintf("AccessKey: %s", u.AccessKey),
+			fmt.Sprintf("Status: %s", u.UserStatus),
+			fmt.Sprintf("PolicyName: %s", u.PolicyName),
+			fmt.Sprintf("MemberOf: %s", memberOf),
+		}
+		if u.Authentication != "" {
+			lines = append(lines, fmt.Sprintf("Authentication: %s", u.Authentication))
+		}
+		return console.Colorize("UserMessage", strings.Join(lines, "\n"))
 	case "remove":
 		return console.Colorize("UserMessage", "Removed user `"+u.AccessKey+"` successfully.")
 	case "disable":

--- a/cmd/admin-user-info.go
+++ b/cmd/admin-user-info.go
@@ -18,10 +18,12 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
+	"github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/pkg/console"
 )
@@ -87,12 +89,26 @@ func mainAdminUserInfo(ctx *cli.Context) error {
 	}
 
 	printMsg(userMessage{
-		op:         ctx.Command.Name,
-		AccessKey:  args.Get(1),
-		PolicyName: user.PolicyName,
-		UserStatus: string(user.Status),
-		MemberOf:   memberOf,
+		op:             ctx.Command.Name,
+		AccessKey:      args.Get(1),
+		PolicyName:     user.PolicyName,
+		UserStatus:     string(user.Status),
+		MemberOf:       memberOf,
+		Authentication: authInfoToUserMessage(user.AuthInfo),
 	})
 
 	return nil
+}
+
+func authInfoToUserMessage(a *madmin.UserAuthInfo) string {
+	if a == nil {
+		return ""
+	}
+
+	authServer := ""
+	if a.Type != madmin.BuiltinUserAuthType {
+		authServer = "/" + a.AuthServer
+	}
+
+	return fmt.Sprintf("%s%s (%s)", a.Type, authServer, a.AuthServerUserID)
 }


### PR DESCRIPTION
## Description

Return authentication metadata in user info command.

Needs https://github.com/minio/madmin-go/pull/201

## Motivation and Context


## How to test this PR?

Example outputs:

```
$ ./mc admin user info myminio foo
AccessKey: foo
Status: enabled
PolicyName: 
MemberOf: []
Authentication: builtin (foo)


$ ./mc admin user info myminio  uid=dillon,ou=people,ou=swengg,dc=min,dc=io
AccessKey: uid=dillon,ou=people,ou=swengg,dc=min,dc=io
Status: 
PolicyName: consoleAdmin
MemberOf: []
Authentication: ldap/localhost:1389 (uid=dillon,ou=people,ou=swengg,dc=min,dc=io)

```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
