### PR TITLE
Fix functional-tests.sh file generation under macOS

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -1149,15 +1149,15 @@ function __init__()
     MC_CMD=( "${MC}" --config-dir "$MC_CONFIG_DIR" --quiet --no-color )
 
     if [ ! -e "$FILE_0_B" ]; then
-	base64 /dev/urandom | head -c 0 >"$FILE_0_B"
+	touch "$FILE_0_B"
     fi
 
     if [ ! -e "$FILE_1_MB" ]; then
-	base64 /dev/urandom | head -c 1048576 >"$FILE_1_MB"
+	base64 -i /dev/urandom | head -c 1048576 >"$FILE_1_MB"
     fi
 
     if [ ! -e "$FILE_65_MB" ]; then
-	base64 /dev/urandom | head -c 68157440 >"$FILE_65_MB"
+	base64 -i /dev/urandom | head -c 68157440 >"$FILE_65_MB"
     fi
 
     set -E


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Fixes #4874 

`head -c 0` leads to an `head: illegal byte count -- 0` error under macOS. We should also provide the input with `-i` parameter (it's ok under GNU/Linux too)

## Motivation and Context

I try to get functional tests working under macOS and some other of my systems

## How to test this PR?

Launch `./functional-tests.sh` under macOS or any other system

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
