### PR TITLE
Removing terminal whitelist for pager mechanism

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/x509"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -86,25 +85,13 @@ var (
 	// Terminal height/width, zero if not found
 	globalTermWidth, globalTermHeight int
 
-	globalDisablePagerFlag  = "--disable-pager"
-	globalPagerDisabled     = false
-	globalHelpPager         *termPager
-	globalPagerEnabledTerms = map[string]bool{
-		"screen-256color": true,
-		"xterm":           true,
-		"xterm-256color":  true,
-		"tmux":            true,
-		"tmux-256color":   true,
-	}
+	globalDisablePagerFlag = "--disable-pager"
+	globalPagerDisabled    = false
+	globalHelpPager        *termPager
 
 	// CA root certificates, a nil value means system certs pool will be used
 	globalRootCAs *x509.CertPool
 )
-
-func terminalSupportsPager() (ok bool) {
-	_, ok = globalPagerEnabledTerms[os.Getenv("TERM")]
-	return
-}
 
 func parsePagerDisableFlag(args []string) {
 	for _, arg := range args {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -512,7 +512,7 @@ func registerApp(name string) *cli.App {
 	app.EnableBashCompletion = true
 	app.OnUsageError = onUsageError
 
-	if isTerminal() &&  !globalPagerDisabled {
+	if isTerminal() && !globalPagerDisabled {
 		app.HelpWriter = globalHelpPager
 	} else {
 		app.HelpWriter = os.Stdout

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -512,7 +512,7 @@ func registerApp(name string) *cli.App {
 	app.EnableBashCompletion = true
 	app.OnUsageError = onUsageError
 
-	if isTerminal() && terminalSupportsPager() && !globalPagerDisabled {
+	if isTerminal() &&  !globalPagerDisabled {
 		app.HelpWriter = globalHelpPager
 	} else {
 		app.HelpWriter = os.Stdout


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Removing the whitelist mechanism for the terminal pager. It should not have been added with the pager update PR. It's not breaking anything but it's not good for us to have to add every terminal type that is supported. 

We already have --disable-pager flag for when it's needed.
