### PR TITLE
fix: add error message to mc put

### DIFF
--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -507,7 +507,7 @@ var completeCmds = map[string]complete.Predictor{
 	"/quota/set":   aliasCompleter,
 	"/quota/info":  aliasCompleter,
 	"/quota/clear": aliasCompleter,
-	"/put":         aliasCompleter,
+	"/put":         complete.PredictOr(s3Completer, fsCompleter),
 }
 
 // flagsToCompleteFlags transforms a cli.Flag to complete.Flags


### PR DESCRIPTION
error message

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
error message add for:
```log
mc: <ERROR> Unable to upload. Source is not local filepath.
mc: <ERROR> Unable to upload. Target is not s3.
mc: <ERROR> Unable to upload. Bucket should not be empty.
mc: <ERROR> Unable to upload. Requested path `/minio/*.yaml` not found
mc: <ERROR> Unable to upload. Source is not local filepath.
```
enable auto complete:
can `auto complete`


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
