### PR TITLE
update container base image to ubi9

### DIFF
--- a/Dockerfile.hotfix
+++ b/Dockerfile.hotfix
@@ -1,8 +1,8 @@
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
 
 RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs && microdnf clean all
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
 ARG TARGETARCH
 ARG RELEASE

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,8 @@
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
 
 RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs && microdnf clean all
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
 ARG TARGETARCH
 ARG RELEASE

--- a/Dockerfile.release.fips
+++ b/Dockerfile.release.fips
@@ -1,8 +1,8 @@
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
 
 RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs && microdnf clean all
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
 ARG TARGETARCH
 ARG RELEASE


### PR DESCRIPTION
## Description
This commit updates the container base image
to ubi9/ubi-9.2. It is ~4 MB smaller than ubi-8.

## Motivation and Context
Docker

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
