### PR TITLE
use ubi-micro instead of ubi-minimal

### DIFF
--- a/Dockerfile.hotfix
+++ b/Dockerfile.hotfix
@@ -1,17 +1,24 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
 
+RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs && microdnf clean all
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
+
+ARG TARGETARCH
 ARG RELEASE
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
+
+# On RHEL the certificate bundle is located at:
+# - /etc/pki/tls/certs/ca-bundle.crt (RHEL 6)
+# - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (RHEL 7)
+COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 
 COPY CREDITS /licenses/CREDITS
 COPY LICENSE /licenses/LICENSE
 
 RUN \
-    microdnf update --nodocs && \
-    microdnf install curl ca-certificates shadow-utils --nodocs && \
-    microdnf clean all && \
-    curl -s -q https://dl.min.io/client/mc/hotfixes/linux-amd64/archive/mc.${RELEASE} -o /usr/bin/mc && \
+    curl -s -q https://dl.minio.io/client/mc/release/linux-${TARGETARCH}/archive/mc.${RELEASE} -o /usr/bin/mc && \
     chmod +x /usr/bin/mc
 
 ENTRYPOINT ["mc"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,18 +1,23 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+
+RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs && microdnf clean all
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
 
 ARG TARGETARCH
-
 ARG RELEASE
 
 LABEL maintainer="MinIO Inc <dev@min.io>"
+
+# On RHEL the certificate bundle is located at:
+# - /etc/pki/tls/certs/ca-bundle.crt (RHEL 6)
+# - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (RHEL 7)
+COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
 
 COPY CREDITS /licenses/CREDITS
 COPY LICENSE /licenses/LICENSE
 
 RUN \
-    microdnf update --nodocs && \
-    microdnf install curl ca-certificates shadow-utils util-linux gzip lsof tar net-tools jq --nodocs && \
-    microdnf clean all && \
     curl -s -q https://dl.minio.io/client/mc/release/linux-${TARGETARCH}/archive/mc.${RELEASE} -o /usr/bin/mc && \
     chmod +x /usr/bin/mc
 

--- a/cmd/client-fs_test.go
+++ b/cmd/client-fs_test.go
@@ -25,19 +25,19 @@ import (
 	"path/filepath"
 	"runtime"
 
-	. "gopkg.in/check.v1"
+	checkv1 "gopkg.in/check.v1"
 )
 
 // Test list files in a folder.
-func (s *TestSuite) TestList(c *C) {
+func (s *TestSuite) TestList(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	// Create multiple files.
 	objectPath := filepath.Join(root, "object1")
 	fsClient, err := fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	data := "hello"
 
@@ -49,12 +49,12 @@ func (s *TestSuite) TestList(c *C) {
 		},
 	},
 	)
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	objectPath = filepath.Join(root, "object2")
 	fsClient, err = fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
@@ -62,11 +62,11 @@ func (s *TestSuite) TestList(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	fsClient, err = fsNew(root)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	// Verify previously create files and list them.
 	var contents []*ClientContent
@@ -77,14 +77,14 @@ func (s *TestSuite) TestList(c *C) {
 		}
 		contents = append(contents, content)
 	}
-	c.Assert(err, IsNil)
-	c.Assert(len(contents), Equals, 1)
-	c.Assert(contents[0].Type.IsDir(), Equals, true)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(len(contents), checkv1.Equals, 1)
+	c.Assert(contents[0].Type.IsDir(), checkv1.Equals, true)
 
 	// Create another file.
 	objectPath = filepath.Join(root, "test1/newObject1")
 	fsClient, err = fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
@@ -92,11 +92,11 @@ func (s *TestSuite) TestList(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	fsClient, err = fsNew(root)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	contents = nil
 	// List non recursive to list only top level files.
@@ -107,12 +107,12 @@ func (s *TestSuite) TestList(c *C) {
 		}
 		contents = append(contents, content)
 	}
-	c.Assert(err, IsNil)
-	c.Assert(len(contents), Equals, 1)
-	c.Assert(contents[0].Type.IsDir(), Equals, true)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(len(contents), checkv1.Equals, 1)
+	c.Assert(contents[0].Type.IsDir(), checkv1.Equals, true)
 
 	fsClient, err = fsNew(root)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	contents = nil
 	// List recursively all files and verify.
@@ -124,8 +124,8 @@ func (s *TestSuite) TestList(c *C) {
 		contents = append(contents, content)
 	}
 
-	c.Assert(err, IsNil)
-	c.Assert(len(contents), Equals, 3)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(len(contents), checkv1.Equals, 3)
 
 	var regularFiles int
 	var regularDirs int
@@ -140,13 +140,13 @@ func (s *TestSuite) TestList(c *C) {
 			continue
 		}
 	}
-	c.Assert(regularDirs, Equals, 0)
-	c.Assert(regularFiles, Equals, 3)
+	c.Assert(regularDirs, checkv1.Equals, 0)
+	c.Assert(regularFiles, checkv1.Equals, 3)
 
 	// Create an ignored file and list to verify if its ignored.
 	objectPath = filepath.Join(root, "test1/.DS_Store")
 	fsClient, err = fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	reader = bytes.NewReader([]byte(data))
 	n, err = fsClient.Put(context.Background(), reader, int64(len(data)), nil, PutOptions{
@@ -154,11 +154,11 @@ func (s *TestSuite) TestList(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	fsClient, err = fsNew(root)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	contents = nil
 	// List recursively all files and verify.
@@ -170,12 +170,12 @@ func (s *TestSuite) TestList(c *C) {
 		contents = append(contents, content)
 	}
 
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	switch runtime.GOOS {
 	case "darwin":
-		c.Assert(len(contents), Equals, 3)
+		c.Assert(len(contents), checkv1.Equals, 3)
 	default:
-		c.Assert(len(contents), Equals, 4)
+		c.Assert(len(contents), checkv1.Equals, 4)
 	}
 
 	regularFiles = 0
@@ -188,72 +188,72 @@ func (s *TestSuite) TestList(c *C) {
 	}
 	switch runtime.GOOS {
 	case "darwin":
-		c.Assert(regularFiles, Equals, 3)
+		c.Assert(regularFiles, checkv1.Equals, 3)
 	default:
-		c.Assert(regularFiles, Equals, 4)
+		c.Assert(regularFiles, checkv1.Equals, 4)
 	}
 }
 
 // Test put bucket aka 'mkdir()' operation.
-func (s *TestSuite) TestPutBucket(c *C) {
+func (s *TestSuite) TestPutBucket(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	bucketPath := filepath.Join(root, "bucket")
 	fsClient, err := fsNew(bucketPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	err = fsClient.MakeBucket(context.Background(), "us-east-1", true, false)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 }
 
 // Test stat bucket aka 'stat()' operation.
-func (s *TestSuite) TestStatBucket(c *C) {
+func (s *TestSuite) TestStatBucket(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	bucketPath := filepath.Join(root, "bucket")
 
 	fsClient, err := fsNew(bucketPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	err = fsClient.MakeBucket(context.Background(), "us-east-1", true, false)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	_, err = fsClient.Stat(context.Background(), StatOptions{})
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 }
 
 // Test bucket acl fails for directories.
-func (s *TestSuite) TestBucketACLFails(c *C) {
+func (s *TestSuite) TestBucketACLFails(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	bucketPath := filepath.Join(root, "bucket")
 	fsClient, err := fsNew(bucketPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	err = fsClient.MakeBucket(context.Background(), "us-east-1", true, false)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	// On windows setting permissions is not supported.
 	if runtime.GOOS != "windows" {
 		err = fsClient.SetAccess(context.Background(), "readonly", false)
-		c.Assert(err, IsNil)
+		c.Assert(err, checkv1.IsNil)
 
 		_, _, err = fsClient.GetAccess(context.Background())
-		c.Assert(err, IsNil)
+		c.Assert(err, checkv1.IsNil)
 	}
 }
 
 // Test creating a file.
-func (s *TestSuite) TestPut(c *C) {
+func (s *TestSuite) TestPut(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
 	fsClient, err := fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	data := "hello"
 	reader := bytes.NewReader([]byte(data))
@@ -265,19 +265,19 @@ func (s *TestSuite) TestPut(c *C) {
 	},
 	)
 
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 }
 
 // Test read a file.
-func (s *TestSuite) TestGet(c *C) {
+func (s *TestSuite) TestGet(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
 	fsClient, err := fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	data := "hello"
 	var reader io.Reader
@@ -287,26 +287,26 @@ func (s *TestSuite) TestGet(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	reader, err = fsClient.Get(context.Background(), GetOptions{})
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	var results bytes.Buffer
 	_, e = io.Copy(&results, reader)
-	c.Assert(e, IsNil)
-	c.Assert([]byte(data), DeepEquals, results.Bytes())
+	c.Assert(e, checkv1.IsNil)
+	c.Assert([]byte(data), checkv1.DeepEquals, results.Bytes())
 }
 
 // Test get range in a file.
-func (s *TestSuite) TestGetRange(c *C) {
+func (s *TestSuite) TestGetRange(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
 	fsClient, err := fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	data := "hello world"
 	var reader io.Reader
@@ -316,30 +316,30 @@ func (s *TestSuite) TestGetRange(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	reader, err = fsClient.Get(context.Background(), GetOptions{})
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	var results bytes.Buffer
 	buf := make([]byte, 5)
 	m, e := reader.(io.ReaderAt).ReadAt(buf, 0)
-	c.Assert(e, IsNil)
-	c.Assert(m, Equals, 5)
+	c.Assert(e, checkv1.IsNil)
+	c.Assert(m, checkv1.Equals, 5)
 	_, e = results.Write(buf)
-	c.Assert(e, IsNil)
-	c.Assert([]byte("hello"), DeepEquals, results.Bytes())
+	c.Assert(e, checkv1.IsNil)
+	c.Assert([]byte("hello"), checkv1.DeepEquals, results.Bytes())
 }
 
 // Test stat file.
-func (s *TestSuite) TestStatObject(c *C) {
+func (s *TestSuite) TestStatObject(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 
 	objectPath := filepath.Join(root, "object")
 	fsClient, err := fsNew(objectPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	data := "hello"
 	dataLen := len(data)
@@ -350,25 +350,25 @@ func (s *TestSuite) TestStatObject(c *C) {
 		},
 	},
 	)
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 
 	content, err := fsClient.Stat(context.Background(), StatOptions{})
-	c.Assert(err, IsNil)
-	c.Assert(content.Size, Equals, int64(dataLen))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(content.Size, checkv1.Equals, int64(dataLen))
 }
 
 // Test copy.
-func (s *TestSuite) TestCopy(c *C) {
+func (s *TestSuite) TestCopy(c *checkv1.C) {
 	root, e := os.MkdirTemp(os.TempDir(), "fs-")
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 	defer os.RemoveAll(root)
 	sourcePath := filepath.Join(root, "source")
 	targetPath := filepath.Join(root, "target")
 	fsClientTarget, err := fsNew(targetPath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	fsClientSource, err := fsNew(sourcePath)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	data := "hello world"
 	reader := bytes.NewReader([]byte(data))
@@ -377,8 +377,8 @@ func (s *TestSuite) TestCopy(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(data)))
 	err = fsClientTarget.Copy(context.Background(), sourcePath, CopyOptions{size: int64(len(data))}, nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 }

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 
 	minio "github.com/minio/minio-go/v7"
-	. "gopkg.in/check.v1"
+	checkv1 "gopkg.in/check.v1"
 )
 
 type bucketHandler struct {
@@ -157,7 +157,7 @@ func (h objectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Test bucket operations.
-func (s *TestSuite) TestBucketOperations(c *C) {
+func (s *TestSuite) TestBucketOperations(c *checkv1.C) {
 	bucket := bucketHandler{
 		resource: "/bucket/",
 	}
@@ -170,41 +170,41 @@ func (s *TestSuite) TestBucketOperations(c *C) {
 	conf.SecretKey = "BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"
 	conf.Signature = "S3v4"
 	s3c, err := S3New(conf)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	err = s3c.MakeBucket(context.Background(), "us-east-1", true, false)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	conf.HostURL = server.URL + string(s3c.GetURL().Separator)
 	s3c, err = S3New(conf)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	for content := range s3c.List(globalContext, ListOptions{ShowDir: DirNone}) {
-		c.Assert(content.Err, IsNil)
-		c.Assert(content.Type.IsDir(), Equals, true)
+		c.Assert(content.Err, checkv1.IsNil)
+		c.Assert(content.Type.IsDir(), checkv1.Equals, true)
 	}
 
 	conf.HostURL = server.URL + "/bucket"
 	s3c, err = S3New(conf)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	for content := range s3c.List(globalContext, ListOptions{ShowDir: DirNone}) {
-		c.Assert(content.Err, IsNil)
-		c.Assert(content.Type.IsDir(), Equals, true)
+		c.Assert(content.Err, checkv1.IsNil)
+		c.Assert(content.Type.IsDir(), checkv1.Equals, true)
 	}
 
 	conf.HostURL = server.URL + "/bucket/"
 	s3c, err = S3New(conf)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	for content := range s3c.List(globalContext, ListOptions{ShowDir: DirNone}) {
-		c.Assert(content.Err, IsNil)
-		c.Assert(content.Type.IsRegular(), Equals, true)
+		c.Assert(content.Err, checkv1.IsNil)
+		c.Assert(content.Type.IsRegular(), checkv1.Equals, true)
 	}
 }
 
 // Test all object operations.
-func (s *TestSuite) TestObjectOperations(c *C) {
+func (s *TestSuite) TestObjectOperations(c *checkv1.C) {
 	object := objectHandler{
 		resource: "/bucket/object",
 		data:     []byte("Hello, World"),
@@ -218,7 +218,7 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 	conf.SecretKey = "BYvgJM101sHngl2uzjXS/OBF/aMxAN06JrJ3qJlF"
 	conf.Signature = "S3v4"
 	s3c, err := S3New(conf)
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	var reader io.Reader
 	reader = bytes.NewReader(object.data)
@@ -227,16 +227,16 @@ func (s *TestSuite) TestObjectOperations(c *C) {
 			"Content-Type": "application/octet-stream",
 		},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(len(object.data)))
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(object.data)))
 
 	reader, err = s3c.Get(context.Background(), GetOptions{})
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	var buffer bytes.Buffer
 	{
 		_, err := io.Copy(&buffer, reader)
-		c.Assert(err, IsNil)
-		c.Assert(buffer.Bytes(), DeepEquals, object.data)
+		c.Assert(err, checkv1.IsNil)
+		c.Assert(buffer.Bytes(), checkv1.DeepEquals, object.data)
 	}
 }
 
@@ -258,9 +258,9 @@ var testSelectCompressionTypeCases = []struct {
 
 // TestSelectCompressionType - tests compression type returned
 // by method
-func (s *TestSuite) TestSelectCompressionType(c *C) {
+func (s *TestSuite) TestSelectCompressionType(c *checkv1.C) {
 	for _, test := range testSelectCompressionTypeCases {
 		cType := selectCompressionType(test.opts, test.object)
-		c.Assert(cType, DeepEquals, test.compressionType)
+		c.Assert(cType, checkv1.DeepEquals, test.compressionType)
 	}
 }

--- a/cmd/client-url_test.go
+++ b/cmd/client-url_test.go
@@ -17,38 +17,38 @@
 
 package cmd
 
-import . "gopkg.in/check.v1"
+import checkv1 "gopkg.in/check.v1"
 
 // TestURL - tests url parsing and fields.
-func (s *TestSuite) TestURL(c *C) {
+func (s *TestSuite) TestURL(c *checkv1.C) {
 	urlStr := "foo?.go"
 	url := newClientURL(urlStr)
-	c.Assert(url.Path, Equals, "foo?.go")
+	c.Assert(url.Path, checkv1.Equals, "foo?.go")
 
 	urlStr = "https://s3.amazonaws.com/mybucket/foo?.go"
 	url = newClientURL(urlStr)
-	c.Assert(url.Scheme, Equals, "https")
-	c.Assert(url.Host, Equals, "s3.amazonaws.com")
-	c.Assert(url.Path, Equals, "/mybucket/foo?.go")
+	c.Assert(url.Scheme, checkv1.Equals, "https")
+	c.Assert(url.Host, checkv1.Equals, "s3.amazonaws.com")
+	c.Assert(url.Path, checkv1.Equals, "/mybucket/foo?.go")
 }
 
 // TestURLJoinPath - tests joining two different urls.
-func (s *TestSuite) TestURLJoinPath(c *C) {
+func (s *TestSuite) TestURLJoinPath(c *checkv1.C) {
 	// Join two URLs
 	url1 := "http://s3.mycompany.io/dev"
 	url2 := "http://s3.aws.amazon.com/mybucket/bin/zgrep"
 	url := urlJoinPath(url1, url2)
-	c.Assert(url, Equals, "http://s3.mycompany.io/dev/mybucket/bin/zgrep")
+	c.Assert(url, checkv1.Equals, "http://s3.mycompany.io/dev/mybucket/bin/zgrep")
 
 	// Join URL and a path
 	url1 = "http://s3.mycompany.io/dev"
 	url2 = "mybucket/bin/zgrep"
 	url = urlJoinPath(url1, url2)
-	c.Assert(url, Equals, "http://s3.mycompany.io/dev/mybucket/bin/zgrep")
+	c.Assert(url, checkv1.Equals, "http://s3.mycompany.io/dev/mybucket/bin/zgrep")
 
 	// Check if it strips URL2's tailing `/`
 	url1 = "http://s3.mycompany.io/dev"
 	url2 = "mybucket/bin/"
 	url = urlJoinPath(url1, url2)
-	c.Assert(url, Equals, "http://s3.mycompany.io/dev/mybucket/bin/")
+	c.Assert(url, checkv1.Equals, "http://s3.mycompany.io/dev/mybucket/bin/")
 }

--- a/cmd/mc_test.go
+++ b/cmd/mc_test.go
@@ -23,90 +23,90 @@ import (
 	"testing"
 	"time"
 
-	. "gopkg.in/check.v1"
+	checkv1 "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { checkv1.TestingT(t) }
 
 type TestSuite struct{}
 
-var _ = Suite(&TestSuite{})
+var _ = checkv1.Suite(&TestSuite{})
 
-func (s *TestSuite) SetUpSuite(_ *C) {
+func (s *TestSuite) SetUpSuite(_ *checkv1.C) {
 }
 
-func (s *TestSuite) TearDownSuite(_ *C) {
+func (s *TestSuite) TearDownSuite(_ *checkv1.C) {
 }
 
-func (s *TestSuite) TestValidPERMS(c *C) {
+func (s *TestSuite) TestValidPERMS(c *checkv1.C) {
 	perms := accessPerms("none")
-	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "none")
+	c.Assert(perms.isValidAccessPERM(), checkv1.Equals, true)
+	c.Assert(string(perms), checkv1.Equals, "none")
 	perms = accessPerms("public")
-	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "public")
+	c.Assert(perms.isValidAccessPERM(), checkv1.Equals, true)
+	c.Assert(string(perms), checkv1.Equals, "public")
 	perms = accessPerms("private")
-	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "private")
+	c.Assert(perms.isValidAccessPERM(), checkv1.Equals, true)
+	c.Assert(string(perms), checkv1.Equals, "private")
 	perms = accessPerms("download")
-	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "download")
+	c.Assert(perms.isValidAccessPERM(), checkv1.Equals, true)
+	c.Assert(string(perms), checkv1.Equals, "download")
 	perms = accessPerms("upload")
-	c.Assert(perms.isValidAccessPERM(), Equals, true)
-	c.Assert(string(perms), Equals, "upload")
+	c.Assert(perms.isValidAccessPERM(), checkv1.Equals, true)
+	c.Assert(string(perms), checkv1.Equals, "upload")
 }
 
-func (s *TestSuite) TestInvalidPERMS(c *C) {
+func (s *TestSuite) TestInvalidPERMS(c *checkv1.C) {
 	perms := accessPerms("invalid")
-	c.Assert(perms.isValidAccessPERM(), Equals, false)
+	c.Assert(perms.isValidAccessPERM(), checkv1.Equals, false)
 }
 
-func (s *TestSuite) TestGetMcConfigDir(c *C) {
+func (s *TestSuite) TestGetMcConfigDir(c *checkv1.C) {
 	dir, err := getMcConfigDir()
-	c.Assert(err, IsNil)
-	c.Assert(dir, Not(Equals), "")
-	c.Assert(mustGetMcConfigDir(), Equals, dir)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(dir, checkv1.Not(checkv1.Equals), "")
+	c.Assert(mustGetMcConfigDir(), checkv1.Equals, dir)
 }
 
-func (s *TestSuite) TestGetMcConfigPath(c *C) {
+func (s *TestSuite) TestGetMcConfigPath(c *checkv1.C) {
 	dir, err := getMcConfigPath()
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 	switch runtime.GOOS {
 	case "linux", "freebsd", "darwin", "solaris":
-		c.Assert(dir, Equals, filepath.Join(mustGetMcConfigDir(), "config.json"))
+		c.Assert(dir, checkv1.Equals, filepath.Join(mustGetMcConfigDir(), "config.json"))
 	case "windows":
-		c.Assert(dir, Equals, filepath.Join(mustGetMcConfigDir(), "config.json"))
+		c.Assert(dir, checkv1.Equals, filepath.Join(mustGetMcConfigDir(), "config.json"))
 	default:
 		c.Fail()
 	}
-	c.Assert(mustGetMcConfigPath(), Equals, dir)
+	c.Assert(mustGetMcConfigPath(), checkv1.Equals, dir)
 }
 
-func (s *TestSuite) TestIsvalidAliasName(c *C) {
-	c.Check(isValidAlias("helloWorld0"), Equals, true)
-	c.Check(isValidAlias("hello_World0"), Equals, true)
-	c.Check(isValidAlias("h0SFD2k24Fdsa"), Equals, true)
-	c.Check(isValidAlias("fdslka-4"), Equals, true)
-	c.Check(isValidAlias("fdslka-"), Equals, true)
-	c.Check(isValidAlias("helloWorld$"), Equals, false)
-	c.Check(isValidAlias("h0SFD2k2#Fdsa"), Equals, false)
-	c.Check(isValidAlias("0dslka-4"), Equals, false)
-	c.Check(isValidAlias("-fdslka"), Equals, false)
+func (s *TestSuite) TestIsvalidAliasName(c *checkv1.C) {
+	c.Check(isValidAlias("helloWorld0"), checkv1.Equals, true)
+	c.Check(isValidAlias("hello_World0"), checkv1.Equals, true)
+	c.Check(isValidAlias("h0SFD2k24Fdsa"), checkv1.Equals, true)
+	c.Check(isValidAlias("fdslka-4"), checkv1.Equals, true)
+	c.Check(isValidAlias("fdslka-"), checkv1.Equals, true)
+	c.Check(isValidAlias("helloWorld$"), checkv1.Equals, false)
+	c.Check(isValidAlias("h0SFD2k2#Fdsa"), checkv1.Equals, false)
+	c.Check(isValidAlias("0dslka-4"), checkv1.Equals, false)
+	c.Check(isValidAlias("-fdslka"), checkv1.Equals, false)
 }
 
-func (s *TestSuite) TestHumanizedTime(c *C) {
+func (s *TestSuite) TestHumanizedTime(c *checkv1.C) {
 	hTime := timeDurationToHumanizedDuration(time.Duration(10) * time.Second)
-	c.Assert(hTime.Minutes, Equals, int64(0))
-	c.Assert(hTime.Hours, Equals, int64(0))
-	c.Assert(hTime.Days, Equals, int64(0))
+	c.Assert(hTime.Minutes, checkv1.Equals, int64(0))
+	c.Assert(hTime.Hours, checkv1.Equals, int64(0))
+	c.Assert(hTime.Days, checkv1.Equals, int64(0))
 
 	hTime = timeDurationToHumanizedDuration(time.Duration(10) * time.Minute)
-	c.Assert(hTime.Hours, Equals, int64(0))
-	c.Assert(hTime.Days, Equals, int64(0))
+	c.Assert(hTime.Hours, checkv1.Equals, int64(0))
+	c.Assert(hTime.Days, checkv1.Equals, int64(0))
 
 	hTime = timeDurationToHumanizedDuration(time.Duration(10) * time.Hour)
-	c.Assert(hTime.Days, Equals, int64(0))
+	c.Assert(hTime.Days, checkv1.Equals, int64(0))
 
 	hTime = timeDurationToHumanizedDuration(time.Duration(24) * time.Hour)
-	c.Assert(hTime.Days, Not(Equals), int64(0))
+	c.Assert(hTime.Days, checkv1.Not(checkv1.Equals), int64(0))
 }

--- a/cmd/session_test.go
+++ b/cmd/session_test.go
@@ -22,14 +22,13 @@ import (
 	"os"
 	"regexp"
 
-	. "gopkg.in/check.v1"
+	checkv1 "gopkg.in/check.v1"
 )
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // newRandomID generates a random id of regular lower case and uppercase english characters.
 func newRandomID(n int) string {
-	rand.Seed(UTCNow().UnixNano())
 	sid := make([]rune, n)
 	for i := range sid {
 		sid[i] = letters[rand.Intn(len(letters))]
@@ -37,38 +36,38 @@ func newRandomID(n int) string {
 	return string(sid)
 }
 
-func (s *TestSuite) TestValidSessionID(c *C) {
+func (s *TestSuite) TestValidSessionID(c *checkv1.C) {
 	validSid := regexp.MustCompile("^[a-zA-Z]+$")
 	sid := newRandomID(8)
-	c.Assert(len(sid), Equals, 8)
-	c.Assert(validSid.MatchString(sid), Equals, true)
+	c.Assert(len(sid), checkv1.Equals, 8)
+	c.Assert(validSid.MatchString(sid), checkv1.Equals, true)
 }
 
-func (s *TestSuite) TestSession(c *C) {
+func (s *TestSuite) TestSession(c *checkv1.C) {
 	err := createSessionDir()
-	c.Assert(err, IsNil)
-	c.Assert(isSessionDirExists(), Equals, true)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(isSessionDirExists(), checkv1.Equals, true)
 
 	session := newSessionV8(getHash("cp", []string{"mybucket", "myminio/mybucket"}))
-	c.Assert(session.Header.CommandArgs, IsNil)
-	c.Assert(len(session.SessionID) >= 8, Equals, true)
+	c.Assert(session.Header.CommandArgs, checkv1.IsNil)
+	c.Assert(len(session.SessionID) >= 8, checkv1.Equals, true)
 	_, e := os.Stat(session.DataFP.Name())
-	c.Assert(e, IsNil)
+	c.Assert(e, checkv1.IsNil)
 
 	err = session.Close()
-	c.Assert(err, IsNil)
-	c.Assert(isSessionExists(session.SessionID), Equals, true)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(isSessionExists(session.SessionID), checkv1.Equals, true)
 
 	savedSession, err := loadSessionV8(session.SessionID)
-	c.Assert(err, IsNil)
-	c.Assert(session.SessionID, Equals, savedSession.SessionID)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(session.SessionID, checkv1.Equals, savedSession.SessionID)
 
 	err = savedSession.Close()
-	c.Assert(err, IsNil)
+	c.Assert(err, checkv1.IsNil)
 
 	err = savedSession.Delete()
-	c.Assert(err, IsNil)
-	c.Assert(isSessionExists(session.SessionID), Equals, false)
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(isSessionExists(session.SessionID), checkv1.Equals, false)
 	_, e = os.Stat(session.DataFP.Name())
-	c.Assert(e, NotNil)
+	c.Assert(e, checkv1.NotNil)
 }

--- a/pkg/hookreader/hookreader_test.go
+++ b/pkg/hookreader/hookreader_test.go
@@ -21,14 +21,14 @@ import (
 	"bytes"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	check "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 type MySuite struct{}
 
-var _ = Suite(&MySuite{})
+var _ = check.Suite(&MySuite{})
 
 // customReader - implements custom progress reader.
 type customReader struct {
@@ -41,16 +41,16 @@ func (c *customReader) Read(b []byte) (n int, err error) {
 }
 
 // Tests hook reader implementation.
-func (s *MySuite) TestHookReader(c *C) {
+func (s *MySuite) TestHookReader(c *check.C) {
 	var buffer bytes.Buffer
 	writer := &buffer
 	_, err := writer.Write([]byte("Hello"))
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 	progress := &customReader{}
 	reader := NewHook(&buffer, progress)
 	b := make([]byte, 3)
 	n, err := reader.Read(b)
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, 3)
-	c.Assert(progress.readBytes, Equals, 3)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 3)
+	c.Assert(progress.readBytes, check.Equals, 3)
 }

--- a/pkg/httptracer/httptracer_test.go
+++ b/pkg/httptracer/httptracer_test.go
@@ -20,14 +20,14 @@ package httptracer
 import (
 	"testing"
 
-	. "gopkg.in/check.v1"
+	check "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 type MySuite struct{}
 
-var _ = Suite(&MySuite{})
+var _ = check.Suite(&MySuite{})
 
-func (s *MySuite) TestHTTPTracer(_ *C) {
+func (s *MySuite) TestHTTPTracer(_ *check.C) {
 }

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 
 	"github.com/minio/mc/pkg/probe"
-	. "gopkg.in/check.v1"
+	check "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 type MySuite struct{}
 
-var _ = Suite(&MySuite{})
+var _ = check.Suite(&MySuite{})
 
 func testDummy0() *probe.Error {
 	_, e := os.Stat("this-file-cannot-exit")
@@ -44,22 +44,22 @@ func testDummy2() *probe.Error {
 	return testDummy1().Trace("DummyTag2")
 }
 
-func (s *MySuite) TestProbe(c *C) {
+func (s *MySuite) TestProbe(c *check.C) {
 	probe.Init() // Set project's root source path.
 	probe.SetAppInfo("Commit-ID", "7390cc957239")
 	es := testDummy2().Trace("TopOfStack")
 	// Uncomment the following Println to visually test probe call trace.
 	// fmt.Println("Expecting a simulated error here.", es)
-	c.Assert(es, Not(Equals), nil)
+	c.Assert(es, check.Not(check.Equals), nil)
 
 	newES := es.Trace()
-	c.Assert(newES, Not(Equals), nil)
+	c.Assert(newES, check.Not(check.Equals), nil)
 }
 
-func (s *MySuite) TestWrappedError(c *C) {
+func (s *MySuite) TestWrappedError(c *check.C) {
 	_, e := os.Stat("this-file-cannot-exit")
 	es := probe.NewError(e) // *probe.Error
 	e = probe.WrapError(es) // *probe.WrappedError
 	_, ok := probe.UnwrapError(e)
-	c.Assert(ok, Equals, true)
+	c.Assert(ok, check.Equals, true)
 }


### PR DESCRIPTION
## Description
This commit replaces the UBI minimal with the
small and less bloated UBI micro image.

This reduces noise from security scanners flagging components not used by mc and reduces the overall
size of the container.

## Motivation and Context
Container, build

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
