### PR TITLE
Fix panic in `mc admin health` command

### DIFF
--- a/cmd/admin-subnet-health.go
+++ b/cmd/admin-subnet-health.go
@@ -32,7 +32,7 @@ var adminSubnetHealthCmd = cli.Command{
 	Action:             mainSubnetHealth,
 	Before:             setGlobalsFromContext,
 	Hidden:             true,
-	Flags:              append(supportDiagFlags, globalFlags...),
+	Flags:              supportDiagFlags, // No need to append globalFlags as top level command would add them
 	CustomHelpTemplate: "This command is deprecated and will be removed in a future release. Use 'mc support diag' instead.\n",
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
The `globalFlags` were getting added twice and so causing duplicate error and so a panic.


## Motivation and Context


## How to test this PR?
`./mc admin health info play/`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
