### PR TITLE
fix: mirror with local path

### DIFF
--- a/cmd/difference_test.go
+++ b/cmd/difference_test.go
@@ -24,26 +24,40 @@ import (
 var testCases = []struct {
 	pattern []string
 
-	object string
+	srcSuffix string
 
 	match bool
+
+	typ ClientURLType
 }{
-	{nil, "testfile", false},
-	{[]string{"test*"}, "testfile", true},
-	{[]string{"file*"}, "file/abc/bcd/def", true},
-	{[]string{"*"}, "file/abc/bcd/def", true},
-	{[]string{""}, "file/abc/bcd/def", false},
-	{[]string{"abc*"}, "file/abc/bcd/def", false},
-	{[]string{"abc*", "*abc/*"}, "file/abc/bcd/def", true},
-	{[]string{"*.txt"}, "file/abc/bcd/def.txt", true},
-	{[]string{".*"}, ".sys", true},
-	{[]string{"*."}, ".sys.", true},
+	{nil, "testfile", false, objectStorage},
+	{[]string{"test*"}, "testfile", true, objectStorage},
+	{[]string{"file*"}, "file/abc/bcd/def", true, objectStorage},
+	{[]string{"*"}, "file/abc/bcd/def", true, objectStorage},
+	{[]string{""}, "file/abc/bcd/def", false, objectStorage},
+	{[]string{"abc*"}, "file/abc/bcd/def", false, objectStorage},
+	{[]string{"abc*", "*abc/*"}, "file/abc/bcd/def", true, objectStorage},
+	{[]string{"*.txt"}, "file/abc/bcd/def.txt", true, objectStorage},
+	{[]string{".*"}, ".sys", true, objectStorage},
+	{[]string{"*."}, ".sys.", true, objectStorage},
+	{nil, "testfile", false, fileSystem},
+	{[]string{"test*"}, "testfile", true, fileSystem},
+	{[]string{"file*"}, "file/abc/bcd/def", true, fileSystem},
+	{[]string{"*"}, "file/abc/bcd/def", true, fileSystem},
+	{[]string{""}, "file/abc/bcd/def", false, fileSystem},
+	{[]string{"abc*"}, "file/abc/bcd/def", false, fileSystem},
+	{[]string{"abc*", "*abc/*"}, "file/abc/bcd/def", true, fileSystem},
+	{[]string{"abc*", "*abc/*"}, "/file/abc/bcd/def", true, fileSystem},
+	{[]string{"*.txt"}, "file/abc/bcd/def.txt", true, fileSystem},
+	{[]string{"*.txt"}, "/file/abc/bcd/def.txt", true, fileSystem},
+	{[]string{".*"}, ".sys", true, fileSystem},
+	{[]string{"*."}, ".sys.", true, fileSystem},
 }
 
 func TestExcludeOptions(t *testing.T) {
 	for _, test := range testCases {
-		if matchExcludeOptions(test.pattern, test.object) != test.match {
-			t.Fatalf("Unexpected result %t, with pattern %s and object %s \n", !test.match, test.pattern, test.object)
+		if matchExcludeOptions(test.pattern, test.srcSuffix, test.typ) != test.match {
+			t.Fatalf("Unexpected result %t, with pattern %s and srcSuffix %s \n", !test.match, test.pattern, test.srcSuffix)
 		}
 	}
 }

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -620,7 +620,7 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 		// joined to the targetURL.
 		sourceSuffix := strings.TrimPrefix(eventPath, sourceURLFull)
 		// Skip the object, if it matches the Exclude options provided
-		if matchExcludeOptions(mj.opts.excludeOptions, sourceSuffix) {
+		if matchExcludeOptions(mj.opts.excludeOptions, sourceSuffix, sourceURL.Type) {
 			continue
 		}
 

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -94,7 +94,7 @@ func matchExcludeOptions(excludeOptions []string, srcSuffix string, typ ClientUR
 	if typ == fileSystem {
 		if strings.HasPrefix(srcSuffix, "/") {
 			srcSuffix = srcSuffix[1:]
-		} else if runtime.GOOS == "windows" && strings.HasPrefix(srcSuffix, "\\") {
+		} else if runtime.GOOS == "windows" && strings.HasPrefix(srcSuffix, `\`) {
 			srcSuffix = srcSuffix[2:]
 		}
 	}

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -89,7 +89,15 @@ func checkMirrorSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB map[st
 	return
 }
 
-func matchExcludeOptions(excludeOptions []string, srcSuffix string) bool {
+func matchExcludeOptions(excludeOptions []string, srcSuffix string, typ ClientURLType) bool {
+	// if type is file system, remove leading slash
+	if typ == fileSystem {
+		if strings.HasPrefix(srcSuffix, "/") {
+			srcSuffix = srcSuffix[1:]
+		} else if runtime.GOOS == "windows" && strings.HasPrefix(srcSuffix, "\\") {
+			srcSuffix = srcSuffix[2:]
+		}
+	}
 	for _, pattern := range excludeOptions {
 		if wildcard.Match(pattern, srcSuffix) {
 			return true
@@ -146,13 +154,13 @@ func deltaSourceTarget(ctx context.Context, sourceURL, targetURL string, opts mi
 
 		srcSuffix := strings.TrimPrefix(diffMsg.FirstURL, sourceURL)
 		// Skip the source object if it matches the Exclude options provided
-		if matchExcludeOptions(opts.excludeOptions, srcSuffix) {
+		if matchExcludeOptions(opts.excludeOptions, srcSuffix, newClientURL(sourceURL).Type) {
 			continue
 		}
 
 		tgtSuffix := strings.TrimPrefix(diffMsg.SecondURL, targetURL)
 		// Skip the target object if it matches the Exclude options provided
-		if matchExcludeOptions(opts.excludeOptions, tgtSuffix) {
+		if matchExcludeOptions(opts.excludeOptions, tgtSuffix, newClientURL(targetURL).Type) {
 			continue
 		}
 

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -95,7 +95,7 @@ func matchExcludeOptions(excludeOptions []string, srcSuffix string, typ ClientUR
 		if strings.HasPrefix(srcSuffix, "/") {
 			srcSuffix = srcSuffix[1:]
 		} else if runtime.GOOS == "windows" && strings.HasPrefix(srcSuffix, `\`) {
-			srcSuffix = srcSuffix[2:]
+			srcSuffix = srcSuffix[1:]
 		}
 	}
 	for _, pattern := range excludeOptions {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

There have path with `/` start when local file path.
before:
`mc mirror --exclude "*.yaml" localPath` will not work.
now:
it work.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix https://github.com/minio/mc/issues/4082
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
