### PR TITLE
Making cli pager optional + better visual indicators for scrolling

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -39,11 +39,6 @@ var globalFlags = []cli.Flag{
 		EnvVar: envPrefix + "QUIET",
 	},
 	cli.BoolFlag{
-		Name:   "disable-pager, dp",
-		Usage:  "disable mc internal pager and print to raw stdout",
-		EnvVar: envPrefix + "DISABLE_PAGER",
-	},
-	cli.BoolFlag{
 		Name:   "no-color",
 		Usage:  "disable color theme",
 		EnvVar: envPrefix + "NO_COLOR",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -39,6 +39,12 @@ var globalFlags = []cli.Flag{
 		EnvVar: envPrefix + "QUIET",
 	},
 	cli.BoolFlag{
+		Name:   "disable-pager, dp",
+		Usage:  "disable mc internal pager and print to raw stdout",
+		EnvVar: envPrefix + "DISABLE_PAGER",
+		Hidden: true,
+	},
+	cli.BoolFlag{
 		Name:   "no-color",
 		Usage:  "disable color theme",
 		EnvVar: envPrefix + "NO_COLOR",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -39,6 +39,11 @@ var globalFlags = []cli.Flag{
 		EnvVar: envPrefix + "QUIET",
 	},
 	cli.BoolFlag{
+		Name:   "disable-pager, dp",
+		Usage:  "disable mc internal pager and print to raw stdout",
+		EnvVar: envPrefix + "DISABLE_PAGER",
+	},
+	cli.BoolFlag{
 		Name:   "no-color",
 		Usage:  "disable color theme",
 		EnvVar: envPrefix + "NO_COLOR",

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/x509"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -85,11 +86,32 @@ var (
 	// Terminal height/width, zero if not found
 	globalTermWidth, globalTermHeight int
 
-	globalHelpPager *termPager
+	globalDisablePagerFlag  = "--disable-pager"
+	globalPagerDisabled     = false
+	globalHelpPager         *termPager
+	globalPagerEnabledTerms = map[string]bool{
+		"xterm":          true,
+		"xterm-256color": true,
+		"tmux":           true,
+		"tmux-256color":  true,
+	}
 
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool
 )
+
+func terminalSupportsPager() (ok bool) {
+	_, ok = globalPagerEnabledTerms[os.Getenv("TERM")]
+	return
+}
+
+func parsePagerDisableFlag(args []string) {
+	for _, arg := range args {
+		if arg == globalDisablePagerFlag {
+			globalPagerDisabled = true
+		}
+	}
+}
 
 // Set global states. NOTE: It is deliberately kept monolithic to ensure we dont miss out any flags.
 func setGlobalsFromContext(ctx *cli.Context) error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,6 +137,7 @@ func Main(args []string) error {
 	// Wait until the user quits the pager
 	defer globalHelpPager.WaitForExit()
 
+	parsePagerDisableFlag(args)
 	// Run the app
 	return registerApp(appName).Run(args)
 }
@@ -510,8 +511,11 @@ func registerApp(name string) *cli.App {
 	app.CustomAppHelpTemplate = mcHelpTemplate
 	app.EnableBashCompletion = true
 	app.OnUsageError = onUsageError
-	if isTerminal() {
+
+	if isTerminal() && terminalSupportsPager() && !globalPagerDisabled {
 		app.HelpWriter = globalHelpPager
+	} else {
+		app.HelpWriter = os.Stdout
 	}
 
 	return app

--- a/cmd/term-pager.go
+++ b/cmd/term-pager.go
@@ -105,27 +105,21 @@ func (m model) footerView() string {
 	if m.viewport.Width == 0 {
 		return ""
 	}
-
-	percent := percentStyle.Render(fmt.Sprintf("%d%%", int(m.viewport.ScrollPercent()*100)))
-	info := fmt.Sprintf(" %s", percent)
-	totalLength := m.viewport.Width - lipgloss.Width(info)
-	var finishedCount int
-	var onePart int
-	if totalLength <= 99 {
-		onePart = m.viewport.Width / 5
-		if !math.IsNaN(m.viewport.ScrollPercent()) {
-			finishedCount = onePart * min(5, int(m.viewport.ScrollPercent()*100)/20)
-		}
-	} else {
-		onePart = max(1, totalLength/100)
-		if !math.IsNaN(m.viewport.ScrollPercent()) {
-			finishedCount = onePart * min(100, int(m.viewport.ScrollPercent()*100))
-		}
+	if math.IsNaN(m.viewport.ScrollPercent()) {
+		return ""
 	}
 
-	lineDone := strings.Repeat("/", finishedCount)
-	line := strings.Repeat("─", max(0, totalLength-finishedCount-5))
-	return lipgloss.JoinHorizontal(lipgloss.Center, info, lineDone, line)
+	viewP := int(m.viewport.ScrollPercent() * 100)
+	info := fmt.Sprintf(" %s", percentStyle.Render(fmt.Sprintf("%d%%", viewP)))
+	totalLength := m.viewport.Width - lipgloss.Width(info)
+	finishedCount := int((float64(totalLength) / 100) * float64(viewP))
+
+	return lipgloss.JoinHorizontal(
+		lipgloss.Center,
+		info,
+		strings.Repeat("/", finishedCount),
+		strings.Repeat("─", max(0, totalLength-finishedCount)),
+	)
 }
 
 type termPager struct {

--- a/cmd/term-pager.go
+++ b/cmd/term-pager.go
@@ -109,12 +109,21 @@ func (m model) footerView() string {
 	percent := percentStyle.Render(fmt.Sprintf("%d%%", int(m.viewport.ScrollPercent()*100)))
 	info := fmt.Sprintf(" %s", percent)
 	totalLength := m.viewport.Width - lipgloss.Width(info)
-	onePart := max(0, totalLength/100)
 	var finishedCount int
-	if !math.IsNaN(m.viewport.ScrollPercent()) {
-		finishedCount = onePart * min(100, int(m.viewport.ScrollPercent()*100))
+	var onePart int
+	if totalLength <= 99 {
+		onePart = m.viewport.Width / 5
+		if !math.IsNaN(m.viewport.ScrollPercent()) {
+			finishedCount = onePart * min(5, int(m.viewport.ScrollPercent()*100)/20)
+		}
+	} else {
+		onePart = max(1, totalLength/100)
+		if !math.IsNaN(m.viewport.ScrollPercent()) {
+			finishedCount = onePart * min(100, int(m.viewport.ScrollPercent()*100))
+		}
 	}
-	lineDone := strings.Repeat("/", max(0, finishedCount))
+
+	lineDone := strings.Repeat("/", finishedCount)
 	line := strings.Repeat("─", max(0, totalLength-finishedCount-5))
 	return lipgloss.JoinHorizontal(lipgloss.Center, info, lineDone, line)
 }

--- a/cmd/term-pager.go
+++ b/cmd/term-pager.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/muesli/reflow/wordwrap"
 )
 
-var percentStyle = lipgloss.NewStyle().Width(5).Align(lipgloss.Left)
+var percentStyle = lipgloss.NewStyle().Width(4).Align(lipgloss.Left)
 
 type model struct {
 	viewport viewport.Model
@@ -100,10 +101,22 @@ func (m model) headerView() string {
 }
 
 func (m model) footerView() string {
+	// Disables printing if the viewport is not ready
+	if m.viewport.Width == 0 {
+		return ""
+	}
+
 	percent := percentStyle.Render(fmt.Sprintf("%d%%", int(m.viewport.ScrollPercent()*100)))
 	info := fmt.Sprintf(" %s", percent)
-	line := strings.Repeat("─", max(0, m.viewport.Width-lipgloss.Width(info)))
-	return lipgloss.JoinHorizontal(lipgloss.Center, line, info)
+	totalLength := m.viewport.Width - lipgloss.Width(info)
+	onePart := max(0, totalLength/100)
+	var finishedCount int
+	if !math.IsNaN(m.viewport.ScrollPercent()) {
+		finishedCount = onePart * min(100, int(m.viewport.ScrollPercent()*100))
+	}
+	lineDone := strings.Repeat("/", max(0, finishedCount))
+	line := strings.Repeat("─", max(0, totalLength-finishedCount-5))
+	return lipgloss.JoinHorizontal(lipgloss.Center, info, lineDone, line)
 }
 
 type termPager struct {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -82,6 +82,13 @@ func max(a, b int) int {
 	return b
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // randString generates random names and prepends them with a known prefix.
 func randString(n int, src rand.Source, prefix string) string {
 	if n == 0 {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -82,13 +82,6 @@ func max(a, b int) int {
 	return b
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // randString generates random names and prepends them with a known prefix.
 func randString(n int, src rand.Source, prefix string) string {
 	if n == 0 {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
This PR is a replacement for [another PR](https://github.com/minio/mc/pull/4816) which completely removed the pager. The decision was made to keep the pager but instead trigger on the TERM environment variable. 

I added an additional way to manually disable the pager using a `--disable-pager` flag.
**The name and/or usage of the flag is up for discussion in this PR**

## Motivation and Context
We had some clients talking about the mc client not exiting straight to terminal. Many cli tools have this scroll behavior but not everyone is a fan of it. This way we can prevent the behavior in non-supported terminals and let the user decide whether they want it or not. 

# Additional formatting changes
Currently the scroll indicator is located on the bottom right of the screen, which is normally the last part of the screen users look at when it comes to GUIs/Terminal usage. I've moved the percentage sign to the bottom left, where user is more likely to see it and added a scroll status indicator for the footer. 

NO SCROLL: 
![image](https://github.com/minio/mc/assets/20964930/538234f9-929c-4d57-ad47-e1285b7ccee9)

SCROLL:
![image](https://github.com/minio/mc/assets/20964930/3ce70b8b-cd0e-4018-bb67-6889b5cffb88)




## How to test this PR?
```bash
$ ./mc --help --disable-pager
```


