### PR TITLE
fix resync to find peers by deployment ID instead of site names

### DIFF
--- a/cmd/admin-replicate-resync-cancel.go
+++ b/cmd/admin-replicate-resync-cancel.go
@@ -92,9 +92,14 @@ func mainAdminReplicateResyncCancel(ctx *cli.Context) error {
 	fatalIf(err, "Unable to initialize admin connection.")
 	info, e := client.SiteReplicationInfo(globalContext)
 	fatalIf(probe.NewError(e), "Unable to fetch site replication info.")
+
+	peerClient := getClient(args.Get(1))
+	peerAdmInfo, e := peerClient.ServerInfo(globalContext)
+	fatalIf(probe.NewError(e), "Unable to fetch server info of the peer.")
+
 	var peer madmin.PeerInfo
 	for _, site := range info.Sites {
-		if args[1] == site.Name {
+		if peerAdmInfo.DeploymentID == site.DeploymentID {
 			peer = site
 		}
 	}

--- a/cmd/admin-replicate-resync-start.go
+++ b/cmd/admin-replicate-resync-start.go
@@ -87,15 +87,20 @@ func mainAdminReplicateResyncStart(ctx *cli.Context) error {
 
 	// Get the alias parameter from cli
 	args := ctx.Args()
-	aliasedURL := args.Get(0)
+
 	// Create a new MinIO Admin Client
-	client, err := newAdminClient(aliasedURL)
+	client, err := newAdminClient(args.Get(0))
 	fatalIf(err, "Unable to initialize admin connection.")
 	info, e := client.SiteReplicationInfo(globalContext)
 	fatalIf(probe.NewError(e), "Unable to fetch site replication info.")
+
+	peerClient := getClient(args.Get(1))
+	peerAdmInfo, e := peerClient.ServerInfo(globalContext)
+	fatalIf(probe.NewError(e), "Unable to fetch server info of the peer.")
+
 	var peer madmin.PeerInfo
 	for _, site := range info.Sites {
-		if args[1] == site.Name {
+		if peerAdmInfo.DeploymentID == site.DeploymentID {
 			peer = site
 		}
 	}

--- a/cmd/admin-replicate-resync-status.go
+++ b/cmd/admin-replicate-resync-status.go
@@ -86,9 +86,14 @@ func mainAdminReplicationResyncStatus(ctx *cli.Context) error {
 		console.Colorize("ResyncMessage", "SiteReplication is not enabled")
 		return nil
 	}
+
+	peerClient := getClient(args.Get(1))
+	peerAdmInfo, e := peerClient.ServerInfo(globalContext)
+	fatalIf(probe.NewError(e), "Unable to fetch server info of the peer.")
+
 	var peer madmin.PeerInfo
 	for _, site := range info.Sites {
-		if args[1] == site.Name {
+		if peerAdmInfo.DeploymentID == site.DeploymentID {
 			peer = site
 		}
 	}


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

The site names may vary if replication sites are added on UI. The Deployment ID is immutable and can be used instead in replicate resync commands.

## Motivation and Context

`mc admin replicate resync` commands should work fine irrespective to the site names configured

## How to test this PR?

- Add a remote site in UI without specifying the site name (The default site name will be set)
- Use `mc admin replicate resync start|status|cancel` commands

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
