### PR TITLE
fix validation in replicate rm to allow stale target cleanup

### DIFF
--- a/cmd/replicate-remove.go
+++ b/cmd/replicate-remove.go
@@ -19,7 +19,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
@@ -131,13 +130,18 @@ func mainReplicateRemove(cliCtx *cli.Context) error {
 	rcfg, err := client.GetReplication(ctx)
 	fatalIf(err.Trace(args...), "Unable to get replication configuration")
 
-	if rcfg.Empty() {
-		fatalIf(probe.NewError(errors.New("replication configuration not set")).Trace(aliasedURL),
-			"Unable to remove replication configuration")
-	}
 	rmAll := cliCtx.Bool("all")
 	rmForce := cliCtx.Bool("force")
 	ruleID := cliCtx.String("id")
+
+	if rcfg.Empty() && !rmAll {
+		printMsg(replicateRemoveMessage{
+			Op:     cliCtx.Command.Name,
+			Status: "success",
+			URL:    aliasedURL,
+		})
+		return nil
+	}
 	if rmAll && rmForce {
 		fatalIf(client.RemoveReplication(ctx), "Unable to remove replication configuration")
 	} else {


### PR DESCRIPTION
when --all --force is specified, send request to server even if replication config is not found to allow stale target cleanup

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
proper cleanup of partially created replication config.

## How to test this PR?
need a 2022 mc version which allowed separate remote target creation before use in replication rule. add a target, then use latest to `mc replicate rm --all --force` on a bucket where repl.config is not configured. It should clean up all targets for the bucket (see mc admin bucket remote ls output of older mc)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
