### PR TITLE
mv: Do not error out when a bucket has an object lock config

### DIFF
--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -238,18 +238,6 @@ func mainMove(cliCtx *cli.Context) error {
 		}
 	}
 
-	// Check if source URLs does not have object locking enabled
-	// since we cannot move them (remove them from the source)
-	for _, urlStr := range cliCtx.Args()[:cliCtx.NArg()-1] {
-		enabled, err := isBucketLockEnabled(ctx, urlStr)
-		if err != nil {
-			fatalIf(err.Trace(), "Unable to get bucket lock configuration of `%s`", urlStr)
-		}
-		if enabled {
-			fatalIf(errDummy().Trace(), fmt.Sprintf("Object lock configuration is enabled on the specified bucket in alias %v.", urlStr))
-		}
-	}
-
 	// Additional command speific theme customization.
 	console.SetColor("Copy", color.New(color.FgGreen, color.Bold))
 


### PR DESCRIPTION
## Description
It appears that this code is coming from the old days when 
locking was implemented before versioning; It does not make 
sense now to make mv errors out when a bucket has a locking 
configuration.


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
