### PR TITLE
Accept --license flag in `mc license register`

### DIFF
--- a/cmd/license-info.go
+++ b/cmd/license-info.go
@@ -179,7 +179,7 @@ func mainLicenseInfo(ctx *cli.Context) error {
 	initLicInfoColors()
 
 	aliasedURL := ctx.Args().Get(0)
-	alias, _ := initSubnetConnectivity(ctx, aliasedURL, false)
+	alias, _ := initSubnetConnectivity(ctx, aliasedURL, false, true)
 
 	apiKey, lic, e := getSubnetCreds(alias)
 	fatalIf(probe.NewError(e), "Error in checking cluster registration status")

--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
@@ -40,6 +41,10 @@ var licenseRegisterFlags = append([]cli.Flag{
 	cli.StringFlag{
 		Name:  "name",
 		Usage: "Specify the name to associate to this MinIO cluster in SUBNET",
+	},
+	cli.StringFlag{
+		Name:  "license",
+		Usage: "License of the account on SUBNET",
 	},
 }, subnetCommonFlags...)
 
@@ -63,14 +68,17 @@ EXAMPLES:
   1. Register MinIO cluster at alias 'play' on SUBNET, using api key for auth
      {{.Prompt}} {{.HelpName}} play --api-key 08efc836-4289-dbd4-ad82-b5e8b6d25577
 
-  2. Register MinIO cluster at alias 'play' on SUBNET, using api key for auth,
+  2. Register MinIO cluster at alias 'play' on SUBNET, using license file ./minio.license
+     {{.Prompt}} {{.HelpName}} play --license ./minio.license
+
+  3. Register MinIO cluster at alias 'play' on SUBNET, using api key for auth,
      and "play-cluster" as the preferred name for the cluster on SUBNET.
      {{.Prompt}} {{.HelpName}} play --api-key 08efc836-4289-dbd4-ad82-b5e8b6d25577 --name play-cluster
 
-  3. Register MinIO cluster at alias 'play' on SUBNET in an airgapped environment
+  4. Register MinIO cluster at alias 'play' on SUBNET in an airgapped environment
      {{.Prompt}} {{.HelpName}} play --airgap
 
-  4. Register MinIO cluster at alias 'play' on SUBNET, using alias as the cluster name.
+  5. Register MinIO cluster at alias 'play' on SUBNET, using alias as the cluster name.
      This asks for SUBNET credentials if the cluster is not already registered.
      {{.Prompt}} {{.HelpName}} play
 `,
@@ -203,7 +211,17 @@ func mainLicenseRegister(ctx *cli.Context) error {
 	aliasedURL := ctx.Args().Get(0)
 	validateNotPlay(aliasedURL)
 
-	alias, accAPIKey := initSubnetConnectivity(ctx, aliasedURL, true)
+	licFile := ctx.String("license")
+
+	var alias, accAPIKey string
+	if len(licFile) > 0 {
+		licBytes, e := os.ReadFile(licFile)
+		fatalIf(probe.NewError(e), fmt.Sprintf("Unable to read license file %s", licFile))
+		alias, _ = url2Alias(aliasedURL)
+		accAPIKey = validateAndSaveLic(string(licBytes), alias, true)
+	} else {
+		alias, accAPIKey = initSubnetConnectivity(ctx, aliasedURL, true, false)
+	}
 
 	clusterName := ctx.String("name")
 	if len(clusterName) == 0 {
@@ -217,14 +235,7 @@ func mainLicenseRegister(ctx *cli.Context) error {
 	regInfo := getClusterRegInfo(getAdminInfo(aliasedURL), clusterName)
 
 	lrm := licRegisterMessage{Status: "success", Alias: alias}
-	if globalAirgapped {
-		lrm.Type = "offline"
-
-		regToken, e := generateRegToken(regInfo)
-		fatalIf(probe.NewError(e), "Unable to generate registration token")
-
-		lrm.URL = subnetOfflineRegisterURL(regToken)
-	} else {
+	if !globalAirgapped {
 		alreadyRegistered := false
 		if len(accAPIKey) == 0 {
 			apiKey, _, e := getSubnetCreds(alias)
@@ -242,14 +253,25 @@ func mainLicenseRegister(ctx *cli.Context) error {
 
 		lrm.Type = "online"
 		_, _, e := registerClusterOnSubnet(regInfo, alias, accAPIKey)
-		fatalIf(probe.NewError(e), "Could not register cluster with SUBNET:")
-
-		lrm.Action = "registered"
-		if alreadyRegistered {
-			lrm.Action = "updated"
+		if e == nil {
+			lrm.Action = "registered"
+			if alreadyRegistered {
+				lrm.Action = "updated"
+			}
+			printMsg(lrm)
+			return nil
 		}
+
+		console.Println("Could not register cluster with SUBNET: ", e.Error())
 	}
 
+	// Airgapped mode OR online mode with registration failure
+	lrm.Type = "offline"
+
+	regToken, e := generateRegToken(regInfo)
+	fatalIf(probe.NewError(e), "Unable to generate registration token")
+
+	lrm.URL = subnetOfflineRegisterURL(regToken)
 	printMsg(lrm)
 	return nil
 }

--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -44,7 +44,7 @@ var licenseRegisterFlags = append([]cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "license",
-		Usage: "License of the account on SUBNET",
+		Usage: "license of the account on SUBNET",
 	},
 }, subnetCommonFlags...)
 

--- a/cmd/license-unregister.go
+++ b/cmd/license-unregister.go
@@ -83,7 +83,7 @@ func mainLicenseUnregister(ctx *cli.Context) error {
 	checkLicenseUnregisterSyntax(ctx)
 
 	aliasedURL := ctx.Args().Get(0)
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, false)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, false, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -782,7 +782,7 @@ func getAPIKeyFlag(ctx *cli.Context) (string, error) {
 	return apiKey, nil
 }
 
-func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, forUpload bool) (string, string) {
+func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, forUpload bool, failOnConnErr bool) (string, string) {
 	e := validateSubnetFlags(ctx, forUpload)
 	fatalIf(probe.NewError(e), "Invalid flags:")
 
@@ -797,7 +797,10 @@ func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, forUpload bool)
 		fatalIf(probe.NewError(e), "Error in setting SUBNET proxy:")
 
 		sbu := subnetBaseURL()
-		fatalIf(checkURLReachable(sbu).Trace(aliasedURL), "Unable to reach %s, please use --airgap if there is no connectivity to SUBNET", sbu)
+		err := checkURLReachable(sbu)
+		if err != nil && failOnConnErr {
+			fatal(err.Trace(aliasedURL), "Unable to reach %s, please use --airgap if there is no connectivity to SUBNET", sbu)
+		}
 	}
 
 	return alias, apiKey

--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -168,7 +168,7 @@ func mainSupportDiag(ctx *cli.Context) error {
 
 	// Get the alias parameter from cli
 	aliasedURL := ctx.Args().Get(0)
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)

--- a/cmd/support-inspect.go
+++ b/cmd/support-inspect.go
@@ -122,7 +122,7 @@ func mainSupportInspect(ctx *cli.Context) error {
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
 
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -461,7 +461,7 @@ func convertPerfResults(results []PerfTestResult) PerfTestOutput {
 }
 
 func execSupportPerf(ctx *cli.Context, aliasedURL, perfType string) {
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -169,7 +169,7 @@ func mainSupportProfile(ctx *cli.Context) error {
 
 	// Get the alias parameter from cli
 	aliasedURL := ctx.Args().Get(0)
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

If passed,

- validate and save it immediately in subnet config
- extract api key from it, and use for online registration with SUBNET (if `--airgap` is not passed)
- in case online registration with SUBNET fails for any reason, fallback to airgap mode (show URL to be visited on SUBNET)

## Motivation and Context

As SUBNET has moved to account level licenses, it is possible to download license even before the cluster is registered.
We'll now allow this license file to be used for registering clusters. This will simplify airgap mode registration as user will not
have to come back and update the license on mc/minio side.

## How to test this PR?

- Download license file from SUBNET
- Run `mc license register <alias> --license </path/to/minio.license>`
- Verify that registration is succesful

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
