### PR TITLE
set-json to fail on custom policies without .json

### DIFF
--- a/cmd/access-perms.go
+++ b/cmd/access-perms.go
@@ -36,14 +36,12 @@ func (b accessPerms) isValidAccessPERM() bool {
 type PolicyDocument struct {
 	Version   string `json:"Version"`
 	Statement []struct {
-		Effect    string    `json:"Effect"`
-		Action    []string  `json:"Action"`
-		Resource  []string  `json:"Resource"`
-		Condition Condition `json:"Condition"`
+		Effect    string                            `json:"Effect"`
+		Action    []string                          `json:"Action"`
+		Resource  []string                          `json:"Resource"`
+		Condition map[string]map[string]interface{} `json:"Condition"`
 	} `json:"Statement"`
 }
-
-type Condition map[string]map[string]interface{}
 
 func (b accessPerms) isValidAccessFile() bool {
 

--- a/cmd/access-perms.go
+++ b/cmd/access-perms.go
@@ -29,7 +29,12 @@ func (b accessPerms) isValidAccessPERM() bool {
 }
 
 func (b accessPerms) isValidAccessFile() bool {
-	return filepath.Ext(string(b)) == ".json"
+	res := filepath.Ext(string(b)) == ".json"
+	if !res {
+		fatalIf(errDummy().Trace(), "Invalid access file extension. Only .json files are supported.")
+		return false
+	}
+	return true
 }
 
 // accessPerms - access level.

--- a/cmd/access-perms.go
+++ b/cmd/access-perms.go
@@ -33,6 +33,7 @@ func (b accessPerms) isValidAccessPERM() bool {
 	return false
 }
 
+// PolicyDocument represents the JSON structure of IAM policy with its conditions and permissions.
 type PolicyDocument struct {
 	Version   string `json:"Version"`
 	Statement []struct {
@@ -44,7 +45,6 @@ type PolicyDocument struct {
 }
 
 func (b accessPerms) isValidAccessFile() bool {
-
 	if filepath.Ext(string(b)) != ".json" {
 		fatalIf(errDummy().Trace(), "Invalid access file extension. Only .json files are supported.")
 		return false

--- a/cmd/access-perms.go
+++ b/cmd/access-perms.go
@@ -34,7 +34,6 @@ func (b accessPerms) isValidAccessPERM() bool {
 }
 
 func (b accessPerms) isValidAccessFile() bool {
-
 	file, err := os.Open(string(b))
 	if err != nil {
 		fatalIf(errDummy().Trace(), "Unable to open access file.")

--- a/cmd/anonymous-main.go
+++ b/cmd/anonymous-main.go
@@ -52,7 +52,7 @@ var anonymousCmd = cli.Command{
 
 USAGE:
   {{.HelpName}} [FLAGS] set PERMISSION TARGET
-  {{.HelpName}} [FLAGS] set-json TARGET FILE
+  {{.HelpName}} [FLAGS] set-json FILE TARGET
   {{.HelpName}} [FLAGS] get TARGET
   {{.HelpName}} [FLAGS] get-json TARGET
   {{.HelpName}} [FLAGS] list TARGET


### PR DESCRIPTION
Fix set-json command to fail on custom policies without .json

This commit addresses the bug where the `set-json` command incorrectly
succeeds for custom policies even when the policy file doesn't have a .json
extension. The fix ensures that the command fails as expected, prompting the user to use the correct file.

`./mc anonymous set-json myminio/mydata ~/test/anonymous.json`

Now, `set-json` will return an error message if the provided policy file is not a .json, aligning the behavior with the documented functionality.

Related to the discussion with @kannappanr 
