### PR TITLE
Fix issues related to 'mc admin svcacct list --json' cmd

### DIFF
--- a/cmd/admin-user-svcacct-add.go
+++ b/cmd/admin-user-svcacct-add.go
@@ -179,7 +179,7 @@ func (u acctMessage) String() string {
 			Field{"AccessKey", accessFieldMaxLen},
 			Field{"Expiration", expirationMaxLen},
 		).buildRow(u.AccessKey, func() string {
-			if u.Expiration != nil && !u.Expiration.IsZero() && !u.Expiration.Equal(timeSentinel) {
+			if u.Expiration != nil && !u.Expiration.IsZero() {
 				return (*u.Expiration).String()
 			}
 			return "no-expiry"

--- a/cmd/admin-user-svcacct-list.go
+++ b/cmd/admin-user-svcacct-list.go
@@ -80,24 +80,32 @@ func mainAdminUserSvcAcctList(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to list service accounts")
 
 	if len(svcList.Accounts) > 0 {
-		// Print table header
-		var header string
-		header += console.Colorize("Headers", newPrettyTable(" | ",
-			Field{"AccessKeyHeader", accessFieldMaxLen},
-			Field{"ExpirationHeader", expirationMaxLen},
-		).buildRow("   Access Key", "Expiry"))
-		console.Println(header)
+		if !globalJSON {
+			// Print table header
+			var header string
+			header += console.Colorize("Headers", newPrettyTable(" | ",
+				Field{"AccessKeyHeader", accessFieldMaxLen},
+				Field{"ExpirationHeader", expirationMaxLen},
+			).buildRow("   Access Key", "Expiry"))
+			console.Println(header)
+		}
 
 		// Print table contents
 		for _, svc := range svcList.Accounts {
+			expiration := svc.Expiration
+			if expiration.Equal(timeSentinel) {
+				expiration = nil
+			}
 			printMsg(acctMessage{
 				op:         svcAccOpList,
 				AccessKey:  svc.AccessKey,
-				Expiration: svc.Expiration,
+				Expiration: expiration,
 			})
 		}
 	} else {
-		console.Println("No service accounts found")
+		if !globalJSON {
+			console.Println("No service accounts found")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description
- Fix table header being printed when the '--json' flag is present for the 'mc admin svcacct list' command
- Fix sentinel date being marshaled when the '--json' flag is present for the 'mc admin svcacct list' command

## Motivation and Context
As it could be seen on https://github.com/minio/minio/pull/17249#issuecomment-1610098695, the `   Access Key        | Expiry` header was causing the JSON that was printed to be invalid. Additionally, when the expiration for the service account was not set, the sentinel date `1970-01-01T00:00:00Z` was being displayed.

## How to test this PR?
- Create service accounts with and without expiration dates for a user
- Use the `--json` flag for the `mc admin user svcacct list` command to list service accounts
- Verify that the service accounts listed are valid JSON
- Verify that the expiration dates are not being displayed for service accounts that are created without an expiry
- Finally, make sure that the rest of the `mc admin user svcacct list` command works as expected

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (PR #4576)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
