### PR TITLE
Update ILM add validation to accept with noncurrent-transition-newer set

### DIFF
--- a/cmd/ilm/options.go
+++ b/cmd/ilm/options.go
@@ -159,7 +159,6 @@ func (opts LifecycleOptions) ToILMRule() (lifecycle.Rule, *probe.Error) {
 			StorageClass:            nonCurrentVersionTransitionStorageClass,
 		},
 	}
-
 	if err := validateILMRule(newRule); err != nil {
 		return lifecycle.Rule{}, err
 	}
@@ -254,8 +253,8 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 	if tier != nil && !ctx.IsSet("transition-days") && !ctx.IsSet("transition-date") {
 		return LifecycleOptions{}, probe.NewError(errors.New("transition-date or transition-days must be set"))
 	}
-	if noncurrentTier != nil && !ctx.IsSet("noncurrentversion-transition-days") && !ctx.IsSet("noncurrent-transition-days") {
-		return LifecycleOptions{}, probe.NewError(errors.New("noncurrentversion-transition-days must be set"))
+	if noncurrentTier != nil && !ctx.IsSet("noncurrentversion-transition-days") && !ctx.IsSet("noncurrent-transition-days") && !ctx.IsSet("noncurrent-transition-newer") {
+		return LifecycleOptions{}, probe.NewError(errors.New("noncurrentversion-transition-days must be set or noncurrent version count must be set"))
 	}
 	// for MinIO transition storage-class is same as label defined on
 	// `mc admin bucket remote add --service ilm --label` command

--- a/cmd/ilm/options.go
+++ b/cmd/ilm/options.go
@@ -253,8 +253,8 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 	if tier != nil && !ctx.IsSet("transition-days") && !ctx.IsSet("transition-date") {
 		return LifecycleOptions{}, probe.NewError(errors.New("transition-date or transition-days must be set"))
 	}
-	if noncurrentTier != nil && !ctx.IsSet("noncurrentversion-transition-days") && !ctx.IsSet("noncurrent-transition-days") && !ctx.IsSet("noncurrent-transition-newer") {
-		return LifecycleOptions{}, probe.NewError(errors.New("noncurrentversion-transition-days must be set or noncurrent version count must be set"))
+	if noncurrentTier != nil && !ctx.IsSet("noncurrent-transition-days") && !ctx.IsSet("noncurrent-transition-newer") {
+		return LifecycleOptions{}, probe.NewError(errors.New("noncurrent-transition-days or noncurrent-transition-newer must be set"))
 	}
 	// for MinIO transition storage-class is same as label defined on
 	// `mc admin bucket remote add --service ilm --label` command
@@ -298,9 +298,6 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 	}
 	if f := "noncurrent-expire-newer"; ctx.IsSet(f) {
 		newerNoncurrentExpirationVersions = intPtr(ctx.Int(f))
-	}
-	if ctx.IsSet("noncurrentversion-transition-days") {
-		noncurrentVersionTransitionDays = intPtr(ctx.Int("noncurrentversion-transition-days"))
 	}
 	if f := "noncurrent-transition-days"; ctx.IsSet(f) {
 		noncurrentVersionTransitionDays = intPtr(ctx.Int(f))

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
 )
-
+replace github.com/minio/minio-go/v7 => /Users/jillii/minio-go
 require (
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/lipgloss v0.8.0
@@ -53,14 +53,11 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_model v0.4.0
 	github.com/rivo/tview v0.0.0-20230909130259-ba6a2a345459
-	github.com/vbauerster/mpb/v8 v8.6.2
 	golang.org/x/term v0.13.0
 )
 
 require (
 	aead.dev/minisign v0.2.0 // indirect
-	github.com/VividCortex/ewma v1.2.0 // indirect
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/minio/mux v1.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
 )
-replace github.com/minio/minio-go/v7 => /Users/jillii/minio-go
+
 require (
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/lipgloss v0.8.0
@@ -53,11 +53,14 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_model v0.4.0
 	github.com/rivo/tview v0.0.0-20230909130259-ba6a2a345459
+	github.com/vbauerster/mpb/v8 v8.6.2
 	golang.org/x/term v0.13.0
 )
 
 require (
 	aead.dev/minisign v0.2.0 // indirect
+	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/minio/mux v1.9.0 // indirect


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Updates validation to accept lifecycle options with noncurrent-transition-newer set

## Motivation and Context
Trying to set ILM rule using noncurrent-transition-newer flag triggered validation which was only checking transitionDays

```
jillii ~/mc [(HEAD detached at upstream/master)] $ ./mc ilm rule add --noncurrent-transition-newer 3 --noncurrent-transition-tier "TESTA" minio/jilltest 
mc: <ERROR> Unable to generate new lifecycle rules for the input: noncurrentversion-transition-days must be set.

```
## How to test this PR?
Try adding a new ILM rule using the --noncurrent-transition-newer flag

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
