### PR TITLE
Add standard EC setting to admin info

### DIFF
--- a/cmd/admin-info.go
+++ b/cmd/admin-info.go
@@ -296,9 +296,10 @@ func (u clusterStruct) String() (msg string) {
 		}
 		// Summary on total no of online and total
 		// number of offline drives at the Cluster level
-		msg += fmt.Sprintf("%s online, %s offline\n",
+		msg += fmt.Sprintf("%s online, %s offline, EC:%d\n",
 			english.Plural(u.Info.Backend.OnlineDisks, "drive", ""),
-			english.Plural(u.Info.Backend.OfflineDisks, "drive", ""))
+			english.Plural(u.Info.Backend.OfflineDisks, "drive", ""),
+			u.Info.Backend.StandardSCParity)
 	}
 
 	// Remove the last new line if any


### PR DESCRIPTION
## Description

Discretely adds the standard EC setting to regular `mc admin info`.

```
λ mc admin info play
●  play.min.io
   Uptime: 1 hour
   Version: 2024-04-15T10:03:01Z
   Network: 1/1 OK
   Drives: 4/4 OK
   Pool: 1

Pools:
   1st, Erasure sets: 1, Drives per erasure set: 4

945 MiB Used, 409 Buckets, 5,498 Objects, 52 Versions, 4 Delete Markers
4 drives online, 0 drives offline, EC:2
```

Will save many deep dives into JSON.


## How to test this PR?

`mc admin info play`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
