### PR TITLE
broaden reach of `--no-color` flag

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -24,10 +24,12 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 	"github.com/minio/cli"
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/pkg/v2/console"
+	"github.com/muesli/termenv"
 )
 
 const (
@@ -111,6 +113,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	// Disable colorified messages if requested.
 	if globalNoColor || globalQuiet {
 		console.SetColorOff()
+		lipgloss.SetColorProfile(termenv.Ascii)
 	}
 
 	globalConnReadDeadline = ctx.Duration("conn-read-deadline")


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Allow `--no-color` flag to affect commands that use lipgloss for formatting

## Motivation and Context
Fixes #4696 

## How to test this PR?
use `--no-color` on any command that uses lipgloss, like `mc admin policy entities` or `mc idp ldap info`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
