### PR TITLE
fix license register error in airgap mode

### DIFF
--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -153,13 +153,18 @@ type SubnetMFAReq struct {
 }
 
 func isPlay(endpoint url.URL) (bool, error) {
+	playEndpoint := "https://play.min.io"
+	if globalAirgapped {
+		return endpoint.String() == playEndpoint, nil
+	}
+
 	aliasIPs, e := net.LookupHost(endpoint.Hostname())
 	if e != nil {
 		return false, e
 	}
 	aliasIPSet := set.CreateStringSet(aliasIPs...)
 
-	playURL, e := url.Parse("https://play.min.io")
+	playURL, e := url.Parse(playEndpoint)
 	if e != nil {
 		return false, e
 	}


### PR DESCRIPTION
## Description

A network lookup was happening even in airgap mode, resulting in failure of the command.

## Motivation and Context

Bugfix

## How to test this PR?

- Ensure that your client machine doesn't have internet connectivity
- Run `mc license register <alias> --airgap`
- Verify that the command doesn't error out and prints the subnet url to be visited for registration

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (PR #4647)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
