### PR TITLE
Fix a panic for bucket heal

### DIFF
--- a/cmd/admin-heal-result-item.go
+++ b/cmd/admin-heal-result-item.go
@@ -61,9 +61,18 @@ func (h hri) getReplicatedFileHCCChange() (b, a col, err error) {
 	getColCode := func(numAvail int) (c col, err error) {
 		// calculate color code for replicated object similar
 		// to erasure coded objects
-		quorum := h.DiskCount/h.SetCount/2 + 1
-		surplus := numAvail/h.SetCount - quorum
-		parity := h.DiskCount/h.SetCount - quorum
+		var quorum, surplus, parity int
+		if h.SetCount > 0 {
+			quorum = h.DiskCount/h.SetCount/2 + 1
+			surplus = numAvail/h.SetCount - quorum
+			parity = h.DiskCount/h.SetCount - quorum
+		} else {
+			// in case of bucket healing, disk count is for the node
+			// also explicitly set count would be set to invalid value of -1
+			quorum = h.DiskCount/2 + 1
+			surplus = numAvail - quorum
+			parity = h.DiskCount - quorum
+		}
 		c, err = getHColCode(surplus, parity)
 		return
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
The bucket heal at node level changes caused a panic while `mc admin heal -r --remove`. With this change, the feature would without breaking.

## How to test this PR?
`./mc mb myminio/test-bucket`
`./mc admin heal myminio -r --remove`
It should not panic

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
