### PR TITLE
add support for min/max time in 'trace --stats'

### DIFF
--- a/cmd/admin-scanner-status.go
+++ b/cmd/admin-scanner-status.go
@@ -224,13 +224,20 @@ func (m *scannerMetricsUI) View() string {
 		s.WriteString(fmt.Sprintf("%s %s\n", console.Colorize("metrics-top-title", "Scanner Activity:"), m.spinner.View()))
 	}
 
-	// Set table header
+	// Set table header - akin to k8s style
+	// https://github.com/olekukonko/tablewriter#example-10---set-nowhitespace-and-tablepadding-option
 	table := tablewriter.NewWriter(&s)
 	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetBorder(true)
-	table.SetRowLine(false)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
 
 	writtenRows := 0
 	addRow := func(s string) {
@@ -253,9 +260,12 @@ func (m *scannerMetricsUI) View() string {
 	title := metricsTitle
 	ui := metricsUint64
 	const wantCycles = 16
+	addRow("")
 	if len(sc.CyclesCompletedAt) < 2 {
-		addRow("Scan time:             Unknown (not enough data)")
+		addRow("Last full scan time:             Unknown (not enough data)")
 	} else {
+		addRow("Overall Statistics")
+		addRow("------------------")
 		sort.Slice(sc.CyclesCompletedAt, func(i, j int) bool {
 			return sc.CyclesCompletedAt[i].After(sc.CyclesCompletedAt[j])
 		})
@@ -286,7 +296,9 @@ func (m *scannerMetricsUI) View() string {
 		}
 		return ""
 	}
-	addRow("-------------------------------------- Last Minute Statistics ---------------------------------------")
+	addRow("")
+	addRow("Last Minute Statistics")
+	addRow("----------------------")
 	objs := uint64(0)
 	x := sc.LastMinute.Actions["ScanObject"]
 	{


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add support for min/max time in 'trace --stats'

## Motivation and Context
also change the UI to match a k8s'isk style
output.

```
mc admin trace play/ --stats
Duration: 12s ●∙∙
Call                    Count           RPM     Avg Time        Min Time        Max Time        Errors  RX Avg  TX Avg
s3.GetBucketLocation    22 (48.9%)      107.8   431µs           205.196µs       1.360389ms      0       135 B   137 B
s3.ListObjectsV2        22 (48.9%)      107.8   1.615ms         520.96µs        6.821432ms      0       135 B   2.3 KiB
s3.ListBuckets          1 (2.2%)        4.9     2.302ms         2.301694ms      2.301694ms      0       135 B   29 KiB
```

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
