### PR TITLE
allow 'mc' flags to have ENV equivalent

### DIFF
--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -77,12 +77,8 @@ func parseKey(sseKeys string) (sse string, err *probe.Error) {
 
 // parse and return encryption key pairs per alias.
 func getEncKeys(ctx *cli.Context) (map[string][]prefixSSEPair, *probe.Error) {
-	sseServer := os.Getenv("MC_ENCRYPT")
-	if prefix := ctx.String("encrypt"); prefix != "" {
-		sseServer = prefix
-	}
-
-	sseKeys := os.Getenv("MC_ENCRYPT_KEY")
+	sseServer := ctx.String("encrypt")
+	var sseKeys string
 	if keyPrefix := ctx.String("encrypt-key"); keyPrefix != "" {
 		if sseServer != "" && strings.Contains(keyPrefix, sseServer) {
 			return nil, errConflictSSE(sseServer, keyPrefix).Trace(ctx.Args()...)

--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -64,10 +64,6 @@ var (
 			Usage: "set storage class for new object(s) on target",
 		},
 		cli.StringFlag{
-			Name:  "encrypt",
-			Usage: "encrypt/decrypt objects (using server-side encryption with server managed keys)",
-		},
-		cli.StringFlag{
 			Name:  "attr",
 			Usage: "add custom metadata for the object",
 		},

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -23,40 +23,50 @@ import (
 	"github.com/minio/cli"
 )
 
+const envPrefix = "MC_"
+
 // Collection of mc flags currently supported
 var globalFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  "config-dir, C",
-		Value: mustGetMcConfigDir(),
-		Usage: "path to configuration folder",
+		Name:   "config-dir, C",
+		Value:  mustGetMcConfigDir(),
+		Usage:  "path to configuration folder",
+		EnvVar: envPrefix + "CONFIG_DIR",
 	},
 	cli.BoolFlag{
-		Name:  "quiet, q",
-		Usage: "disable progress bar display",
+		Name:   "quiet, q",
+		Usage:  "disable progress bar display",
+		EnvVar: envPrefix + "QUIET",
 	},
 	cli.BoolFlag{
-		Name:  "no-color",
-		Usage: "disable color theme",
+		Name:   "no-color",
+		Usage:  "disable color theme",
+		EnvVar: envPrefix + "NO_COLOR",
 	},
 	cli.BoolFlag{
-		Name:  "json",
-		Usage: "enable JSON lines formatted output",
+		Name:   "json",
+		Usage:  "enable JSON lines formatted output",
+		EnvVar: envPrefix + "JSON",
 	},
 	cli.BoolFlag{
-		Name:  "debug",
-		Usage: "enable debug output",
+		Name:   "debug",
+		Usage:  "enable debug output",
+		EnvVar: envPrefix + "DEBUG",
 	},
 	cli.BoolFlag{
-		Name:  "insecure",
-		Usage: "disable SSL certificate verification",
+		Name:   "insecure",
+		Usage:  "disable SSL certificate verification",
+		EnvVar: envPrefix + "INSECURE",
 	},
 	cli.StringFlag{
-		Name:  "limit-upload",
-		Usage: "limits uploads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		Name:   "limit-upload",
+		Usage:  "limits uploads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		EnvVar: envPrefix + "LIMIT_UPLOAD",
 	},
 	cli.StringFlag{
-		Name:  "limit-download",
-		Usage: "limits downloads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		Name:   "limit-download",
+		Usage:  "limits downloads to a maximum rate in KiB/s, MiB/s, GiB/s. (default: unlimited)",
+		EnvVar: envPrefix + "LIMIT_DOWNLOAD",
 	},
 	cli.DurationFlag{
 		Name:   "conn-read-deadline",
@@ -75,7 +85,13 @@ var globalFlags = []cli.Flag{
 // Flags common across all I/O commands such as cp, mirror, stat, pipe etc.
 var ioFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  "encrypt-key",
-		Usage: "encrypt/decrypt objects (using server-side encryption with customer provided keys)",
+		Name:   "encrypt-key",
+		Usage:  "encrypt/decrypt objects (using server-side encryption with customer provided keys)",
+		EnvVar: envPrefix + "ENCRYPT_KEY",
+	},
+	cli.StringFlag{
+		Name:   "encrypt",
+		Usage:  "encrypt/decrypt objects (using server-side encryption with server managed keys)",
+		EnvVar: envPrefix + "ENCRYPT",
 	},
 }

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -118,10 +118,6 @@ var (
 			Usage: "specify storage class for new object(s) on target",
 		},
 		cli.StringFlag{
-			Name:  "encrypt",
-			Usage: "encrypt/decrypt objects (using server-side encryption with server managed keys)",
-		},
-		cli.StringFlag{
 			Name:  "attr",
 			Usage: "add custom metadata for all objects",
 		},

--- a/cmd/mv-main.go
+++ b/cmd/mv-main.go
@@ -49,10 +49,6 @@ var (
 			Usage: "set storage class for new object(s) on target",
 		},
 		cli.StringFlag{
-			Name:  "encrypt",
-			Usage: "encrypt/decrypt objects (using server-side encryption with server managed keys)",
-		},
-		cli.StringFlag{
 			Name:  "attr",
 			Usage: "add custom metadata for the object",
 		},

--- a/cmd/pipe-main.go
+++ b/cmd/pipe-main.go
@@ -36,10 +36,6 @@ func defaultPartSize() string {
 
 var pipeFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  "encrypt",
-		Usage: "encrypt objects (using server-side encryption with server managed keys)",
-	},
-	cli.StringFlag{
 		Name:  "storage-class, sc",
 		Usage: "set storage class for new object(s) on target",
 	},


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
allow 'mc' flags to have ENV equivalent

## Motivation and Context
it simplifies the codebase a bit and also
allows for `mc` to easily be configured in
containerized environments.

## How to test this PR?
Nothing must change with this introduction
only change is the ease of use.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
