### PR TITLE
Fixes `cp --recursive` validation check on prefixes

### DIFF
--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -185,7 +185,7 @@ func urlJoinPath(url1, url2 string) string {
 	return joinURLs(u1, u2).String()
 }
 
-// url2Stat returns stat info for URL - supports bucket, object and a prefixe with or without a trailing slash
+// url2Stat returns stat info for URL - supports bucket, object and a directories with or without a trailing delimeter. Does not support prefixes
 func url2Stat(ctx context.Context, urlStr, versionID string, fileAttr bool, encKeyDB map[string][]prefixSSEPair, timeRef time.Time, isZip bool) (client Client, content *ClientContent, err *probe.Error) {
 	client, err = newClient(urlStr)
 	if err != nil {


### PR DESCRIPTION
## Description

Fixes an issues with the way that `cp --recursive` validates the sources url that complicates working with minio prefixes

## Motivation and Context 

Please see #4452

## How to test this PR?

Am adding functional test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
