### PR TITLE
allow purge to happen on quorum lost objects

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.20.6
         check-latest: true
     - name: Get official govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -243,6 +243,7 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 		fatalIf(errDummy().Trace(),
 			"You cannot specify --purge with --recursive.")
 	}
+
 	if isForceDel && (isNoncurrentVersion || isVersions || cliCtx.IsSet("older-than") || cliCtx.IsSet("newer-than") || versionID != "") {
 		fatalIf(errDummy().Trace(),
 			"You cannot specify --purge flag with any flag(s) other than --force.")
@@ -303,12 +304,15 @@ func removeSingle(url, versionID string, opts removeOpts) error {
 
 	_, content, pErr := url2Stat(ctx, url, versionID, false, opts.encKeyDB, time.Time{}, false)
 	if pErr != nil {
-		switch minio.ToErrorResponse(pErr.ToGoError()).StatusCode {
+		switch st := minio.ToErrorResponse(pErr.ToGoError()).StatusCode; st {
 		case http.StatusBadRequest, http.StatusMethodNotAllowed:
 			ignoreStatError = true
 		default:
-			errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
-			return exitStatus(globalErrorExitStatus)
+			ignoreStatError = st == http.StatusServiceUnavailable && opts.isForce && opts.isForceDel
+			if !ignoreStatError {
+				errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
+				return exitStatus(globalErrorExitStatus)
+			}
 		}
 	} else {
 		isDir = content.Type.IsDir()


### PR DESCRIPTION
## Description
allow purge to happen on quorum lost objects

## Motivation and Context
objects when returning '503' 

## How to test this PR?
you need objects that return 503
```
mc rm --purge --force alias/bucket/object-with-503
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
