### PR TITLE
add exclude-storageclass flag for mirror

### DIFF
--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -147,6 +147,19 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 			continue
 		}
 
+		if diffMsg.firstContent != nil {
+			var found bool
+			for _, esc := range opts.excludeStorageClasses {
+				if esc == diffMsg.firstContent.StorageClass {
+					found = true
+					break
+				}
+			}
+			if found {
+				continue
+			}
+		}
+
 		switch diffMsg.Diff {
 		case differInNone:
 			// No difference, continue.
@@ -203,14 +216,14 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 }
 
 type mirrorOptions struct {
-	isFake, isOverwrite, activeActive bool
-	isWatch, isRemove, isMetadata     bool
-	excludeOptions                    []string
-	encKeyDB                          map[string][]prefixSSEPair
-	md5, disableMultipart             bool
-	olderThan, newerThan              string
-	storageClass                      string
-	userMetadata                      map[string]string
+	isFake, isOverwrite, activeActive     bool
+	isWatch, isRemove, isMetadata         bool
+	excludeOptions, excludeStorageClasses []string
+	encKeyDB                              map[string][]prefixSSEPair
+	md5, disableMultipart                 bool
+	olderThan, newerThan                  string
+	storageClass                          string
+	userMetadata                          map[string]string
 }
 
 // Prepares urls that need to be copied or removed based on requested options.


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add exclude-storageclass flag for mirror

## Motivation and Context
this option exists to skip tiered objects such as

- "GLACIER"
- "DEEP_ARCHIVE"

users can use this option when migrating awss3 -> minio

```
mc mirror --exclude-storageclass GLACIER \
   --exclude-storageclass DEEP_ARCHIVE s3/bucket minio/bucket
```

## How to test this PR?
via `mc mirror --exclude-storageclass ..` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
