### PR TITLE
improve user messaging in 'support perf' and 'mc rm --dry-run'

### DIFF
--- a/cmd/support-inspect.go
+++ b/cmd/support-inspect.go
@@ -197,8 +197,7 @@ func mainSupportInspect(ctx *cli.Context) error {
 		return nil
 	}
 
-	clr := color.New(color.FgGreen, color.Bold)
-	clr.Println("uploaded successfully to SUBNET.")
+	console.Infof("Object inspection data for '%s' uploaded to SUBNET successfully\n", aliasedURL)
 	return nil
 }
 

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 
 	humanize "github.com/dustin/go-humanize"
-	"github.com/fatih/color"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
 	"github.com/minio/madmin-go/v3"
@@ -233,7 +232,7 @@ func (p PerfTestOutput) String() string {
 // JSON - jsonified output of the perf tests
 func (p PerfTestOutput) JSON() string {
 	JSONBytes, e := json.MarshalIndent(p, "", "    ")
-	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON")
 	return string(JSONBytes)
 }
 
@@ -404,17 +403,17 @@ func execSupportPerf(ctx *cli.Context, aliasedURL string, perfType string) {
 
 	// If results still not available, don't write anything
 	if len(results) == 0 {
-		clr := color.New(color.FgRed, color.Bold)
-		clr.Println("Nothing available to upload to SUBNET yet.")
+		console.Fatalln("No performance reports were captured, please report this issue")
 	} else {
 		resultFileNamePfx := fmt.Sprintf("%s-perf_%s", filepath.Clean(alias), UTCNow().Format("20060102150405"))
 		resultFileName := resultFileNamePfx + ".json"
 
 		regInfo := getClusterRegInfo(getAdminInfo(aliasedURL), alias)
 		tmpFileName, e := zipPerfResult(convertPerfResults(results), resultFileName, regInfo)
-		fatalIf(probe.NewError(e), "Error creating zip from perf test results:")
+		fatalIf(probe.NewError(e), "Unable to generate zip file from performance results")
 
 		if globalAirgapped {
+			console.Infoln()
 			savePerfResultFile(tmpFileName, resultFileNamePfx)
 			return
 		}
@@ -424,21 +423,20 @@ func execSupportPerf(ctx *cli.Context, aliasedURL string, perfType string) {
 
 		_, e = uploadFileToSubnet(alias, tmpFileName, reqURL, headers)
 		if e != nil {
-			console.Errorln("Unable to upload perf test results to SUBNET portal: " + e.Error())
+			errorIf(probe.NewError(e), "Unable to upload performance results to SUBNET portal")
 			savePerfResultFile(tmpFileName, resultFileNamePfx)
 			return
 		}
 
-		clr := color.New(color.FgGreen, color.Bold)
-		clr.Println("uploaded successfully to SUBNET.")
+		console.Infoln("Uploaded performance report to SUBNET successfully")
 	}
 }
 
 func savePerfResultFile(tmpFileName string, resultFileNamePfx string) {
 	zipFileName := resultFileNamePfx + ".zip"
 	e := moveFile(tmpFileName, zipFileName)
-	fatalIf(probe.NewError(e), fmt.Sprintf("Error moving temp file %s to %s:", tmpFileName, zipFileName))
-	console.Infoln("MinIO performance report saved at", zipFileName)
+	fatalIf(probe.NewError(e), fmt.Sprintf("Unable to move %s -> %s", tmpFileName, zipFileName))
+	console.Infof("MinIO performance report saved at %s, please upload to SUBNET portal manually\n", zipFileName)
 }
 
 func runPerfTests(ctx *cli.Context, aliasedURL string, perfType string) []PerfTestResult {

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/probe"
@@ -197,23 +196,21 @@ func execSupportProfile(ctx *cli.Context, client *madmin.AdminClient, alias stri
 		reqURL, headers = prepareSubnetUploadURL(uploadURL, alias, apiKey)
 	}
 
-	console.Infof("Profiling '%s' for %d seconds... ", alias, duration)
+	console.Infof("Profiling '%s' for %d seconds... \n", alias, duration)
 	data, e := client.Profile(globalContext, madmin.ProfilerType(profilers), time.Second*time.Duration(duration))
 	fatalIf(probe.NewError(e), "Unable to save profile data")
 
 	saveProfileFile(data)
 
-	successClr := color.New(color.FgGreen, color.Bold)
-	failureClr := color.New(color.FgRed, color.Bold)
 	if !globalAirgapped {
-		_, e := uploadFileToSubnet(alias, profileFile, reqURL, headers)
+		_, e = uploadFileToSubnet(alias, profileFile, reqURL, headers)
 		if e != nil {
-			failureClr.Println("\nUnable to upload profile file to SUBNET:", e.Error())
-			successClr.Printf("Profiling data are saved locally at '%s'\n", profileFile)
+			errorIf(probe.NewError(e), "Unable to upload profile file to SUBNET")
+			console.Infof("Profiling data saved locally at '%s'\n", profileFile)
 			return
 		}
-		successClr.Println("uploaded successfully to SUBNET.")
+		console.Infoln("Profiling data uploaded to SUBNET successfully")
 	} else {
-		successClr.Printf("saved successfully at '%s'\n", profileFile)
+		console.Infoln("Profiling data saved successfully at", profileFile)
 	}
 }


### PR DESCRIPTION

## Description
improve user messaging in 'support perf' and 'mc rm --dry-run'

## Motivation and Context
- terminal messaging for 'mc rm --dry-run' was completely 
  wrong, it was using `fmt.Println` which shouldn't be done.

- mc support perf - printing was using a mix of color.New()
  and console.Infoln() (use one)

- mc support profile - printing was using a mix of color.New()
  and console.Info() (use one)

- mc support inspect - printing was using a mix of color.New()
  and consoleInfo() (use one)


## How to test this PR?
Just as per the PR description

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
