### PR TITLE
Functional tests: add a parameter for the full site cleaning test

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -65,7 +65,7 @@ if [ -z "${SERVER_ENDPOINT+x}" ]; then
 fi
 
 # If you want to run the complete site cleaning test, set this variable to true 
-COMPLETE_RB_TEST=false
+COMPLETE_RB_TEST=true
 
 WORK_DIR="$PWD"
 DATA_DIR="$MINT_DATA_DIR"

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -278,7 +278,7 @@ function test_rb()
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force "${SERVER_ALIAS}/${bucket1}"
 
     # Test rb with --force and --dangerous to remove a site content
-    if [ "${COMPLETE_RB_TEST}" = "true" ]; then
+    if [ "${COMPLETE_RB_TEST}" == "true" ]; then
         assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${bucket1}"
         assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${bucket2}"
         assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "${FILE_1_MB}" "${SERVER_ALIAS}/${bucket1}/${object_name}"

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -64,6 +64,9 @@ if [ -z "${SERVER_ENDPOINT+x}" ]; then
     ENABLE_HTTPS=1
 fi
 
+# If you want to run the complete site cleaning test, set this variable to true 
+COMPLETE_RB_TEST=false
+
 WORK_DIR="$PWD"
 DATA_DIR="$MINT_DATA_DIR"
 if [ -z "$MINT_MODE" ]; then
@@ -275,13 +278,15 @@ function test_rb()
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force "${SERVER_ALIAS}/${bucket1}"
 
     # Test rb with --force and --dangerous to remove a site content
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${bucket1}"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${bucket2}"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "${FILE_1_MB}" "${SERVER_ALIAS}/${bucket1}/${object_name}"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "${FILE_1_MB}" "${SERVER_ALIAS}/${bucket2}/${object_name}"
-    assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force "${SERVER_ALIAS}/"
-    assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force --dangerous "${SERVER_ALIAS}"
-
+    if [ "${COMPLETE_RB_TEST}" = "true" ]; then
+        assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${bucket1}"
+        assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${bucket2}"
+        assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "${FILE_1_MB}" "${SERVER_ALIAS}/${bucket1}/${object_name}"
+        assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "${FILE_1_MB}" "${SERVER_ALIAS}/${bucket2}/${object_name}"
+        assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force "${SERVER_ALIAS}/"
+        assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rb --force --dangerous "${SERVER_ALIAS}"
+    fi
+    
     log_success "$start_time" "${FUNCNAME[0]}"
 }
 


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Fix #4876 

The latest `mc rb` test clean all the site data, and on the demo site, there are sometimes WORM objects put by some users and it leads to an failure. This test should only be run on sites on which the user knows he can clean everything without errors

## Motivation and Context

I need to run functional tests without errors on the demo site, even if some user put WORM objects in it. The `COMPLETE_RB_TEST` allow to run the "clean everything" test when the user needs it. The parameter name can be changed if it doesn't comply to any mc development rule.

## How to test this PR?

Launch `make test` with `COMPLETE_RB_TEST` parameter set to false/true

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
