### PR TITLE
feat: Set top-level flags by env var

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -26,56 +26,67 @@ import (
 // Collection of mc flags currently supported
 var globalFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  "config-dir, C",
-		Value: mustGetMcConfigDir(),
-		Usage: "path to configuration folder",
+		Name:   "config-dir, C",
+		Value:  mustGetMcConfigDir(),
+		Usage:  "path to configuration folder",
+		EnvVar: "MINIO_CLIENT_CONFIG_DIR",
 	},
 	cli.BoolFlag{
-		Name:  "quiet, q",
-		Usage: "disable progress bar display",
+		Name:   "quiet, q",
+		Usage:  "disable progress bar display",
+		EnvVar: "MINIO_CLIENT_QUIET",
 	},
 	cli.BoolFlag{
-		Name:  "no-color",
-		Usage: "disable color theme",
+		Name:   "no-color",
+		Usage:  "disable color theme",
+		EnvVar: "MINIO_CLIENT_NO_COLOR",
 	},
 	cli.BoolFlag{
-		Name:  "json",
-		Usage: "enable JSON lines formatted output",
+		Name:   "json",
+		Usage:  "enable JSON lines formatted output",
+		EnvVar: "MINIO_CLIENT_JSON",
 	},
 	cli.BoolFlag{
-		Name:  "debug",
-		Usage: "enable debug output",
+		Name:   "debug",
+		Usage:  "enable debug output",
+		EnvVar: "MINIO_CLIENT_DEBUG",
 	},
 	cli.BoolFlag{
-		Name:  "insecure",
-		Usage: "disable SSL certificate verification",
+		Name:   "insecure",
+		Usage:  "disable SSL certificate verification",
+		EnvVar: "MINIO_CLIENT_INSECURE",
 	},
 	cli.StringFlag{
-		Name:  "limit-upload",
-		Usage: "limits uploads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		Name:   "limit-upload",
+		Usage:  "limits uploads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		EnvVar: "MINIO_CLIENT_LIMIT_UPLOAD",
 	},
 	cli.StringFlag{
-		Name:  "limit-download",
-		Usage: "limits downloads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		Name:   "limit-download",
+		Usage:  "limits downloads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		EnvVar: "MINIO_CLIENT_DOWNLOAD",
 	},
 	cli.DurationFlag{
 		Name:   "conn-read-deadline",
 		Usage:  "custom connection READ deadline",
 		Hidden: true,
 		Value:  10 * time.Minute,
+		EnvVar: "MINIO_CLIENT_CONN_READ_DEADLINE",
 	},
 	cli.DurationFlag{
 		Name:   "conn-write-deadline",
 		Usage:  "custom connection WRITE deadline",
 		Hidden: true,
 		Value:  10 * time.Minute,
+		EnvVar: "MINIO_CLIENT_CONN_WRITE_DEADLINE",
 	},
 }
 
 // Flags common across all I/O commands such as cp, mirror, stat, pipe etc.
 var ioFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  "encrypt-key",
-		Usage: "encrypt/decrypt objects (using server-side encryption with customer provided keys)",
+		Name:   "encrypt-key",
+		Usage:  "encrypt/decrypt objects (using server-side encryption with customer provided keys)",
+		EnvVar: "MINIO_CLIENT_ENCRYPT_KEY",
 	},
 }


### PR DESCRIPTION
## Contribution License
All contributions in this pull request are licensed to the project maintainers 
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

For all global flags, enable setting them via environment variable `MINIO_CLIENT_<flag name>`,
as per [minio/cli > Values From The Environment](https://github.com/minio/cli#values-from-the-environment).


## Motivation and Context

In scripts, adding e.g. `--config-dir <some path>` to each and every command is annoying.
Workarounds that put partial commands into variables do not improve readability of those scripts.

![image](https://github.com/minio/mc/assets/4246780/a04af7e2-bf02-4c0f-b166-3aefdb5ee2db)

When configuring deployments, setting environment variables is more convenient than changing scripts.


## How to test this PR?

Good question, have not looked into that. 😅 Would need guidance to add tests.

If no regression tests break, we should be clear on that front as we do not add or change functional code.
_Assuming_ `minio/cli` works as documented, the additions should have the desired affect. Not that that kind of argument has ever reassured anyone. ;)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
