### PR TITLE
Add support for resource metrics

### DIFF
--- a/cmd/admin-prometheus-generate.go
+++ b/cmd/admin-prometheus-generate.go
@@ -31,12 +31,14 @@ import (
 )
 
 const (
-	defaultJobName     = "minio-job"
-	nodeJobName        = "minio-job-node"
-	bucketJobName      = "minio-job-bucket"
-	defaultMetricsPath = "/minio/v2/metrics/cluster"
-	nodeMetricsPath    = "/minio/v2/metrics/node"
-	bucketMetricsPath  = "/minio/v2/metrics/bucket"
+	defaultJobName      = "minio-job"
+	nodeJobName         = "minio-job-node"
+	bucketJobName       = "minio-job-bucket"
+	defaultMetricsPath  = "/minio/v2/metrics/cluster"
+	nodeMetricsPath     = "/minio/v2/metrics/node"
+	bucketMetricsPath   = "/minio/v2/metrics/bucket"
+	resourceJobName     = "minio-job-resource"
+	resourceMetricsPath = "/minio/v2/metrics/resource"
 )
 
 var prometheusFlags = []cli.Flag{
@@ -75,6 +77,9 @@ EXAMPLES:
 
   3. Generate prometheus config for bucket metrics.
      {{.Prompt}} {{.HelpName}} play bucket
+
+  4. Generate prometheus config for resource metrics.
+     {{.Prompt}} {{.HelpName}} play resource
 `,
 }
 
@@ -181,6 +186,20 @@ func generatePrometheusConfig(ctx *cli.Context) error {
 				{
 					JobName:     bucketJobName,
 					MetricsPath: bucketMetricsPath,
+					StaticConfigs: []StatConfig{
+						{
+							Targets: []string{""},
+						},
+					},
+				},
+			},
+		}
+	case "resource":
+		config = PrometheusConfig{
+			ScrapeConfigs: []ScrapeConfig{
+				{
+					JobName:     resourceJobName,
+					MetricsPath: resourceMetricsPath,
 					StaticConfigs: []StatConfig{
 						{
 							Targets: []string{""},

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -42,7 +42,7 @@ USAGE:
   {{.HelpName}} TARGET [METRIC-TYPE]
 
 METRIC-TYPE:
-  valid values are ['cluster', 'node', 'bucket']. Defaults to 'cluster' if not specified.
+  valid values are ['cluster', 'node', 'bucket', 'resource']. Defaults to 'cluster' if not specified.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
@@ -56,6 +56,9 @@ EXAMPLES:
 
   3. List of metrics reported at bucket level.
      {{.Prompt}} {{.HelpName}} play bucket
+
+  4. List of resource metrics.
+     {{.Prompt}} {{.HelpName}} play resource
 `,
 }
 
@@ -91,7 +94,7 @@ func printPrometheusMetrics(ctx *cli.Context) error {
 	}
 	metricsSubSystem := args.Get(1)
 	switch metricsSubSystem {
-	case "node", "bucket", "cluster":
+	case "node", "bucket", "cluster", "resource":
 	case "":
 		metricsSubSystem = "cluster"
 	default:


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add `resource` as an additional metric type in the command
`mc admin prometheus metrics`

## Motivation and Context

Support for resource metrics.

## How to test this PR?

Requires https://github.com/minio/minio/pull/18057

`mc admin prometheus metrics <alias> resource`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
