### PR TITLE
Enabled option to show node and bucket metrics

### DIFF
--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -39,24 +39,30 @@ var adminPrometheusMetricsCmd = cli.Command{
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 USAGE:
-  {{.HelpName}} TARGET
+  {{.HelpName}} TARGET [METRIC-TYPE]
+METRIC-TYPE:
+  valid values are ['node', 'bucket']. Defaults to 'cluster' if not passed.
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
   1. List of metrics reported cluster wide.
      {{.Prompt}} {{.HelpName}} play
+  2. List of metrics reported at node level.
+     {{.Prompt}} {{.HelpName}} play node
+  3. List of metrics reported at bucket level.
+     {{.Prompt}} {{.HelpName}} play bucket
 `,
 }
 
 const (
 	metricsRespBodyLimit = 10 << 20 // 10 MiB
-	metricsEndPoint      = "/minio/v2/metrics/cluster"
+	metricsEndPointRoot  = "/minio/v2/metrics/"
 )
 
 // checkSupportMetricsSyntax - validate arguments passed by a user
 func checkSupportMetricsSyntax(ctx *cli.Context) {
-	if len(ctx.Args()) == 0 || len(ctx.Args()) > 1 {
+	if len(ctx.Args()) == 0 || len(ctx.Args()) > 2 {
 		showCommandHelpAndExit(ctx, 1) // last argument is exit code
 	}
 }
@@ -79,8 +85,17 @@ func printPrometheusMetrics(ctx *cli.Context) error {
 	if e != nil {
 		return e
 	}
+	var metricsSubSystem string
+	switch args.Get(1) {
+	case "node":
+		metricsSubSystem = "node"
+	case "bucket":
+		metricsSubSystem = "bucket"
+	default:
+		metricsSubSystem = "cluster"
+	}
 
-	req, e := http.NewRequest(http.MethodGet, hostConfig.URL+metricsEndPoint, nil)
+	req, e := http.NewRequest(http.MethodGet, hostConfig.URL+metricsEndPointRoot+metricsSubSystem, nil)
 	if e != nil {
 		return e
 	}

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -89,16 +89,13 @@ func printPrometheusMetrics(ctx *cli.Context) error {
 	if e != nil {
 		return e
 	}
-	var metricsSubSystem string
-	switch args.Get(1) {
-	case "node":
-		metricsSubSystem = "node"
-	case "bucket":
-		metricsSubSystem = "bucket"
+	metricsSubSystem := args.Get(1)
+	switch metricsSubSystem {
+	case "node", "bucket", "cluster":
 	case "":
 		metricsSubSystem = "cluster"
 	default:
-		fatalIf(errInvalidArgument().Trace(), "invalid metric type '%v'", args.Get(1))
+		fatalIf(errInvalidArgument().Trace(), "invalid metric type '%v'", metricsSubSystem)
 	}
 
 	req, e := http.NewRequest(http.MethodGet, hostConfig.URL+metricsEndPointRoot+metricsSubSystem, nil)

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -95,8 +95,10 @@ func printPrometheusMetrics(ctx *cli.Context) error {
 		metricsSubSystem = "node"
 	case "bucket":
 		metricsSubSystem = "bucket"
-	default:
+	case "":
 		metricsSubSystem = "cluster"
+	default:
+		fatalIf(errInvalidArgument().Trace(), "invalid metric type '%v'", args.Get(1))
 	}
 
 	req, e := http.NewRequest(http.MethodGet, hostConfig.URL+metricsEndPointRoot+metricsSubSystem, nil)

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -40,16 +40,20 @@ var adminPrometheusMetricsCmd = cli.Command{
   {{.HelpName}} - {{.Usage}}
 USAGE:
   {{.HelpName}} TARGET [METRIC-TYPE]
+
 METRIC-TYPE:
-  valid values are ['node', 'bucket']. Defaults to 'cluster' if not passed.
+  valid values are ['cluster', 'node', 'bucket']. Defaults to 'cluster' if not specified.
+
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
   1. List of metrics reported cluster wide.
      {{.Prompt}} {{.HelpName}} play
+
   2. List of metrics reported at node level.
      {{.Prompt}} {{.HelpName}} play node
+
   3. List of metrics reported at bucket level.
      {{.Prompt}} {{.HelpName}} play bucket
 `,


### PR DESCRIPTION
## Description
Earlier the command `mc admin prometheus metrics ALIAS` used to display only the cluster level metrics. This change enables optionally to list node / bucket specific metrics.

## Motivation and Context
Enable listing of node and bucket specific metrics

## How to test this PR?
`mc admin prometheus metrics ALIAS node`
`mc admin prometheus metrics ALIAS bucket`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
