### PR TITLE
add STS support for `mc admin` command

### DIFF
--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -24,13 +24,18 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/klauspost/compress/gzhttp"
+
+	"github.com/minio/pkg/v2/env"
+
 	"github.com/mattn/go-ieproxy"
 	"github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/httptracer"
+	"github.com/minio/mc/pkg/limiter"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
@@ -67,8 +72,97 @@ func NewAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 		var api *madmin.AdminClient
 		var found bool
 		if api, found = clientCache[confSum]; !found {
+
+			var transport http.RoundTripper
+
+			if config.Transport != nil {
+				transport = config.Transport
+			} else {
+				tr := &http.Transport{
+					Proxy:                 http.ProxyFromEnvironment,
+					DialContext:           newCustomDialContext(config),
+					MaxIdleConnsPerHost:   1024,
+					WriteBufferSize:       32 << 10, // 32KiB moving up from 4KiB default
+					ReadBufferSize:        32 << 10, // 32KiB moving up from 4KiB default
+					IdleConnTimeout:       90 * time.Second,
+					TLSHandshakeTimeout:   10 * time.Second,
+					ExpectContinueTimeout: 10 * time.Second,
+					DisableCompression:    true,
+					// Set this value so that the underlying transport round-tripper
+					// doesn't try to auto decode the body of objects with
+					// content-encoding set to `gzip`.
+					//
+					// Refer:
+					//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
+				}
+				if useTLS {
+					// Keep TLS config.
+					tlsConfig := &tls.Config{
+						RootCAs: globalRootCAs,
+						// Can't use SSLv3 because of POODLE and BEAST
+						// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+						// Can't use TLSv1.1 because of RC4 cipher usage
+						MinVersion: tls.VersionTLS12,
+					}
+					if config.Insecure {
+						tlsConfig.InsecureSkipVerify = true
+					}
+					tr.TLSClientConfig = tlsConfig
+
+					// Because we create a custom TLSClientConfig, we have to opt-in to HTTP/2.
+					// See https://github.com/golang/go/issues/14275
+					//
+					// TODO: Enable http2.0 when upstream issues related to HTTP/2 are fixed.
+					//
+					// if e = http2.ConfigureTransport(tr); e != nil {
+					// 	return nil, probe.NewError(e)
+					// }
+				}
+				transport = tr
+			}
+
+			transport = limiter.New(config.UploadLimit, config.DownloadLimit, transport)
+
+			if config.Debug {
+				transport = httptracer.GetNewTraceTransport(newTraceV4(), transport)
+			}
+
+			transport = gzhttp.Transport(transport)
+
+			var credsChain []credentials.Provider
+
+			// if an STS endpoint is set, we will add that to the chain
+			if stsEndpoint := env.Get("MC_STS_ENDPOINT", ""); stsEndpoint != "" {
+				// set AWS_WEB_IDENTITY_TOKEN_FILE is MC_WEB_IDENTITY_TOKEN_FILE is set
+				if val := env.Get("MC_WEB_IDENTITY_TOKEN_FILE", ""); val != "" {
+					os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", val)
+				}
+
+				stsEndpointURL, err := url.Parse(stsEndpoint)
+				if err != nil {
+					return nil, probe.NewError(fmt.Errorf("Error parsing sts endpoint: %v", err))
+				}
+				credsSts := &credentials.IAM{
+					Client: &http.Client{
+						Transport: transport,
+					},
+					Endpoint: stsEndpointURL.String(),
+				}
+				credsChain = append(credsChain, credsSts)
+			}
+
+			// V4 Credentials
+			credsV4 := &credentials.Static{
+				Value: credentials.Value{
+					AccessKeyID:     config.AccessKey,
+					SecretAccessKey: config.SecretKey,
+					SessionToken:    config.SessionToken,
+					SignerType:      credentials.SignatureV4,
+				},
+			}
+			credsChain = append(credsChain, credsV4)
 			// Admin API only supports signature v4.
-			creds := credentials.NewStaticV4(config.AccessKey, config.SecretKey, config.SessionToken)
+			creds := credentials.NewChainCredentials(credsChain)
 
 			// Not found. Instantiate a new MinIO
 			var e error
@@ -78,34 +172,6 @@ func NewAdminFactory() func(config *Config) (*madmin.AdminClient, *probe.Error) 
 			})
 			if e != nil {
 				return nil, probe.NewError(e)
-			}
-
-			// Keep TLS config.
-			tlsConfig := &tls.Config{
-				RootCAs: globalRootCAs,
-				// Can't use SSLv3 because of POODLE and BEAST
-				// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
-				// Can't use TLSv1.1 because of RC4 cipher usage
-				MinVersion: tls.VersionTLS12,
-			}
-			if config.Insecure {
-				tlsConfig.InsecureSkipVerify = true
-			}
-
-			var transport http.RoundTripper = &http.Transport{
-				Proxy:                 ieproxy.GetProxyFunc(),
-				DialContext:           newCustomDialContext(config),
-				MaxIdleConnsPerHost:   256,
-				IdleConnTimeout:       90 * time.Second,
-				TLSHandshakeTimeout:   10 * time.Second,
-				ExpectContinueTimeout: 10 * time.Second,
-				TLSClientConfig:       tlsConfig,
-				DisableCompression:    true,
-			}
-			transport = gzhttp.Transport(transport)
-
-			if config.Debug {
-				transport = httptracer.GetNewTraceTransport(newTraceV4(), transport)
 			}
 
 			// Set custom transport.

--- a/cmd/client-admin_test.go
+++ b/cmd/client-admin_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// # This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+
+	checkv1 "gopkg.in/check.v1"
+)
+
+type adminPolicyHandler struct {
+	endpoint string
+	name     string
+	policy   []byte
+}
+
+func (h adminPolicyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if ak := r.Header.Get("Authorization"); len(ak) == 0 {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+	switch {
+	case r.Method == "PUT":
+		length, e := strconv.Atoi(r.Header.Get("Content-Length"))
+		if e != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var buffer bytes.Buffer
+		if _, e = io.CopyN(&buffer, r.Body, int64(length)); e != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if len(h.policy) != buffer.Len() {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+
+	default:
+		w.WriteHeader(http.StatusForbidden)
+	}
+}
+
+func (s *TestSuite) TestAdminSTSOperation(c *checkv1.C) {
+	sts := stsHandler{
+		endpoint: "/",
+		jwt:      []byte("eyJhbGciOiJSUzI1NiIsImtpZCI6Inc0dFNjMEc5Tk0wQWhGaWJYaWIzbkpRZkRKeDc1dURRTUVpOTNvTHJ0OWcifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNzMxMTg3NzEwLCJpYXQiOjE2OTk2NTE3MTAsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJtaW5pby10ZW5hbnQtMSIsInBvZCI6eyJuYW1lIjoic2V0dXAtYnVja2V0LXQ4eGdjIiwidWlkIjoiNjZhYjlkZWItNzkwMC00YTFlLTgzMDgtMTkwODIwZmQ3NDY5In0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJtYy1qb2Itc2EiLCJ1aWQiOiI3OTc4NzJjZC1kMjkwLTRlM2EtYjYyMC00ZGFkYzZhNzUyMTYifSwid2FybmFmdGVyIjoxNjk5NjU1MzE3fSwibmJmIjoxNjk5NjUxNzEwLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6bWluaW8tdGVuYW50LTE6bWMtam9iLXNhIn0.rY7dpAh8GBTViH9Ges7tRhgyihdFWEN0DwXchelmZg58VOI526S-YfbCqrxksTs8Iu0fp1rmk1cUj7FGDh3AOv2RphHjoWci1802zKkHgH0iOEbKMp3jHXwfyHda8CyrSCPycGzClueCf1ae91wd_0lgK9lOR1qqY1HuDeXqSEAUIGrfh1VcP2n95Zc07EY-Uh3XjJE4drtgusACEK5n3P3WtN9s0m0GomEGQzF5ZJczxLGpHBKMQ5VDhMksVKdBAsx9xHgSx84aUhKQViYilAL-8PRj-RZA9s_IpEymAh5R37dKzAO8Fqq0nG7fVbH_ifzw3xhHiG92BhHldBDqEQ"),
+	}
+
+	tmpfile, errFs := os.CreateTemp("", "jwt")
+	if errFs != nil {
+		log.Fatal(errFs)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, errFs := tmpfile.Write(sts.jwt); errFs != nil {
+		log.Fatal(errFs)
+	}
+	if errFs := tmpfile.Close(); errFs != nil {
+		log.Fatal(errFs)
+	}
+
+	stsServer := httptest.NewServer(sts)
+	defer stsServer.Close()
+	os.Setenv("MC_STS_ENDPOINT", stsServer.URL+sts.endpoint)
+	os.Setenv("MC_WEB_IDENTITY_TOKEN_FILE", tmpfile.Name())
+	handler := adminPolicyHandler{
+		endpoint: "/minio/admin/v3/add-canned-policy?name=",
+		name:     "test",
+		policy: []byte(`
+{
+  "Version": "2012-10-17",
+  "Statement": [
+	{
+	  "Effect": "Allow",
+	  "Action": [
+		"s3:*"
+	  ],
+	  "Resource": [
+		"arn:aws:s3:::test-bucket",
+		"arn:aws:s3:::test-bucket/*"
+	  ]
+	}
+  ]
+
+}`),
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conf := new(Config)
+	conf.Debug = true
+	conf.Insecure = true
+	conf.HostURL = server.URL + handler.endpoint + handler.name
+	s3c, err := s3AdminNew(conf)
+	c.Assert(err, checkv1.IsNil)
+
+	policyErr := s3c.AddCannedPolicy(context.Background(), handler.name, handler.policy)
+	c.Assert(policyErr, checkv1.IsNil)
+}

--- a/cmd/client-s3_test.go
+++ b/cmd/client-s3_test.go
@@ -22,8 +22,10 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 
 	minio "github.com/minio/minio-go/v7"
@@ -80,6 +82,11 @@ type objectHandler struct {
 }
 
 func (h objectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if ak := r.Header.Get("Authorization"); len(ak) == 0 {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
 	switch {
 	case r.Method == "PUT":
 		// Handler for PUT object request.
@@ -153,6 +160,38 @@ func (h objectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("ETag", "9af2f8218b150c351ad802c6f3d66abe")
 		w.WriteHeader(http.StatusOK)
 		io.Copy(w, bytes.NewReader(h.data))
+	}
+}
+
+type stsHandler struct {
+	endpoint string
+	jwt      []byte
+}
+
+func (h stsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := ParseForm(r); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	switch {
+	case r.Method == "POST":
+		token := r.Form.Get("WebIdentityToken")
+		if token == string(h.jwt) {
+			response := []byte("<AssumeRoleWithWebIdentityResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\"><AssumeRoleWithWebIdentityResult><AssumedRoleUser><Arn></Arn><AssumeRoleId></AssumeRoleId></AssumedRoleUser><Credentials><AccessKeyId>7NL5BR739GUQ0ZOD4JNB</AccessKeyId><SecretAccessKey>A2mxZSxPnHNhSduedUHczsXZpVSSssOLpDruUmTV</SecretAccessKey><Expiration>0001-01-01T00:00:00Z</Expiration><SessionToken>eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiI3Tkw1QlI3MzlHVVEwWk9ENEpOQiIsImV4cCI6MTY5OTYwMzMwNiwicGFyZW50IjoibWluaW8iLCJzZXNzaW9uUG9saWN5IjoiZXlKV1pYSnphVzl1SWpvaU1qQXhNaTB4TUMweE55SXNJbE4wWVhSbGJXVnVkQ0k2VzNzaVJXWm1aV04wSWpvaVFXeHNiM2NpTENKQlkzUnBiMjRpT2xzaVlXUnRhVzQ2S2lKZGZTeDdJa1ZtWm1WamRDSTZJa0ZzYkc5M0lpd2lRV04wYVc5dUlqcGJJbXR0Y3pvcUlsMTlMSHNpUldabVpXTjBJam9pUVd4c2IzY2lMQ0pCWTNScGIyNGlPbHNpY3pNNktpSmRMQ0pTWlhOdmRYSmpaU0k2V3lKaGNtNDZZWGR6T25Nek9qbzZLaUpkZlYxOSJ9.uuE_x7PO8QoPfUk9KzUELoAqxihIknZAvJLl5aYJjwpSjJYFTPLp6EvuyJX2hc18s9HzeiJ-vU0dPzsy50dXmg</SessionToken></Credentials></AssumeRoleWithWebIdentityResult><ResponseMetadata></ResponseMetadata></AssumeRoleWithWebIdentityResponse>")
+			w.Header().Set("Content-Length", strconv.Itoa(len(response)))
+			w.Header().Set("Content-Type", "application/xml")
+			w.Header().Set("Server", "MinIO")
+			w.Write(response)
+			w.WriteHeader(http.StatusOK)
+			return
+		} else {
+			response := []byte("<ErrorResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\"><Error><Type></Type><Code>AccessDenied</Code><Message>Access denied: Invalid Token</Message></Error><RequestId></RequestId></ErrorResponse>")
+			w.Header().Set("Content-Length", strconv.Itoa(len(response)))
+			w.Header().Set("Content-Type", "application/xml")
+			w.Write(response)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
 	}
 }
 
@@ -238,6 +277,52 @@ func (s *TestSuite) TestObjectOperations(c *checkv1.C) {
 		c.Assert(err, checkv1.IsNil)
 		c.Assert(buffer.Bytes(), checkv1.DeepEquals, object.data)
 	}
+}
+
+func (s *TestSuite) TestSTSOperation(c *checkv1.C) {
+	sts := stsHandler{
+		endpoint: "/",
+		jwt:      []byte("eyJhbGciOiJSUzI1NiIsImtpZCI6Inc0dFNjMEc5Tk0wQWhGaWJYaWIzbkpRZkRKeDc1dURRTUVpOTNvTHJ0OWcifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNzMxMTIyNjg0LCJpYXQiOjE2OTk1ODY2ODQsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJtaW5pby10ZW5hbnQtMSIsInBvZCI6eyJuYW1lIjoic2V0dXAtYnVja2V0LXJ4aHhiIiwidWlkIjoiNmNhMzhjMmItYTdkMC00M2Y0LWE0NjMtZjdlNjU4MGUyZDdiIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJtYy1qb2Itc2EiLCJ1aWQiOiI3OTc4NzJjZC1kMjkwLTRlM2EtYjYyMC00ZGFkYzZhNzUyMTYifSwid2FybmFmdGVyIjoxNjk5NTkwMjkxfSwibmJmIjoxNjk5NTg2Njg0LCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6bWluaW8tdGVuYW50LTE6bWMtam9iLXNhIn0.fBJckmoQFyJ9bUgKZv6jzBESd9ccX_HFPPBZ17Gz_CsQ5wXrMqnvoMs1mcv6QKWsDsvSnWnw_tcW0cjvVkXb2mKmioKLzqV4ihGbiWzwk2e1xDohn8fizdQkf64bXpncjGdEGv8oi9A4300jfLMfg53POriMyEAQMeIDKPOI9qx913xjGni2w2H49mjLfnFnRaj9osvy17425dNIrMC6GDFq3rcq6Z_cdDmL18Jwsjy1xDsAhUzmOclr-VI3AeSnuD4fbf6jhbKE14qVUjLmIBf__B5NhESiaFNwxFYjonZyi357Nx93CD1wai28tNRSODx7BiPHLxk8SyzY0CP0sQ"),
+	}
+
+	tmpfile, errFs := os.CreateTemp("", "jwt")
+	if errFs != nil {
+		log.Fatal(errFs)
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, errFs := tmpfile.Write(sts.jwt); errFs != nil {
+		log.Fatal(errFs)
+	}
+	if errFs := tmpfile.Close(); errFs != nil {
+		log.Fatal(errFs)
+	}
+
+	stsServer := httptest.NewServer(sts)
+	defer stsServer.Close()
+	os.Setenv("MC_STS_ENDPOINT", stsServer.URL+sts.endpoint)
+	os.Setenv("MC_WEB_IDENTITY_TOKEN_FILE", tmpfile.Name())
+	object := objectHandler{
+		resource: "/bucket/object",
+		data:     []byte("Hello, World"),
+	}
+	server := httptest.NewServer(object)
+	defer server.Close()
+
+	conf := new(Config)
+	conf.HostURL = server.URL + object.resource
+	s3c, err := S3New(conf)
+	c.Assert(err, checkv1.IsNil)
+
+	var reader io.Reader
+	reader = bytes.NewReader(object.data)
+	n, err := s3c.Put(context.Background(), reader, int64(len(object.data)), nil, PutOptions{
+		metadata: map[string]string{
+			"Content-Type": "application/octet-stream",
+		},
+	})
+	c.Assert(err, checkv1.IsNil)
+	c.Assert(n, checkv1.Equals, int64(len(object.data)))
 }
 
 var testSelectCompressionTypeCases = []struct {

--- a/cmd/common-methods.go
+++ b/cmd/common-methods.go
@@ -654,3 +654,16 @@ func newClient(aliasedURL string) (Client, *probe.Error) {
 	}
 	return newClientFromAlias(alias, urlStrFull)
 }
+
+// ParseForm parses a http.Request form and populates the array
+func ParseForm(r *http.Request) error {
+	if err := r.ParseForm(); err != nil {
+		return err
+	}
+	for k, v := range r.PostForm {
+		if _, ok := r.Form[k]; !ok {
+			r.Form[k] = v
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
add STS support for `mc admin` commands

## Motivation and Context
To allow invoke subcommands in the `admin` section such as `user`, `group`, `policy`, etc.

Example:

```
MC_HOST_demomc=http://localhost:9000  \
MC_STS_ENDPOINT=https://sts.minio-operator.svc.cluster.local:4223/sts/ns-1 \
MC_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token \
./mc admin policy create demomc bucket-rw policy.json 
```

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
