### PR TITLE
Add missing space between 'at' and filename

### DIFF
--- a/cmd/support-diag.go
+++ b/cmd/support-diag.go
@@ -142,7 +142,7 @@ func tarGZ(healthInfo interface{}, version, filename string) error {
 		warningMsgHeader := infoText(warningMsgBoundary)
 		warningMsgTrailer := infoText(warningMsgBoundary)
 		console.Printf("%s\n%s\n%s\n%s\n", warningMsgHeader, warning, warningContents, warningMsgTrailer)
-		console.Infoln("MinIO diagnostics report saved at", filename)
+		console.Infoln("MinIO diagnostics report saved at ", filename)
 	}
 
 	return nil


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

When the report is generated in airgap mode, mc shows a message

MinIO diagnostics report saved at<filename>

Here a space is missing between 'at' and the filename. Add the same.

## Motivation and Context

Bugfix

## How to test this PR?

- Run `mc support diag <alias> --airgap`
- Verify that the message printed after generating the report contains a space between 'at' and the filename
e.g. `MinIO diagnostics report saved at myminio-health_20240103114649.json.gz`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
