### PR TITLE
Validation optimization

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -108,12 +108,12 @@ func getEncKeys(ctx *cli.Context) (map[string][]prefixSSEPair, *probe.Error) {
 // Check if the passed URL represents a folder. It may or may not exist yet.
 // If it exists, we can easily check if it is a folder, if it doesn't exist,
 // we can guess if the url is a folder from how it looks.
-func isAliasURLDir(ctx context.Context, aliasURL string, keys map[string][]prefixSSEPair, timeRef time.Time) bool {
+func isAliasURLDir(ctx context.Context, aliasURL string, keys map[string][]prefixSSEPair, timeRef time.Time) (bool, *ClientContent) {
 	// If the target url exists, check if it is a directory
 	// and return immediately.
 	_, targetContent, err := url2Stat(ctx, aliasURL, "", false, keys, timeRef, false)
 	if err == nil {
-		return targetContent.Type.IsDir()
+		return targetContent.Type.IsDir(), targetContent
 	}
 
 	_, expandedURL, _ := mustExpandAlias(aliasURL)
@@ -121,7 +121,7 @@ func isAliasURLDir(ctx context.Context, aliasURL string, keys map[string][]prefi
 	// Check if targetURL is an FS or S3 aliased url
 	if expandedURL == aliasURL {
 		// This is an FS url, check if the url has a separator at the end
-		return strings.HasSuffix(aliasURL, string(filepath.Separator))
+		return strings.HasSuffix(aliasURL, string(filepath.Separator)), targetContent
 	}
 
 	// This is an S3 url, then:
@@ -134,14 +134,14 @@ func isAliasURLDir(ctx context.Context, aliasURL string, keys map[string][]prefi
 	switch len(fields) {
 	// Nothing or alias format
 	case 0, 1:
-		return false
+		return false, targetContent
 	// alias/bucket format
 	case 2:
-		return true
+		return true, targetContent
 	} // default case..
 
 	// alias/bucket/prefix format
-	return strings.HasSuffix(pathURL, "/")
+	return strings.HasSuffix(pathURL, "/"), targetContent
 }
 
 // getSourceStreamMetadataFromURL gets a reader from URL.

--- a/cmd/du-main.go
+++ b/cmd/du-main.go
@@ -243,8 +243,10 @@ func mainDu(cliCtx *cli.Context) error {
 	timeRef := parseRewindFlag(cliCtx.String("rewind"))
 
 	var duErr error
+	var isDir bool
 	for _, urlStr := range cliCtx.Args() {
-		if !isAliasURLDir(ctx, urlStr, nil, time.Time{}) {
+		isDir, _ = isAliasURLDir(ctx, urlStr, nil, time.Time{})
+		if !isDir {
 			fatalIf(errInvalidArgument().Trace(urlStr), fmt.Sprintf("Source `%s` is not a folder. Only folders are supported by 'du' command.", urlStr))
 		}
 

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -227,7 +227,7 @@ func mainMove(cliCtx *cli.Context) error {
 	}
 
 	// check 'copy' cli arguments.
-	checkCopySyntax(ctx, cliCtx, encKeyDB, true)
+	checkCopySyntax(ctx, cliCtx, encKeyDB)
 
 	if cliCtx.NArg() == 2 {
 		args := cliCtx.Args()

--- a/cmd/od-main.go
+++ b/cmd/od-main.go
@@ -105,7 +105,7 @@ func getOdUrls(ctx context.Context, args argKVS) (odURLs URLs, e error) {
 		sourceURLs: []string{inFile},
 		targetURL:  outFile,
 	}
-	odType, _, err := guessCopyURLType(ctx, opts)
+	odType, _, _, _, err := guessCopyURLType(ctx, opts)
 	fatalIf(err, "Unable to guess copy URL type")
 
 	// Get content of inFile, set up URLs.

--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -253,7 +253,7 @@ func checkRmSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[string
 		// Note: UNC path using / works properly in go 1.9.2 even though it breaks the UNC specification.
 		url = filepath.ToSlash(filepath.Clean(url))
 		// namespace removal applies only for non FS. So filter out if passed url represents a directory
-		dir := isAliasURLDir(ctx, url, encKeyDB, time.Time{})
+		dir, _ := isAliasURLDir(ctx, url, encKeyDB, time.Time{})
 		if dir {
 			_, path := url2Alias(url)
 			isNamespaceRemoval = (path == "")

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -39,6 +39,13 @@ var errInvalidArgument = func() *probe.Error {
 	return probe.NewError(invalidArgumentErr(errors.New(msg))).Untrace()
 }
 
+type unableToGuessErr error
+
+var errUnableToGuess = func() *probe.Error {
+	msg := "Unable to guess the type of copy operation."
+	return probe.NewError(unableToGuessErr(errors.New(msg)))
+}
+
 type unrecognizedDiffTypeErr error
 
 var errUnrecognizedDiffType = func(diff differType) *probe.Error {
@@ -97,6 +104,20 @@ var errInvalidTarget = func(URL string) *probe.Error {
 	return probe.NewError(invalidTargetErr(errors.New(msg))).Untrace()
 }
 
+type requiresRecuriveErr error
+
+var errRequiresRecursive = func(URL string) *probe.Error {
+	msg := "To copy or move '" + URL + "' the --recursive flag is required."
+	return probe.NewError(requiresRecuriveErr(errors.New(msg))).Untrace()
+}
+
+type CopyIntoSelfErr error
+
+var errCopyIntoSelf = func(URL string) *probe.Error {
+	msg := "Copying or moving '" + URL + "' into itself is not allowed."
+	return probe.NewError(CopyIntoSelfErr(errors.New(msg))).Untrace()
+}
+
 type targetNotFoundErr error
 
 var errTargetNotFound = func(URL string) *probe.Error {
@@ -111,6 +132,13 @@ type overwriteNotAllowedErr struct {
 var errOverWriteNotAllowed = func(URL string) *probe.Error {
 	msg := "Overwrite not allowed for `" + URL + "`. Use `--overwrite` to override this behavior."
 	return probe.NewError(overwriteNotAllowedErr{errors.New(msg)})
+}
+
+type targetIsNotDirErr error
+
+var errTargetIsNotDir = func(URL string) *probe.Error {
+	msg := "Target `" + URL + "` is not a folder."
+	return probe.NewError(targetIsNotDirErr(errors.New(msg))).Untrace()
 }
 
 type sourceIsDirErr error

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -983,6 +983,11 @@ function test_admin_users()
     # create a user
     username=foo
     password=foobar12345
+    test_alias="aliasx"
+		
+		# Remove user incase the user was created and not removed due to a failed test
+    mc_cmd admin user remove "$SERVER_ALIAS" "$username"
+
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin user add "$SERVER_ALIAS" "$username" "$password"
 
     # check that user appears in the user list
@@ -993,49 +998,61 @@ function test_admin_users()
     # setup temporary alias to make requests as the created user.
     scheme="https"
     if [ "$ENABLE_HTTPS" != "1" ]; then
-	scheme="http"
+	  scheme="http"
     fi
     object1_name="mc-test-object-$RANDOM"
     object2_name="mc-test-object-$RANDOM"
-    export MC_HOST_foo="${scheme}://${username}:${password}@${SERVER_ENDPOINT}"
+
+    # Adding an alias for the $test_alias
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd alias set $test_alias "${scheme}://${SERVER_ENDPOINT}" ${username} ${password} 
+
+    # check that alias appears in the alias list
+    "${MC_CMD[@]}" --json alias list | jq -r '.alias' | grep --quiet "^${test_alias}$"
+    rv=$?
+    assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure ${rv} "alias ${test_alias} did NOT appear in the list of aliases returned by server"
 
     # check that the user can write objects with readwrite policy
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin policy attach "$SERVER_ALIAS" readwrite --user="${username}"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_1_MB" "foo/${BUCKET_NAME}/${object1_name}"
+
+    # Validate that the correct policy has been added to the user
+    "${MC_CMD[@]}" --json admin user list "${SERVER_ALIAS}" | jq -r '.policyName' | grep --quiet "^readwrite$"
+    rv=$?
+    assert_success "$start_time" "${FUNCNAME[0]}" show_on_failure ${rv} "user ${username} did NOT have the readwrite policy attached"
+
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${test_alias}/${BUCKET_NAME}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_1_MB" "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     # check that the user cannot write objects with readonly policy
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin policy detach "$SERVER_ALIAS" readwrite --user="${username}"
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin policy attach "$SERVER_ALIAS" readonly --user="${username}"
-    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_1_MB" "foo/${BUCKET_NAME}/${object2_name}"
+    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_1_MB" "${test_alias}/${BUCKET_NAME}/${object2_name}"
 
     # check that the user can read with readonly policy
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cat "foo/${BUCKET_NAME}/${object1_name}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cat "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     # check that user can delete with readwrite policy
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin policy attach "$SERVER_ALIAS" readwrite --user="${username}"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm "foo/${BUCKET_NAME}/${object1_name}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     # check that user cannot perform admin actions with readwrite policy
-    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd admin info "foo"
+    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd admin info $test_alias
 
     # create object1_name for subsequent tests.
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_1_MB" "foo/${BUCKET_NAME}/${object1_name}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_1_MB" "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     # check that user can be disabled
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin user disable "$SERVER_ALIAS" "$username"
 
     # check that disabled cannot perform any action
-    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd cat "foo/${BUCKET_NAME}/${object1_name}"
+    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd cat "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     # check that user can be enabled and can then perform an allowed action
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin user enable "$SERVER_ALIAS" "$username"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cat "foo/${BUCKET_NAME}/${object1_name}"
+    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cat "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     # check that user can be removed, and then is no longer available
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin user remove "$SERVER_ALIAS" "$username"
-    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd cat "foo/${BUCKET_NAME}/${object1_name}"
-
-    unset MC_HOST_foo
+    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd cat "${test_alias}/${BUCKET_NAME}/${object1_name}"
 
     log_success "$start_time" "${FUNCNAME[0]}"
 }
@@ -1162,8 +1179,20 @@ function __init__()
     set +e
 }
 
+function validate_dependencies() {
+	jqVersion=$(jq --version)
+	if [[ $jqVersion == *"jq"* ]]; then
+		echo "Dependency validation complete"
+	else
+		echo "jq is missing, please install: 'sudo apt install jq'"
+		exit 1
+	fi
+}
+
 function main()
 {
+		validate_dependencies
+
     ( run_test )
     rv=$?
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This pull request provides performance optimizations for the mv and cp commands along with some minor cleanup and validation refactor. 

## Related Issues
https://github.com/minio/mc/issues/3149

## Motivation and Context
During some cp and mv operations the mc client makes too many HEAD calls. These head calls were being made on multiple levels of execution so in order to reduce the overhead a sizable cleanup was required. </br>

### The Validation layer
The main offender here was the [checkCopySyntax](https://github.com/minio/mc/blob/master/cmd/cp-url-syntax.go#L31) function. On [Line 61](https://github.com/minio/mc/blob/eca8310ac822cf0e533c6bd3fb85c8d6099d1465/cmd/cp-url-syntax.go#L61) the function validates object existance, however, the objects existance is validate numerous times through out the process making this redundant. The next offender start on [line 111](https://github.com/minio/mc/blob/eca8310ac822cf0e533c6bd3fb85c8d6099d1465/cmd/cp-url-syntax.go#L111), this is the initial syntax validation. This validation method calls for HEAD multiple times to validate the syntax. 

### Merging URL generation and Syntax Validation
The simplest way to reduce the number of HEAD calls is to no repeat that operation multiple times for the same object. This means passing already known information down the execution path. The simplest way to achieve this goal was to merge the validation and URL generation layer since the URL generation layer has it's own requirement on HEAD checking. It would not have been wise  to merge the URL generation layer up into the validation layer since the logic behind the URL generation is much more complex.

### This is an example trace of a file being moved from a local filesystem to a bucket
```bash
2023-10-10T08:20:35.958 [200 OK] s3.GetBucketLocation 192.168.2.10:9000/bb1/?location=  192.168.2.10     176µs       ⇣  165.972µs  ↑ 77 B ↓ 128 B
2023-10-10T08:20:35.959 [200 OK] s3.HeadObject 192.168.2.10:9000/bb1/m 192.168.2.10     6.663ms      ⇣  0s         ↑ 77 B ↓ 0 B
2023-10-10T08:20:35.967 [200 OK] s3.HeadObject 192.168.2.10:9000/bb1/m 192.168.2.10     200µs       ⇣  0s         ↑ 77 B ↓ 0 B
2023-10-10T08:20:35.967 [200 OK] s3.HeadObject 192.168.2.10:9000/bb1/m 192.168.2.10     209µs       ⇣  0s         ↑ 77 B ↓ 0 B
2023-10-10T08:20:35.968 [200 OK] s3.HeadObject 192.168.2.10:9000/bb1/m 192.168.2.10     190µs       ⇣  0s         ↑ 77 B ↓ 0 B
2023-10-10T08:20:35.969 [200 OK] s3.HeadObject 192.168.2.10:9000/bb1/m 192.168.2.10     174µs       ⇣  0s         ↑ 77 B ↓ 0 B
2023-10-10T08:20:35.970 [200 OK] s3.HeadObject 192.168.2.10:9000/bb1/m 192.168.2.10     174µs       ⇣  0s         ↑ 77 B ↓ 0 B
2023-10-10T08:20:35.971 [200 OK] s3.GetObject 192.168.2.10:9000/bb1/m 192.168.2.10     24.561ms     ⇣  1.507702ms  ↑ 86 B ↓ 25 MiB

```

## How to test this PR?
There is a functional-tests.sh script in the root of the project. 

**NOTE**: The **test_admin_users** functional test seems to be broken and I could not figure out why it's not working. It has nothing to do with my current changes and I suspect it's been broken for a while. I did refactor the **test_admin_users** test a bit and I opened a discussion on slack about it.

```bash
$ ./functional-tests.sh
```

## Types of changes
- [ x ] Optimization (provides speedup with no functional changes)

## Checklist:
- [ x ] Unit tests added/updated

