### PR TITLE
Add `ldap accesskey create`, update `accesskey list` with new endpoint

### DIFF
--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -383,7 +383,9 @@ var completeCmds = map[string]complete.Predictor{
 
 	"/idp/ldap/accesskey/create": aliasCompleter,
 	"/idp/ldap/accesskey/list":   aliasCompleter,
+	"/idp/ldap/accesskey/ls":     aliasCompleter,
 	"/idp/ldap/accesskey/remove": aliasCompleter,
+	"/idp/ldap/accesskey/rm":     aliasCompleter,
 	"/idp/ldap/accesskey/info":   aliasCompleter,
 
 	"/admin/policy/info":     aliasCompleter,

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -188,17 +188,6 @@ func newAnonymousClient(aliasedURL string) (*madmin.AnonymousClient, *probe.Erro
 	return anonClient, nil
 }
 
-// newExpandedClient creates client without an alias
-func newExpandedClient(aliasCfg aliasConfigV10) (*madmin.AdminClient, *probe.Error) {
-	s3Config := NewS3Config(aliasCfg.URL, &aliasCfg)
-
-	s3Client, err := s3AdminNew(s3Config)
-	if err != nil {
-		return nil, err.Trace(aliasCfg.URL)
-	}
-	return s3Client, nil
-}
-
 // s3AdminNew returns an initialized minioAdmin structure. If debug is enabled,
 // it also enables an internal trace transport.
 var s3AdminNew = NewAdminFactory()

--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -188,6 +188,17 @@ func newAnonymousClient(aliasedURL string) (*madmin.AnonymousClient, *probe.Erro
 	return anonClient, nil
 }
 
+// newExpandedClient creates client without an alias
+func newExpandedClient(aliasCfg aliasConfigV10) (*madmin.AdminClient, *probe.Error) {
+	s3Config := NewS3Config(aliasCfg.URL, &aliasCfg)
+
+	s3Client, err := s3AdminNew(s3Config)
+	if err != nil {
+		return nil, err.Trace(aliasCfg.URL)
+	}
+	return s3Client, nil
+}
+
 // s3AdminNew returns an initialized minioAdmin structure. If debug is enabled,
 // it also enables an internal trace transport.
 var s3AdminNew = NewAdminFactory()

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -79,6 +79,14 @@ FLAGS:
 EXAMPLES:
   1. Create a new access key pair with the same policy as the authenticated user
      {{.Prompt}} {{.HelpName}} local/
+  2. Create a new access key pair with custom access key and secret key
+	 {{.Prompt}} {{.HelpName}} local/ --access-key myaccesskey --secret-key mysecretkey
+  3. Create a new access key pair for user with DN "uid=james,dc=min,dc=io" with a custom policy
+	 {{.Prompt}} {{.HelpName}} uid=james,dc=min,dc=io --policy policy.json
+  4. Create a new access key pair for user with username "james" that expires in 1 day
+	 {{.Prompt}} {{.HelpName}} james --expiry-duration 24h
+  5. Create a new access key pair for authenticated user that expires on 2021-01-01
+	 {{.Prompt}} {{.HelpName}} --expiry 2021-01-01
 	`,
 }
 

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -246,5 +246,4 @@ func loginLDAPAccesskey(URL string) *madmin.AdminClient {
 	fatalIf(probe.NewError(e), "Unable to initialize admin connection.")
 
 	return client
-
 }

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2015-2023 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"time"
+
+	"github.com/minio/cli"
+	"github.com/minio/madmin-go/v3"
+	"github.com/minio/mc/pkg/probe"
+)
+
+var idpLdapAccesskeyCreateFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "access-key",
+		Usage: "set an access key for the service account",
+	},
+	cli.StringFlag{
+		Name:  "secret-key",
+		Usage: "set a secret key for the service account",
+	},
+	cli.StringFlag{
+		Name:  "policy",
+		Usage: "path to a JSON policy file",
+	},
+	cli.StringFlag{
+		Name:  "name",
+		Usage: "friendly name for the service account",
+	},
+	cli.StringFlag{
+		Name:  "description",
+		Usage: "description for the service account",
+	},
+	cli.StringFlag{
+		Name:  "expiry",
+		Usage: "time of expiration for the service account",
+	},
+}
+
+var idpLdapAccesskeyCreateCmd = cli.Command{
+	Name:         "create",
+	Usage:        "create access key pairs for LDAP",
+	Action:       mainIDPLdapAccesskeyCreate,
+	Before:       setGlobalsFromContext,
+	Flags:        append(idpLdapAccesskeyCreateFlags, globalFlags...),
+	OnUsageError: onUsageError,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS] [TARGET]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Create a new access key pair with the same policy as the authenticated user
+     {{.Prompt}} {{.HelpName}} local/
+	`,
+}
+
+func mainIDPLdapAccesskeyCreate(ctx *cli.Context) error {
+	if len(ctx.Args()) == 0 || len(ctx.Args()) > 2 {
+		showCommandHelpAndExit(ctx, 1) // last argument is exit code
+	}
+
+	args := ctx.Args()
+	aliasedURL := args.Get(0)
+	targetUser := args.Get(1)
+
+	expVal := ctx.Duration("expiration")
+	exp := time.Now().Add(expVal)
+	accessVal := ctx.String("accesskey")
+	secretVal := ctx.String("secretkey")
+
+	if expVal == 0 {
+		exp = time.Unix(0, 0)
+	}
+
+	// Create a new MinIO Admin Client
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err, "Unable to initialize admin connection.")
+
+	accessKey, secretKey, e := generateCredentials()
+	fatalIf(probe.NewError(e), "Unable to generate credentials.")
+
+	// If access key and secret key are provided, use them instead
+	if accessVal != "" {
+		accessKey = accessVal
+	}
+	if secretVal != "" {
+		secretKey = secretVal
+	}
+
+	res, e := client.AddServiceAccountLDAP(globalContext,
+		madmin.AddServiceAccountReq{
+			TargetUser: targetUser,
+			AccessKey:  accessKey,
+			SecretKey:  secretKey,
+			Expiration: &exp,
+		})
+	fatalIf(probe.NewError(e), "Unable to add service account.")
+
+	// If target user is not provided, use the authenticated user
+	if targetUser == "" {
+		parentUser, e := client.AccountInfo(globalContext, madmin.AccountOpts{})
+		fatalIf(probe.NewError(e), "Unable to get account info.")
+		targetUser = parentUser.AccountName
+	}
+
+	m := ldapAccesskeyMessage{
+		op:         "create",
+		Status:     "success",
+		AccessKey:  res.AccessKey,
+		SecretKey:  res.SecretKey,
+		Expiration: &res.Expiration,
+	}
+	printMsg(m)
+
+	return nil
+}

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -172,9 +172,8 @@ func mainIDPLdapAccesskeyCreate(ctx *cli.Context) error {
 		}
 		isTerminal := term.IsTerminal(int(os.Stdin.Fd()))
 		if !isTerminal {
-
-			//e := fmt.Errorf("login flag cannot be used with non-interactive terminal")
-			//fatalIf(probe.NewError(e), "Invalid flags.")
+			e := fmt.Errorf("login flag cannot be used with non-interactive terminal")
+			fatalIf(probe.NewError(e), "Invalid flags.")
 		}
 
 		// For login, aliasedURL is not aliased, but the actual server URL

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -225,11 +225,13 @@ func loginLDAPAccesskey(URL string) *madmin.AdminClient {
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Printf("%s", console.Colorize(cred, "Enter LDAP Username: "))
-	value, _, _ := reader.ReadLine()
+	value, _, e := reader.ReadLine()
+	fatalIf(probe.NewError(e), "Unable to read username")
 	username := string(value)
 
 	fmt.Printf("%s", console.Colorize(cred, "Enter Password: "))
-	bytePassword, _ := term.ReadPassword(int(os.Stdin.Fd()))
+	bytePassword, e := term.ReadPassword(int(os.Stdin.Fd()))
+	fatalIf(probe.NewError(e), "Unable to read password")
 	fmt.Printf("\n")
 	password := string(bytePassword)
 

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -91,8 +91,6 @@ EXAMPLES:
      {{.Prompt}} {{.HelpName}} local/
   2. Create a new access key pair with custom access key and secret key
 	 {{.Prompt}} {{.HelpName}} local/ --access-key myaccesskey --secret-key mysecretkey
-  3. Create a new access key pair for user with DN "uid=james,dc=min,dc=io" with a custom policy
-	 {{.Prompt}} {{.HelpName}} uid=james,dc=min,dc=io --policy policy.json
   4. Create a new access key pair for user with username "james" that expires in 1 day
 	 {{.Prompt}} {{.HelpName}} james --expiry-duration 24h
   5. Create a new access key pair for authenticated user that expires on 2021-01-01

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -83,7 +83,7 @@ func mainIDPLdapAccesskeyCreate(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 	targetUser := args.Get(1)
 
-	expVal := ctx.Duration("expiration")
+	expVal := ctx.Duration("expiry")
 	exp := time.Now().Add(expVal)
 	accessVal := ctx.String("accesskey")
 	secretVal := ctx.String("secretkey")
@@ -115,13 +115,6 @@ func mainIDPLdapAccesskeyCreate(ctx *cli.Context) error {
 			Expiration: &exp,
 		})
 	fatalIf(probe.NewError(e), "Unable to add service account.")
-
-	// If target user is not provided, use the authenticated user
-	if targetUser == "" {
-		parentUser, e := client.AccountInfo(globalContext, madmin.AccountOpts{})
-		fatalIf(probe.NewError(e), "Unable to get account info.")
-		targetUser = parentUser.AccountName
-	}
 
 	m := ldapAccesskeyMessage{
 		op:         "create",

--- a/cmd/idp-ldap-accesskey-create.go
+++ b/cmd/idp-ldap-accesskey-create.go
@@ -97,6 +97,8 @@ EXAMPLES:
 	 {{.Prompt}} {{.HelpName}} james --expiry-duration 24h
   5. Create a new access key pair for authenticated user that expires on 2021-01-01
 	 {{.Prompt}} {{.HelpName}} --expiry 2021-01-01
+  6. Create a new access key pair for minio.example.com by logging in with LDAP credentials
+	 {{.Prompt}} {{.HelpName}} --login minio.example.com
 	`,
 }
 

--- a/cmd/idp-ldap-accesskey-info.go
+++ b/cmd/idp-ldap-accesskey-info.go
@@ -108,6 +108,12 @@ func (m ldapAccesskeyMessage) String() string {
 		o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("Access Key:"), m.AccessKey))
 		o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("Secret Key:"), m.SecretKey))
 		o.WriteString(iFmt(0, "%s %s\n\n", labelStyle.Render("Expiration:"), expirationStr))
+		if m.Name != "" {
+			o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("Name:"), m.Name))
+		}
+		if m.Description != "" {
+			o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("Description:"), m.Description))
+		}
 
 		return o.String()
 	case "remove":

--- a/cmd/idp-ldap-accesskey-info.go
+++ b/cmd/idp-ldap-accesskey-info.go
@@ -104,7 +104,6 @@ func (m ldapAccesskeyMessage) String() string {
 		labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575")) // green
 		o := strings.Builder{}
 
-		o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("User DN:   "), m.ParentUser))
 		o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("Access Key:"), m.AccessKey))
 		o.WriteString(iFmt(0, "%s %s\n", labelStyle.Render("Secret Key:"), m.SecretKey))
 		o.WriteString(iFmt(0, "%s %s\n\n", labelStyle.Render("Expiration:"), expirationStr))

--- a/cmd/idp-ldap-accesskey-list.go
+++ b/cmd/idp-ldap-accesskey-list.go
@@ -34,12 +34,12 @@ var idpLdapAccesskeyListFlags = []cli.Flag{
 		Usage: "only list user DNs",
 	},
 	cli.BoolFlag{
-		Name:  "temp-only",
-		Usage: "only list temporary access keys",
+		Name:  "sts-only",
+		Usage: "only list sts access keys",
 	},
 	cli.BoolFlag{
-		Name:  "permanent-only",
-		Usage: "only list permanent access keys/service accounts",
+		Name:  "svcacc-only",
+		Usage: "only list service account access keys",
 	},
 }
 
@@ -77,31 +77,26 @@ EXAMPLES:
 }
 
 type ldapUsersList struct {
-	Status string             `json:"status"`
-	Result ldapUserAccessKeys `json:"result"`
-}
-
-type ldapUserAccessKeys struct {
-	DN                  string                      `json:"dn"`
-	TempAccessKeys      []madmin.ServiceAccountInfo `json:"tempAccessKeys,omitempty"`
-	PermanentAccessKeys []madmin.ServiceAccountInfo `json:"permanentAccessKeys,omitempty"`
+	Status          string                      `json:"status"`
+	DN              string                      `json:"dn"`
+	STSKeys         []madmin.ServiceAccountInfo `json:"stsKeys"`
+	ServiceAccounts []madmin.ServiceAccountInfo `json:"svcaccs"`
 }
 
 func (m ldapUsersList) String() string {
 	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575"))
 	o := strings.Builder{}
 
-	u := m.Result
-	o.WriteString(iFmt(0, "%s\n", labelStyle.Render("DN "+u.DN)))
-	if len(u.TempAccessKeys) > 0 {
-		o.WriteString(iFmt(2, "%s\n", labelStyle.Render("Temporary Access Keys:")))
-		for _, k := range u.TempAccessKeys {
+	o.WriteString(iFmt(0, "%s\n", labelStyle.Render("DN "+m.DN)))
+	if len(m.STSKeys) > 0 {
+		o.WriteString(iFmt(2, "%s\n", labelStyle.Render("STS Access Keys:")))
+		for _, k := range m.STSKeys {
 			o.WriteString(iFmt(4, "%s\n", k.AccessKey))
 		}
 	}
-	if len(u.PermanentAccessKeys) > 0 {
-		o.WriteString(iFmt(2, "%s\n", labelStyle.Render("Permanent Access Keys:")))
-		for _, k := range u.PermanentAccessKeys {
+	if len(m.ServiceAccounts) > 0 {
+		o.WriteString(iFmt(2, "%s\n", labelStyle.Render("Service Account Access Keys:")))
+		for _, k := range m.ServiceAccounts {
 			o.WriteString(iFmt(4, "%s\n", k.AccessKey))
 		}
 	}
@@ -123,12 +118,18 @@ func mainIDPLdapAccesskeyList(ctx *cli.Context) error {
 	}
 
 	usersOnly := ctx.Bool("users-only")
-	tempOnly := ctx.Bool("temp-only")
-	permanentOnly := ctx.Bool("permanent-only")
+	tempOnly := ctx.Bool("sts-only")
+	permanentOnly := ctx.Bool("svcacc-only")
+	listType := ""
 
 	if (usersOnly && permanentOnly) || (usersOnly && tempOnly) || (permanentOnly && tempOnly) {
 		e := errors.New("only one of --users-only, --temp-only, or --permanent-only can be specified")
 		fatalIf(probe.NewError(e), "Invalid flags.")
+	}
+	if tempOnly {
+		listType = "sts-only"
+	} else if permanentOnly {
+		listType = "svcacc-only"
 	}
 
 	args := ctx.Args()
@@ -167,55 +168,30 @@ func mainIDPLdapAccesskeyList(ctx *cli.Context) error {
 	}
 
 	for dn := range users {
-		if !usersOnly {
-			accessKeys, _ := client.ListServiceAccounts(globalContext, dn)
-
-			var tempAccessKeys []madmin.ServiceAccountInfo
-			var permanentAccessKeys []madmin.ServiceAccountInfo
-
-			for _, accessKey := range accessKeys.Accounts {
-				if accessKey.Expiration.Unix() == 0 {
-					permanentAccessKeys = append(permanentAccessKeys, accessKey)
-				} else {
-					tempAccessKeys = append(tempAccessKeys, accessKey)
-				}
-			}
-
-			// if dn is blank, it means we are listing the current user's access keys
-			if dn == "" {
-				name, e := client.AccountInfo(globalContext, madmin.AccountOpts{})
-				fatalIf(probe.NewError(e), "Unable to retrieve account name.")
-				dn = name.AccountName
-			}
-
-			userAccessKeys := ldapUserAccessKeys{DN: dn}
-			if !tempOnly {
-				userAccessKeys.PermanentAccessKeys = permanentAccessKeys
-			}
-			if !permanentOnly {
-				userAccessKeys.TempAccessKeys = tempAccessKeys
-			}
-
-			m := ldapUsersList{
-				Status: "success",
-				Result: userAccessKeys,
-			}
-			printMsg(m)
-
-		} else {
-			// If dn is blank, it means we are listing the current user's access keys
-			if dn == "" {
-				name, e := client.AccountInfo(globalContext, madmin.AccountOpts{})
-				fatalIf(probe.NewError(e), "Unable to retrieve account name.")
-				dn = name.AccountName
-			}
-
-			m := ldapUsersList{
-				Status: "success",
-				Result: ldapUserAccessKeys{DN: dn},
-			}
-			printMsg(m)
+		// if dn is blank, it means we are listing the current user's access keys
+		if dn == "" {
+			name, e := client.AccountInfo(globalContext, madmin.AccountOpts{})
+			fatalIf(probe.NewError(e), "Unable to retrieve account name.")
+			dn = name.AccountName
 		}
+
+		m := ldapUsersList{
+			Status: "success",
+			DN:     dn,
+		}
+
+		// Get access keys if not listing users only
+		if !usersOnly {
+			accessKeys, e := client.ListAccessKeysLDAP(globalContext, dn, listType)
+			if e != nil {
+				errorIf(probe.NewError(e), "Unable to retrieve access keys for user '"+dn+"'.")
+				continue
+			}
+
+			m.STSKeys = accessKeys.STSKeys
+			m.ServiceAccounts = accessKeys.ServiceAccounts
+		}
+		printMsg(m)
 	}
 
 	return nil

--- a/cmd/idp-ldap-accesskey-list.go
+++ b/cmd/idp-ldap-accesskey-list.go
@@ -34,8 +34,8 @@ var idpLdapAccesskeyListFlags = []cli.Flag{
 		Usage: "only list user DNs",
 	},
 	cli.BoolFlag{
-		Name:  "sts-only",
-		Usage: "only list sts access keys",
+		Name:  "temp-only",
+		Usage: "only list temporary access keys",
 	},
 	cli.BoolFlag{
 		Name:  "svcacc-only",
@@ -69,9 +69,11 @@ EXAMPLES:
 	 {{.Prompt}} {{.HelpName}} play/ --temp-only
   4. Get list of access keys associated with user 'bobfisher'
   	 {{.Prompt}} {{.HelpName}} play/ uid=bobfisher,dc=min,dc=io
-  5. Get list of access keys associated with users 'bobfisher' and 'cody3'
+  5. Get list of access keys associated with user 'bobfisher' (alt)
+	 {{.Prompt}} {{.HelpName}} play/ bobfisher
+  6. Get list of access keys associated with users 'bobfisher' and 'cody3'
   	 {{.Prompt}} {{.HelpName}} play/ uid=bobfisher,dc=min,dc=io uid=cody3,dc=min,dc=io
-  6. Get authenticated user and associated access keys in local server (if not admin)
+  7. Get authenticated user and associated access keys in local server (if not admin)
 	 {{.Prompt}} {{.HelpName}} local/
 	`,
 }

--- a/cmd/idp-ldap-accesskey-list.go
+++ b/cmd/idp-ldap-accesskey-list.go
@@ -149,12 +149,8 @@ func mainIDPLdapAccesskeyList(ctx *cli.Context) error {
 	} else {
 		users = make(map[string]madmin.UserInfo)
 		for _, user := range userArg {
-			// Check existence of each user
-			if _, e = client.GetUserInfo(globalContext, user); e != nil {
-				errorIf(probe.NewError(e), "User '"+user+"' invalid")
-			} else {
-				users[user] = madmin.UserInfo{}
-			}
+			users[user] = madmin.UserInfo{}
+
 		}
 	}
 	if e != nil {

--- a/cmd/idp-ldap-accesskey-list.go
+++ b/cmd/idp-ldap-accesskey-list.go
@@ -158,7 +158,6 @@ func mainIDPLdapAccesskeyList(ctx *cli.Context) error {
 		users = make(map[string]madmin.UserInfo)
 		for _, user := range userArg {
 			users[user] = madmin.UserInfo{}
-
 		}
 	}
 	if e != nil {
@@ -197,6 +196,5 @@ func mainIDPLdapAccesskeyList(ctx *cli.Context) error {
 		}
 		printMsg(m)
 	}
-
 	return nil
 }

--- a/cmd/idp-ldap-accesskey-list.go
+++ b/cmd/idp-ldap-accesskey-list.go
@@ -63,19 +63,25 @@ FLAGS:
 EXAMPLES:
   1. Get list of all users and associated access keys in local server (if admin)
  	 {{.Prompt}} {{.HelpName}} local/
+
   2. Get list of users in local server (if admin)
  	 {{.Prompt}} {{.HelpName}} local/ --users-only
+
   3. Get list of all users and associated temporary access keys in play server (if admin)
 	 {{.Prompt}} {{.HelpName}} play/ --temp-only
+
   4. Get list of access keys associated with user 'bobfisher'
   	 {{.Prompt}} {{.HelpName}} play/ uid=bobfisher,dc=min,dc=io
+
   5. Get list of access keys associated with user 'bobfisher' (alt)
 	 {{.Prompt}} {{.HelpName}} play/ bobfisher
+
   6. Get list of access keys associated with users 'bobfisher' and 'cody3'
   	 {{.Prompt}} {{.HelpName}} play/ uid=bobfisher,dc=min,dc=io uid=cody3,dc=min,dc=io
+
   7. Get authenticated user and associated access keys in local server (if not admin)
 	 {{.Prompt}} {{.HelpName}} local/
-	`,
+`,
 }
 
 type ldapUsersList struct {

--- a/cmd/idp-ldap-accesskey.go
+++ b/cmd/idp-ldap-accesskey.go
@@ -23,6 +23,7 @@ var idpLdapAccesskeySubcommands = []cli.Command{
 	idpLdapAccesskeyListCmd,
 	idpLdapAccesskeyRemoveCmd,
 	idpLdapAccesskeyInfoCmd,
+	idpLdapAccesskeyCreateCmd,
 }
 
 var idpLdapAccesskeyCmd = cli.Command{


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Not ready for review
Accompanying minio/minio#18402

Adds `mc idp ldap accesskey create`, which creates an LDAP access key with desired settings, and can take both short LDAP username or full DN as an input user, or none to create one for the authenticated user.

Adds `mc idp ldap accesskey create --login` for use in an interactive terminal, which allows a user to input their LDAP username and password and returns a corresponding access key with desired settings.

Changes `mc idp ldap accesskey list` so it uses new API endpoint, which verifies the user is in LDAP and can take both short username and full DN. Also changes `--temp-only` to `--sts-only` and `--permanent-only` to `--svcacct-only` to avoid confusion.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
