### PR TITLE
Ensure `--airgap` is available on all support commands

### DIFF
--- a/cmd/license-info.go
+++ b/cmd/license-info.go
@@ -37,7 +37,7 @@ var licenseInfoCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainLicenseInfo,
 	Before:       setGlobalsFromContext,
-	Flags:        append(supportGlobalFlags, subnetCommonFlags...),
+	Flags:        subnetCommonFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -46,7 +46,7 @@ var licenseRegisterCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainLicenseRegister,
 	Before:       setGlobalsFromContext,
-	Flags:        append(licenseRegisterFlags, supportGlobalFlags...),
+	Flags:        licenseRegisterFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/license-unregister.go
+++ b/cmd/license-unregister.go
@@ -36,7 +36,7 @@ var licenseUnregisterCmd = cli.Command{
 	Action:       mainLicenseUnregister,
 	Before:       setGlobalsFromContext,
 	Hidden:       true,
-	Flags:        append(supportGlobalFlags, subnetCommonFlags...),
+	Flags:        subnetCommonFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -60,17 +60,11 @@ MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEbo+e1wpBY4tBq9AONKww3Kq7m6QP/TBQ
 mr/cKCUyBL7rcAvg0zNq1vcSrUSGlAmY3SEDCu3GOKnjG/U4E7+p957ocWSV+mQU
 9NKlTdQFGF3+aO6jbQ4hX/S5qPyF+a3z
 -----END PUBLIC KEY-----` // https://localhost:9000/downloads/license-pubkey.pem
-	subnetCommonFlags = []cli.Flag{
-		cli.BoolFlag{
-			Name:  "airgap",
-			Usage: "use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
-		},
-		cli.StringFlag{
-			Name:   "api-key",
-			Usage:  "API Key of the account on SUBNET",
-			EnvVar: "_MC_SUBNET_API_KEY",
-		},
-	}
+	subnetCommonFlags = append(supportGlobalFlags, cli.StringFlag{
+		Name:   "api-key",
+		Usage:  "API Key of the account on SUBNET",
+		EnvVar: "_MC_SUBNET_API_KEY",
+	})
 )
 
 func subnetOfflinePublicKey() string {

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -54,16 +54,6 @@ var supportDiagFlags = append([]cli.Flag{
 		Value:  1 * time.Hour,
 		Hidden: true,
 	},
-	cli.StringFlag{
-		Name:   "license",
-		Usage:  "SUBNET license key",
-		Hidden: true, // deprecated dec 2021
-	},
-	cli.StringFlag{
-		Name:   "name",
-		Usage:  "Specify the name to associate to this MinIO cluster in SUBNET",
-		Hidden: true, // deprecated may 2022
-	},
 }, subnetCommonFlags...)
 
 var supportDiagCmd = cli.Command{
@@ -73,7 +63,7 @@ var supportDiagCmd = cli.Command{
 	OnUsageError: onUsageError,
 	Action:       mainSupportDiag,
 	Before:       setGlobalsFromContext,
-	Flags:        append(supportDiagFlags, supportGlobalFlags...),
+	Flags:        supportDiagFlags,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 

--- a/cmd/support-inspect.go
+++ b/cmd/support-inspect.go
@@ -57,7 +57,7 @@ var supportInspectCmd = cli.Command{
 	Action:          mainSupportInspect,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(supportInspectFlags, supportGlobalFlags...),
+	Flags:           supportInspectFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -91,7 +91,7 @@ var supportPerfCmd = cli.Command{
 	Action:          mainSupportPerf,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(supportPerfFlags, supportGlobalFlags...),
+	Flags:           supportPerfFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -54,7 +54,7 @@ var supportProfileCmd = cli.Command{
 	Action:          mainSupportProfile,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           append(profileFlags, supportGlobalFlags...),
+	Flags:           profileFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support-proxy-remove.go
+++ b/cmd/support-proxy-remove.go
@@ -76,6 +76,9 @@ func mainSupportProxyRemove(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
+	alias, _ := url2Alias(aliasedURL)
+
+	validateClusterRegistered(alias, false)
 
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)

--- a/cmd/support-proxy-set.go
+++ b/cmd/support-proxy-set.go
@@ -79,6 +79,9 @@ func mainSupportProxySet(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
+	alias, _ := url2Alias(aliasedURL)
+
+	validateClusterRegistered(alias, false)
 
 	// Create a new MinIO Admin Client
 	client := getClient(aliasedURL)

--- a/cmd/support-proxy-show.go
+++ b/cmd/support-proxy-show.go
@@ -82,6 +82,8 @@ func mainSupportProxyShow(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 	alias, _ := url2Alias(aliasedURL)
 
+	validateClusterRegistered(alias, false)
+
 	// Main execution
 	// get the subnet proxy config from MinIO if available
 	proxy, supported := getKeyFromSubnetConfig(alias, "proxy")

--- a/cmd/support-register.go
+++ b/cmd/support-register.go
@@ -34,7 +34,7 @@ var supportRegisterCmd = cli.Command{
 	OnUsageError:       onUsageError,
 	Action:             mainSupportRegister,
 	Before:             setGlobalsFromContext,
-	Flags:              append(supportRegisterFlags, supportGlobalFlags...),
+	Flags:              supportRegisterFlags,
 	CustomHelpTemplate: "Please use 'mc license register'",
 }
 

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -31,11 +31,17 @@ import (
 
 const supportSuccessMsgTag = "SupportSuccessMessage"
 
-var supportGlobalFlags = append(globalFlags, cli.BoolFlag{
-	Name:   "dev",
-	Usage:  "Development mode",
-	Hidden: true,
-})
+var supportGlobalFlags = append(globalFlags,
+	cli.BoolFlag{
+		Name:   "dev",
+		Usage:  "Development mode",
+		Hidden: true,
+	},
+	cli.BoolFlag{
+		Name:  "airgap",
+		Usage: "use in environments without network access to SUBNET (e.g. airgapped, firewalled, etc.)",
+	},
+)
 
 var supportSubcommands = []cli.Command{
 	supportRegisterCmd,


### PR DESCRIPTION
## Description

Ensure `--airgap` is available on all support commands

Also,

- remove deprecated and unused flags from `support diag`
- add missing registration check in
  - callhome status
  - proxy set|show|remove

## Motivation and Context

Consistent behavior across `mc support` commands

## How to test this PR?

- All commands under `mc support` should continue to work fine
- All of them should require the cluster to be registered
- All of them should allow the `--airgap` flag

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
