### PR TITLE
Show net info spinner in health diagnostics

### DIFF
--- a/cmd/support-diag-spinner-v3.go
+++ b/cmd/support-diag-spinner-v3.go
@@ -59,6 +59,7 @@ func receiveHealthInfo(decoder *json.Decoder) (info madmin.HealthInfo, e error) 
 
 	createSpinner("CPU Info", func(info madmin.HealthInfo) bool { return len(info.Sys.CPUInfo) > 0 })
 	createSpinner("Disk Info", func(info madmin.HealthInfo) bool { return len(info.Sys.Partitions) > 0 })
+	createSpinner("Net Info", func(info madmin.HealthInfo) bool { return len(info.Sys.NetInfo) > 0 })
 	createSpinner("OS Info", func(info madmin.HealthInfo) bool { return len(info.Sys.OSInfo) > 0 })
 	createSpinner("Mem Info", func(info madmin.HealthInfo) bool { return len(info.Sys.MemInfo) > 0 })
 	createSpinner("Process Info", func(info madmin.HealthInfo) bool { return len(info.Sys.ProcInfo) > 0 })


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Show net info spinner in health diagnostics

## Motivation and Context

Latest version of minio returns the network hardware info from each server.
Show a spinner for this category of data as well.

## How to test this PR?

Requires https://github.com/minio/minio/pull/18381

- Generate health report (`mc support diag <alias> --airgap`)
- Verify that a spinner is added for `Net info` in output of the command

![image](https://github.com/minio/mc/assets/355479/e13d4117-7e5a-4186-b670-65fba4859a79)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
