### PR TITLE
scanner: Limit the active disks if no enough term space

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -82,8 +82,8 @@ var (
 )
 
 var (
-	// Terminal width
-	globalTermWidth int
+	// Terminal height/width, zero if not found
+	globalTermWidth, globalTermHeight int
 
 	globalHelpPager *termPager
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cheggaaa/pb"
 	"github.com/inconshreveable/mousetrap"
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
@@ -42,6 +41,7 @@ import (
 	"github.com/minio/pkg/v2/env"
 	"github.com/minio/pkg/v2/trie"
 	"github.com/minio/pkg/v2/words"
+	"golang.org/x/term"
 
 	completeinstall "github.com/posener/complete/cmd/install"
 )
@@ -117,10 +117,10 @@ func Main(args []string) error {
 
 	// Fetch terminal size, if not available, automatically
 	// set globalQuiet to true.
-	if w, e := pb.GetTerminalWidth(); e != nil {
+	if w, h, e := term.GetSize(int(os.Stdin.Fd())); e != nil {
 		globalQuiet = true
 	} else {
-		globalTermWidth = w
+		globalTermWidth, globalTermHeight = w, h
 	}
 
 	// Set the mc app name.


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
If the terminal height is not enough to show the number of active disks, 
which is likley the case in a large deployment, print only few entries
until the number of lines reaches the terminal height.

## Motivation and Context
Do not overload mc admin scanner status screen with large deployments

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
