### PR TITLE
admin-info: Include delete markers count

### DIFF
--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2023 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -284,6 +284,9 @@ func (u clusterStruct) String() (msg string) {
 			english.Plural(int(u.Info.Objects.Count), "Object", ""))
 		if u.Info.Versions.Count > 0 {
 			msg += ", " + english.Plural(int(u.Info.Versions.Count), "Version", "")
+		}
+		if u.Info.DeleteMarkers.Count > 0 {
+			msg += ", " + english.Plural(int(u.Info.DeleteMarkers.Count), "Delete Marker", "")
 		}
 		msg += "\n"
 	}


### PR DESCRIPTION
## Description
Add total number of delete markers to the usage summary section of admin-info output.

## Motivation and Context
To allow users to track unusual application behavior like creating excessive delete markers, usually since the application is not bucket versioning aware.

## How to test this PR?
`mc admin info ALIAS`
### Sample output
```
mc admin info play
●  play.min.io
   Uptime: 5 hours
   Version: 2023-07-19T05:25:12Z
   Network: 1/1 OK
   Drives: 4/4 OK
   Pool: 1

Pools:
   1st, Erasure sets: 1, Drives per erasure set: 4

11 GiB Used, 428 Buckets, 38,035 Objects, 54,636 Versions, 26,363 Delete Markers
4 drives online, 0 drives offline
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
