### PR TITLE
Add support for STS credentials

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -224,6 +224,12 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			// if an STS endpoint is set, we will add that to the chain
 			stsEndpoint := env.Get("MC_STS_ENDPOINT", "")
 			if stsEndpoint != "" {
+				// set AWS_WEB_IDENTITY_TOKEN_FILE is MC_WEB_IDENTITY_TOKEN_FILE is set
+				mcWebIdentityTokenFile := env.Get("MC_WEB_IDENTITY_TOKEN_FILE", "")
+				if mcWebIdentityTokenFile != "" {
+					os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", mcWebIdentityTokenFile)
+				}
+
 				stsEndpointURL, err := url.Parse(stsEndpoint)
 				if err != nil {
 					return nil, probe.NewError(fmt.Errorf("Error parsing sts endpoint: %v", err))

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/minio/pkg/v2/env"
 	"hash/fnv"
 	"io"
 	"net"
@@ -38,6 +37,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/minio/pkg/v2/env"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -222,12 +222,10 @@ func newFactory() func(config *Config) (Client, *probe.Error) {
 			var credsChain []credentials.Provider
 
 			// if an STS endpoint is set, we will add that to the chain
-			stsEndpoint := env.Get("MC_STS_ENDPOINT", "")
-			if stsEndpoint != "" {
+			if stsEndpoint := env.Get("MC_STS_ENDPOINT", ""); stsEndpoint != "" {
 				// set AWS_WEB_IDENTITY_TOKEN_FILE is MC_WEB_IDENTITY_TOKEN_FILE is set
-				mcWebIdentityTokenFile := env.Get("MC_WEB_IDENTITY_TOKEN_FILE", "")
-				if mcWebIdentityTokenFile != "" {
-					os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", mcWebIdentityTokenFile)
+				if val := env.Get("MC_WEB_IDENTITY_TOKEN_FILE", ""); val != "" {
+					os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", val)
 				}
 
 				stsEndpointURL, err := url.Parse(stsEndpoint)


### PR DESCRIPTION
Adds support for STS on `mc` via the `MC_STS_ENDPOINT` environment variable.

For example:

```bash
MC_HOST_demomc=http://localhost:9000  MC_STS_ENDPOINT=https://sts.minio-operator.svc.cluster.local:4223/sts/ns-1 MC_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token mc ls demomc/
```

If you have `STS` enabled on Operator and a tenant on the `ns-1` namespace, you can test this way

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  namespace: ns-1
  name: my-sa
---
apiVersion: sts.min.io/v1alpha1
kind: PolicyBinding
metadata:
  name: binding-1
  namespace: ns-1
spec:
  application:
    namespace: ns-1
    serviceaccount: my-sa
  policies:
    - consoleAdmin
---
apiVersion: batch/v1
kind: Job
metadata:
  name: mc-ls-sts
  namespace: ns-1
spec:
  template:
    metadata:
    spec:
      serviceAccountName: my-sa
      restartPolicy: Never
      containers:
        - name: mc-job
          image: miniodev/mc:sts
          imagePullPolicy: Always
          command:
            - mc
            - ls
            - myminio/memes
            - --json
          env:
            - name: MC_HOST_myminio
              value: https://minio.ns-1.svc.cluster.local
            - name: MC_STS_ENDPOINT
              value: https://sts.minio-operator.svc.cluster.local:4223/sts/ns-1
            - name: MC_WEB_IDENTITY_TOKEN_FILE
              value: /var/run/secrets/kubernetes.io/serviceaccount/token
  backoffLimit: 0
```