### PR TITLE
Set exitcode on copy/mirror source failure

### DIFF
--- a/cmd/cp-main.go
+++ b/cmd/cp-main.go
@@ -659,6 +659,11 @@ loop:
 		}
 	}
 
+	// Source has error
+	if errSeen && totalObjects == 0 && retErr == nil {
+		retErr = exitStatus(globalErrorExitStatus)
+	}
+
 	return retErr
 }
 

--- a/cmd/cp-url.go
+++ b/cmd/cp-url.go
@@ -361,6 +361,10 @@ func prepareCopyURLs(ctx context.Context, o prepareCopyURLsOpts) chan URLs {
 	go func() {
 		defer close(finalCopyURLsCh)
 		for cpURLs := range copyURLsCh {
+			if cpURLs.Error != nil {
+				finalCopyURLsCh <- cpURLs
+				continue
+			}
 			// Skip objects older than --older-than parameter if specified
 			if o.olderThan != "" && isOlder(cpURLs.SourceContent.Time, o.olderThan) {
 				continue


### PR DESCRIPTION
## Description

Also fixes errors potentially being swallowed by filtering.

Fixes #4773

```
λ go build&&mc cp s3/default/1.mp4 1.mp4
mc: <ERROR> Unable to prepare URL for copying. Unable to guess the type of copy operation.

λ echo %errorlevel%
1
```

## How to test this PR?

See above and #4773

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
