### PR TITLE
Transition doesn't support NewerNoncurrentVersions

### DIFF
--- a/cmd/ilm-rule-add.go
+++ b/cmd/ilm-rule-add.go
@@ -156,8 +156,9 @@ var ilmAddFlags = []cli.Flag{
 		Hidden: true,
 	},
 	cli.IntFlag{
-		Name:  "noncurrent-transition-newer",
-		Usage: "number of noncurrent versions to retain in hot tier",
+		Name:   "noncurrent-transition-newer",
+		Usage:  "number of noncurrent versions to retain in hot tier",
+		Hidden: true,
 	},
 	cli.StringFlag{
 		Name:   "noncurrentversion-transition-storage-class",


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
.. hiding --noncurrent-transition-newer flag to avoid confusion to MinIO users.


## Motivation and Context
MinIO doesn't support NewerNoncurrentVersions for Transition lifecycle action. 

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
