### PR TITLE
fix: with --purge flag ignore path validation errors

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -308,7 +308,8 @@ func removeSingle(url, versionID string, opts removeOpts) error {
 		case http.StatusBadRequest, http.StatusMethodNotAllowed:
 			ignoreStatError = true
 		default:
-			ignoreStatError = st == http.StatusServiceUnavailable && opts.isForce && opts.isForceDel
+			_, ok := pErr.ToGoError().(ObjectMissing)
+			ignoreStatError = (st == http.StatusServiceUnavailable || ok || st == http.StatusNotFound) && (opts.isForce && opts.isForceDel)
 			if !ignoreStatError {
 				errorIf(pErr.Trace(url), "Failed to remove `"+url+"`.")
 				return exitStatus(globalErrorExitStatus)


### PR DESCRIPTION
## Description
fix: with --purge flag ignore path validation errors

## Motivation and Context
`--purge` is used in situations where it needs to work

## How to test this PR?
try `mc rm --purge --force alias/bucket/non-existent-file` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
