### PR TITLE
mc support commands: allow --json in online mode

### DIFF
--- a/cmd/license-info.go
+++ b/cmd/license-info.go
@@ -179,7 +179,7 @@ func mainLicenseInfo(ctx *cli.Context) error {
 	initLicInfoColors()
 
 	aliasedURL := ctx.Args().Get(0)
-	alias, _ := initSubnetConnectivity(ctx, aliasedURL, false, true)
+	alias, _ := initSubnetConnectivity(ctx, aliasedURL, true)
 
 	apiKey, lic, e := getSubnetCreds(alias)
 	fatalIf(probe.NewError(e), "Error in checking cluster registration status")

--- a/cmd/license-register.go
+++ b/cmd/license-register.go
@@ -220,7 +220,7 @@ func mainLicenseRegister(ctx *cli.Context) error {
 		alias, _ = url2Alias(aliasedURL)
 		accAPIKey = validateAndSaveLic(string(licBytes), alias, true)
 	} else {
-		alias, accAPIKey = initSubnetConnectivity(ctx, aliasedURL, true, false)
+		alias, accAPIKey = initSubnetConnectivity(ctx, aliasedURL, false)
 	}
 
 	clusterName := ctx.String("name")

--- a/cmd/license-unregister.go
+++ b/cmd/license-unregister.go
@@ -83,7 +83,7 @@ func mainLicenseUnregister(ctx *cli.Context) error {
 	checkLicenseUnregisterSyntax(ctx)
 
 	aliasedURL := ctx.Args().Get(0)
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, false, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -783,7 +783,7 @@ func getAPIKeyFlag(ctx *cli.Context) (string, error) {
 }
 
 func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, failOnConnErr bool) (string, string) {
-	if ctx.IsSet("airgap") && len(ctx.String("api-key")) > 0 {
+	if ctx.Bool("airgap") && len(ctx.String("api-key")) > 0 {
 		fatal(errDummy().Trace(), "--api-key is not applicable in airgap mode")
 	}
 

--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -782,9 +782,10 @@ func getAPIKeyFlag(ctx *cli.Context) (string, error) {
 	return apiKey, nil
 }
 
-func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, forUpload bool, failOnConnErr bool) (string, string) {
-	e := validateSubnetFlags(ctx, forUpload)
-	fatalIf(probe.NewError(e), "Invalid flags:")
+func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, failOnConnErr bool) (string, string) {
+	if ctx.IsSet("airgap") && len(ctx.String("api-key")) > 0 {
+		fatal(errDummy().Trace(), "--api-key is not applicable in airgap mode")
+	}
 
 	alias, _ := url2Alias(aliasedURL)
 
@@ -804,18 +805,4 @@ func initSubnetConnectivity(ctx *cli.Context, aliasedURL string, forUpload bool,
 	}
 
 	return alias, apiKey
-}
-
-func validateSubnetFlags(ctx *cli.Context, forUpload bool) error {
-	if !globalAirgapped {
-		if globalJSON && forUpload {
-			return errors.New("--json is applicable only when --airgap is also passed")
-		}
-		return nil
-	}
-
-	if len(ctx.String("api-key")) > 0 {
-		return errors.New("--api-key is not applicable in airgap mode")
-	}
-	return nil
 }

--- a/cmd/support-perf.go
+++ b/cmd/support-perf.go
@@ -461,7 +461,7 @@ func convertPerfResults(results []PerfTestResult) PerfTestOutput {
 }
 
 func execSupportPerf(ctx *cli.Context, aliasedURL, perfType string) {
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -47,6 +48,36 @@ var (
 )
 
 const profileFile = "profile.zip"
+
+type supportProfileMessage struct {
+	Status string `json:"status"`
+	File   string `json:"file,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Colorized message for console printing.
+func (s supportProfileMessage) String() string {
+	var msg string
+	if s.Error != "" {
+		errMsg := fmt.Sprintln("Unable to upload profile file to SUBNET: ", s.Error)
+		msg := console.Colorize(supportErrorMsgTag, errMsg)
+		infoMsg := fmt.Sprintf("Profiling data saved locally at '%s'", profileFile)
+		msg += console.Colorize(supportSuccessMsgTag, infoMsg)
+		return msg
+	}
+
+	if globalAirgapped {
+		msg = fmt.Sprintf("Profiling data saved successfully at %s", s.File)
+	} else {
+		msg = "Profiling data uploaded to SUBNET successfully"
+	}
+	return console.Colorize(supportSuccessMsgTag, msg)
+}
+
+// JSON jsonified proxy remove message
+func (s supportProfileMessage) JSON() string {
+	return toJSON(s)
+}
 
 var supportProfileCmd = cli.Command{
 	Name:            "profile",
@@ -167,9 +198,12 @@ func mainSupportProfile(ctx *cli.Context) error {
 	// Check for command syntax
 	checkAdminProfileSyntax(ctx)
 
+	setSuccessMessageColor()
+	setErrorMessageColor()
+
 	// Get the alias parameter from cli
 	aliasedURL := ctx.Args().Get(0)
-	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true, true)
+	alias, apiKey := initSubnetConnectivity(ctx, aliasedURL, true)
 	if len(apiKey) == 0 {
 		// api key not passed as flag. Check that the cluster is registered.
 		apiKey = validateClusterRegistered(alias, true)
@@ -196,7 +230,9 @@ func execSupportProfile(ctx *cli.Context, client *madmin.AdminClient, alias, api
 		reqURL, headers = prepareSubnetUploadURL(uploadURL, alias, apiKey)
 	}
 
-	console.Infof("Profiling '%s' for %d seconds... \n", alias, duration)
+	if !globalJSON {
+		console.Infof("Profiling '%s' for %d seconds... \n", alias, duration)
+	}
 	data, e := client.Profile(globalContext, madmin.ProfilerType(profilers), time.Second*time.Duration(duration))
 	fatalIf(probe.NewError(e), "Unable to save profile data")
 
@@ -205,12 +241,20 @@ func execSupportProfile(ctx *cli.Context, client *madmin.AdminClient, alias, api
 	if !globalAirgapped {
 		_, e = uploadFileToSubnet(alias, profileFile, reqURL, headers)
 		if e != nil {
-			errorIf(probe.NewError(e), "Unable to upload profile file to SUBNET")
-			console.Infof("Profiling data saved locally at '%s'\n", profileFile)
+			printMsg(supportProfileMessage{
+				Status: "error",
+				Error:  e.Error(),
+				File:   profileFile,
+			})
 			return
 		}
-		console.Infoln("Profiling data uploaded to SUBNET successfully")
+		printMsg(supportProfileMessage{
+			Status: "success",
+		})
 	} else {
-		console.Infoln("Profiling data saved successfully at ", profileFile)
+		printMsg(supportProfileMessage{
+			Status: "success",
+			File:   profileFile,
+		})
 	}
 }

--- a/cmd/support-proxy-remove.go
+++ b/cmd/support-proxy-remove.go
@@ -44,7 +44,7 @@ var supportProxyRemoveCmd = cli.Command{
 	Action:          mainSupportProxyRemove,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           supportGlobalFlags,
+	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support-proxy-set.go
+++ b/cmd/support-proxy-set.go
@@ -47,7 +47,7 @@ var supportProxySetCmd = cli.Command{
 	Action:          mainSupportProxySet,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           supportGlobalFlags,
+	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support-proxy-show.go
+++ b/cmd/support-proxy-show.go
@@ -28,7 +28,7 @@ var supportProxyShowCmd = cli.Command{
 	Action:          mainSupportProxyShow,
 	OnUsageError:    onUsageError,
 	Before:          setGlobalsFromContext,
-	Flags:           supportGlobalFlags,
+	Flags:           globalFlags,
 	HideHelpCommand: true,
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}

--- a/cmd/support.go
+++ b/cmd/support.go
@@ -29,7 +29,10 @@ import (
 	"github.com/minio/pkg/v2/console"
 )
 
-const supportSuccessMsgTag = "SupportSuccessMessage"
+const (
+	supportSuccessMsgTag = "SupportSuccessMessage"
+	supportErrorMsgTag   = "SupportErrorMessage"
+)
 
 var supportGlobalFlags = append(globalFlags,
 	cli.BoolFlag{
@@ -92,6 +95,10 @@ func checkToggleCmdSyntax(ctx *cli.Context) (string, string) {
 
 func setSuccessMessageColor() {
 	console.SetColor(supportSuccessMsgTag, color.New(color.FgGreen, color.Bold))
+}
+
+func setErrorMessageColor() {
+	console.SetColor(supportErrorMsgTag, color.New(color.FgYellow, color.Italic))
 }
 
 func featureStatusStr(enabled bool) string {


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

There was a validation that said `--json` is supported only when `--airgap` is also passed for SUBNET related `mc support` commands.

Remove this validation to allow `--json` to be passed even in online mode. In this scenario, print a status JSON after upload to SUBNET.

  While at it,
  
  - `mc support profile` currently doesn't support `--json` properly. fix
    it.
  - Remove `--api-key` flat from `mc support proxy` commands as they don't
    need to talk to SUBNET.

## Motivation and Context

Ensure `--json` is supported in all scenarios

## How to test this PR?

- Test `mc support diag|perf|profile|inspect`
  - verify that all of them support `--json` irrespective of whether `--airgap` is passed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
