### PR TITLE
ILM rule type filter flags should work with --json

### DIFF
--- a/cmd/ilm/utils.go
+++ b/cmd/ilm/utils.go
@@ -82,7 +82,7 @@ func getTransitionDays(rule lifecycle.Rule) int {
 }
 
 // ToTables converts a lifecycle.Configuration into its tabular representation.
-func ToTables(cfg *lifecycle.Configuration, filter LsFilter) []Table {
+func ToTables(cfg *lifecycle.Configuration) []Table {
 	var tierCur tierCurrentTable
 	var tierNoncur tierNoncurrentTable
 	var expCur expirationCurrentTable
@@ -130,12 +130,15 @@ func ToTables(cfg *lifecycle.Configuration, filter LsFilter) []Table {
 		}
 	}
 
-	switch filter {
-	case ExpiryOnly:
-		return []Table{expCur, expNoncur}
-	case TransitionOnly:
-		return []Table{tierCur, tierNoncur}
-	default:
-		return []Table{tierCur, tierNoncur, expCur, expNoncur}
+	var table []Table
+	inclTbl := func(tbl Table) {
+		if len(tbl.Rows()) > 0 {
+			table = append(table, tbl)
+		}
 	}
+	inclTbl(expCur)
+	inclTbl(expNoncur)
+	inclTbl(tierCur)
+	inclTbl(tierNoncur)
+	return table
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
`mc ilm rule ls --expiry --json ALIAS/bucket` returns the following error message,
`only one display field flag is allowed per ls command. Refer mc rule list --help.`
 
 This PR fixes this and allows for rule type filters to work with `--json` formatted output too.

## Motivation and Context
Allow users to filter by ILM rule type in `--json` output format too.


## How to test this PR?
1. `mc ilm rule ls --expiry --json ALIAS/bucket`
2. `mc ilm rule ls --transition --json ALIAS/bucket`
3. `mc ilm rule ls --json ALIAS/bucket`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
