### PR TITLE
Fix missing colours on windows

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,9 +116,9 @@ func Main(args []string) error {
 	probe.SetAppInfo("Commit", ShortCommitID)
 
 	// Fetch terminal size, if not available, automatically
-	// set globalQuiet to true.
+	// set globalQuiet to on non-window.
 	if w, h, e := term.GetSize(int(os.Stdin.Fd())); e != nil {
-		globalQuiet = true
+		globalQuiet = runtime.GOOS != "windows"
 	} else {
 		globalTermWidth, globalTermHeight = w, h
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,7 +116,7 @@ func Main(args []string) error {
 	probe.SetAppInfo("Commit", ShortCommitID)
 
 	// Fetch terminal size, if not available, automatically
-	// set globalQuiet to on non-window.
+	// set globalQuiet to true on non-window.
 	if w, h, e := term.GetSize(int(os.Stdin.Fd())); e != nil {
 		globalQuiet = runtime.GOOS != "windows"
 	} else {


### PR DESCRIPTION
## Description

#4705 removed all color from Windows output.

## Motivation and Context

The world should have color diversity.

## How to test this PR?

Run any command on Windows. Observe greyness.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Fixes a regression #4705
