### PR TITLE
Created a retry mechanism and added a --retry flag to mc mirror

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -488,7 +488,7 @@ func (mj *mirrorJob) doMirror(ctx context.Context, sURLs URLs) URLs {
 		return ret
 	}
 
-	newRetryManager(ctx, time.Second, 3).encapsulateWithRetry(func(rm *retryManager) *probe.Error {
+	newRetryManager(ctx, time.Second, 3).retry(func(rm *retryManager) *probe.Error {
 		if rm.retries > 0 {
 			printMsg(retryMessage{
 				SourceURL: sURLs.SourceContent.URL.String(),

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -129,6 +129,10 @@ var (
 			Name:  "monitoring-address",
 			Usage: "if specified, a new prometheus endpoint will be created to report mirroring activity. (eg: localhost:8081)",
 		},
+		cli.BoolFlag{
+			Name:  "retry",
+			Usage: "if specified, will enable retrying on a per object basis if errors occur",
+		},
 	}
 )
 
@@ -471,12 +475,38 @@ func (mj *mirrorJob) doMirror(ctx context.Context, sURLs URLs) URLs {
 	sURLs.MD5 = mj.opts.md5
 	sURLs.DisableMultipart = mj.opts.disableMultipart
 
-	now := time.Now()
-	ret := uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.opts.encKeyDB, mj.opts.isMetadata, false)
-	if ret.Error == nil {
-		durationMs := time.Since(now).Milliseconds()
-		mirrorReplicationDurations.With(prometheus.Labels{"object_size": convertSizeToTag(sURLs.SourceContent.Size)}).Observe(float64(durationMs))
+	var ret URLs
+
+	if !mj.opts.isRetriable {
+		now := time.Now()
+		ret = uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.opts.encKeyDB, mj.opts.isMetadata, false)
+		if ret.Error == nil {
+			durationMs := time.Since(now).Milliseconds()
+			mirrorReplicationDurations.With(prometheus.Labels{"object_size": convertSizeToTag(sURLs.SourceContent.Size)}).Observe(float64(durationMs))
+		}
+
+		return ret
 	}
+
+	newRetryManager(ctx, time.Second*1, 3).encapsulateWithRetry(func(rm *retryManager) *probe.Error {
+		if rm.retries > 0 {
+			printMsg(retryMessage{
+				SourceURL: sURLs.SourceContent.URL.String(),
+				TargetURL: sURLs.TargetContent.URL.String(),
+				Retries:   rm.retries,
+			})
+		}
+
+		now := time.Now()
+		ret = uploadSourceToTargetURL(ctx, sURLs, mj.status, mj.opts.encKeyDB, mj.opts.isMetadata, false)
+		if ret.Error == nil {
+			durationMs := time.Since(now).Milliseconds()
+			mirrorReplicationDurations.With(prometheus.Labels{"object_size": convertSizeToTag(sURLs.SourceContent.Size)}).Observe(float64(durationMs))
+		}
+
+		return ret.Error
+	})
+
 	return ret
 }
 
@@ -913,6 +943,7 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 		isOverwrite:           isOverwrite,
 		isWatch:               isWatch,
 		isMetadata:            isMetadata,
+		isRetriable:           cli.Bool("retry"),
 		md5:                   cli.Bool("md5"),
 		disableMultipart:      cli.Bool("disable-multipart"),
 		excludeOptions:        cli.StringSlice("exclude"),

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -488,7 +488,7 @@ func (mj *mirrorJob) doMirror(ctx context.Context, sURLs URLs) URLs {
 		return ret
 	}
 
-	newRetryManager(ctx, time.Second*1, 3).encapsulateWithRetry(func(rm *retryManager) *probe.Error {
+	newRetryManager(ctx, time.Second, 3).encapsulateWithRetry(func(rm *retryManager) *probe.Error {
 		if rm.retries > 0 {
 			printMsg(retryMessage{
 				SourceURL: sURLs.SourceContent.URL.String(),

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -218,6 +218,7 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 type mirrorOptions struct {
 	isFake, isOverwrite, activeActive     bool
 	isWatch, isRemove, isMetadata         bool
+	isRetriable                           bool
 	excludeOptions, excludeStorageClasses []string
 	encKeyDB                              map[string][]prefixSSEPair
 	md5, disableMultipart                 bool

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -45,7 +45,7 @@ func (r retryMessage) JSON() string {
 	return string(jsonMessageBytes)
 }
 
-func (r *retryManager) encapsulateWithRetry(action func(*retryManager) *probe.Error) {
+func (r *retryManager) retry(action func(context.Context, *retryManager) *probe.Error) {
 	for r.retries <= r.maxRetries {
 		if r.shouldStop {
 			return

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	json "github.com/minio/colorjson"
+	"github.com/minio/mc/pkg/probe"
+)
+
+type retryManager struct {
+	retries       int
+	maxRetries    int
+	retryInterval time.Duration
+	shouldStop    bool
+	ctx           context.Context
+}
+
+func newRetryManager(ctx context.Context, retryInterval time.Duration, maxRetries int) *retryManager {
+	return &retryManager{
+		retryInterval: retryInterval,
+		maxRetries:    maxRetries,
+		ctx:           ctx,
+	}
+}
+
+type retryMessage struct {
+	SourceURL string `json:"sourceURL"`
+	TargetURL string `json:"targetURL"`
+	Retries   int    `json:"retries"`
+}
+
+func (r *retryManager) Stop() {
+	r.shouldStop = true
+}
+
+func (r retryMessage) String() string {
+	return fmt.Sprintf("<INFO> Retries %d: source `%s` >> target `%s`", r.Retries, r.SourceURL, r.TargetURL)
+}
+
+func (r retryMessage) JSON() string {
+	jsonMessageBytes, e := json.MarshalIndent(r, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+	return string(jsonMessageBytes)
+}
+
+func (r *retryManager) encapsulateWithRetry(action func(*retryManager) *probe.Error) {
+	for r.retries <= r.maxRetries {
+		if r.shouldStop {
+			return
+		}
+
+		err := action(r)
+		if err == nil || r.ctx.Err() != nil {
+			return
+		}
+
+		_ = <-time.After(r.retryInterval)
+
+		r.retries++
+	}
+	return
+}

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -56,7 +56,7 @@ func (r *retryManager) encapsulateWithRetry(action func(*retryManager) *probe.Er
 			return
 		}
 
-		<-time.After(r.retryInterval)
+		<-time.After(r.retryInterval/2 + time.Duration(rand.Int63n(int64(r.retryInterval))))
 
 		r.retries++
 	}

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -56,9 +56,8 @@ func (r *retryManager) encapsulateWithRetry(action func(*retryManager) *probe.Er
 			return
 		}
 
-		_ = <-time.After(r.retryInterval)
+		<-time.After(r.retryInterval)
 
 		r.retries++
 	}
-	return
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
There are failure cases when doing transfers that are not recoverable in the minio-go library. These cases can be recovered from at a higher level (more specifically in the mc client). This pull request implements a very basic retry mechanism which can be used to encapsulate any logic. 

## Notes
The retry mechanism is only encapsulating the mc mirror command for now. But we could expand it to encapsulate all transfers, eventually.

There are a few github issues which have been reported with failure cases (not bugs) which **might** be avoided with this retry mechanism:
https://github.com/minio/mc/issues/4635
https://github.com/minio/mc/issues/4231
https://github.com/minio/mc/issues/3075
https://github.com/minio/mc/issues/3965 (this one might have been a filesystem issue)
https://github.com/minio/mc/issues/4138
https://github.com/minio/mc/issues/4202

## How to test this PR?
```bash
$ ./functional-tests.sh
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
