### PR TITLE
Add --bucket-bandwidth flag to `mc admin replicate update`

### DIFF
--- a/cmd/admin-replicate-info.go
+++ b/cmd/admin-replicate-info.go
@@ -18,8 +18,10 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
@@ -72,19 +74,36 @@ func (i srInfo) String() string {
 			Field{"Name", 15},
 			Field{"Endpoint", 46},
 			Field{"Sync", 4},
-		).buildRow("Deployment ID", "Site Name", "Endpoint", "Sync"))
+			Field{"Bandwidth", 10},
+		).buildRow("Deployment ID", "Site Name", "Endpoint", "Sync", "Bandwidth"))
+		messages = append(messages, r)
+
+		r = console.Colorize("THeaders", newPrettyTable(" | ",
+			Field{"Deployment ID", 36},
+
+			Field{"Name", 15},
+			Field{"Endpoint", 46},
+			Field{"Sync", 4},
+			Field{"Bandwidth", 10},
+		).buildRow("", "", "", "", "Per Bucket"))
 		messages = append(messages, r)
 		for _, peer := range info.Sites {
 			var chk string
 			if peer.SyncState == madmin.SyncEnabled {
 				chk = check
 			}
+			limit := "N/A" // N/A means cluster bandwidth is not configured
+			if peer.DefaultBandwidth.Limit > 0 {
+				limit = humanize.Bytes(uint64(peer.DefaultBandwidth.Limit * 8))
+				limit = fmt.Sprintf("%sb/s", limit[:len(limit)-1])
+			}
 			r := console.Colorize("TDetail", newPrettyTable(" | ",
 				Field{"Deployment ID", 36},
 				Field{"Name", 15},
 				Field{"Endpoint", 46},
 				Field{"Sync", 4},
-			).buildRow(peer.DeploymentID, peer.Name, peer.Endpoint, chk))
+				Field{"Bandwidth", 10},
+			).buildRow(peer.DeploymentID, peer.Name, peer.Endpoint, chk, limit))
 			messages = append(messages, r)
 		}
 	} else {

--- a/cmd/admin-replicate-update.go
+++ b/cmd/admin-replicate-update.go
@@ -48,7 +48,10 @@ var adminReplicateUpdateFlags = []cli.Flag{
 		Usage:  "enable synchronous replication for this target, valid values are ['enable', 'disable'].",
 		Value:  "disable",
 		Hidden: true, // deprecated Jul 2023
-
+	},
+	cli.StringFlag{
+		Name:  "bucket-bandwidth",
+		Usage: "Set default bandwidth limit for bucket in bits per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
 	},
 }
 
@@ -74,6 +77,9 @@ FLAGS:
 EXAMPLES:
   1. Edit a site endpoint participating in cluster-level replication:
      {{.Prompt}} {{.HelpName}} myminio --deployment-id c1758167-4426-454f-9aae-5c3dfdf6df64 --endpoint https://minio2:9000
+
+  2. Edit a site in cluster-level replication to set default bandwidth limit for bucket:
+     {{.Prompt}} {{.HelpName}} myminio --deployment-id c1758167-4426-454f-9aae-5c3dfdf6df64 --bucket-bandwidth "2G"
 `,
 }
 
@@ -122,8 +128,8 @@ func mainAdminReplicateUpdate(ctx *cli.Context) error {
 	if !ctx.IsSet("deployment-id") {
 		fatalIf(errInvalidArgument(), "--deployment-id is a required flag")
 	}
-	if !ctx.IsSet("endpoint") && !ctx.IsSet("mode") && !ctx.IsSet("sync") {
-		fatalIf(errInvalidArgument(), "--endpoint or --mode is a required flag")
+	if !ctx.IsSet("endpoint") && !ctx.IsSet("mode") && !ctx.IsSet("sync") && !ctx.IsSet("bucket-bandwidth") {
+		fatalIf(errInvalidArgument(), "--endpoint, --mode or --bucket-bandwidth is a required flag")
 	}
 	if ctx.IsSet("mode") && ctx.IsSet("sync") {
 		fatalIf(errInvalidArgument(), "either --sync or --mode flag should be specified")
@@ -150,6 +156,16 @@ func mainAdminReplicateUpdate(ctx *cli.Context) error {
 			fatalIf(errInvalidArgument().Trace(args...), "--mode can be either [sync|async]")
 		}
 	}
+
+	var bwDefaults madmin.BucketBandwidth
+	if ctx.IsSet("bucket-bandwidth") {
+		bandwidthStr := ctx.String("bucket-bandwidth")
+		bandwidth, e := getBandwidthInBytes(bandwidthStr)
+		fatalIf(probe.NewError(e).Trace(bandwidthStr), "invalid bandwidth value")
+
+		bwDefaults.Limit = bandwidth
+		bwDefaults.IsSet = true
+	}
 	var ep string
 	if ctx.IsSet("endpoint") {
 		parsedURL := ctx.String("endpoint")
@@ -160,9 +176,10 @@ func mainAdminReplicateUpdate(ctx *cli.Context) error {
 		ep = u.String()
 	}
 	res, e := client.SiteReplicationEdit(globalContext, madmin.PeerInfo{
-		DeploymentID: ctx.String("deployment-id"),
-		Endpoint:     ep,
-		SyncState:    madmin.SyncStatus(syncState),
+		DeploymentID:     ctx.String("deployment-id"),
+		Endpoint:         ep,
+		SyncState:        madmin.SyncStatus(syncState),
+		DefaultBandwidth: bwDefaults,
 	})
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to edit cluster replication site endpoint")
 


### PR DESCRIPTION
to allow default bucket bandwidth to be set in site replication

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?
with minio [PR](https://github.com/minio/minio/pull/18062) 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
