### PR TITLE
decom: status clearly shows that the it is about raw disk usage

### DIFF
--- a/cmd/admin-decom-status.go
+++ b/cmd/admin-decom-status.go
@@ -139,14 +139,14 @@ func mainAdminDecommissionStatus(ctx *cli.Context) error {
 	cellText[0] = []string{
 		"ID",
 		"Pools",
-		"Capacity",
+		"Raw Drives Usage",
 		"Status",
 	}
 	for idx, pool := range poolStatuses {
 		idx++
 		totalSize := uint64(pool.Decommission.TotalSize)
-		currentSize := uint64(pool.Decommission.CurrentSize)
-		capacity := humanize.IBytes(totalSize-currentSize) + " (used) / " + humanize.IBytes(totalSize) + " (total)"
+		usedCurrent := uint64(pool.Decommission.TotalSize - pool.Decommission.CurrentSize)
+		capacity := fmt.Sprintf("%.1f%% (total: %s)", 100*float64(usedCurrent)/float64(totalSize), humanize.IBytes(totalSize))
 		status := "Active"
 		if pool.Decommission != nil {
 			if pool.Decommission.Complete {


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Some users are confused about the 'Capacity' wording and think 
this is about the objects usage, not disk usage; 

Change the wording to make this is more clear.

```
➜  ./mc admin decom status play                                    
┌─────┬───────────────────┬──────────────────────┬────────┐  
│ ID  │ Pools             │ Raw Drives Usage     │ Status │          
│ 1st │ /disk{1...4}/data │ 2.8% (total: 80 GiB) │ Active │
└─────┴───────────────────┴──────────────────────┴────────┘
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
