### PR TITLE
fix replication bandwidth unit conversion

### DIFF
--- a/cmd/admin-bucket-remote-add_test.go
+++ b/cmd/admin-bucket-remote-add_test.go
@@ -25,10 +25,10 @@ func TestGetBandwidthInBytes(t *testing.T) {
 	type args struct {
 		bandwidthStr string
 	}
-	f1 := 999.123457 * 1024 * 1024 / 8
-	f2 := 10.123456790 * 1024 * 1024 * 1024 / 8
-	f3 := 10000.123456790 * 1024 * 1024 * 1024 / 8
-	f4 := (0.001*1024*1024*1024 + 1) / 8 // round up
+	f1 := 999.1234567 * 1024 * 1024
+	f2 := 10.123456789 * 1024 * 1024 * 1024
+	f3 := 10000.123456789 * 1024 * 1024 * 1024
+	f4 := 0.001 * 1024 * 1024 * 1024
 	tests := []struct {
 		name string
 		args args
@@ -39,66 +39,66 @@ func TestGetBandwidthInBytes(t *testing.T) {
 			args: args{
 				bandwidthStr: "1Mi",
 			},
-			want: 1024 * 1024 / 8,
+			want: 1024 * 1024,
 		},
 		{
 			name: "1MegaBit",
 			args: args{
 				bandwidthStr: "1M",
 			},
-			want: 1000000 / 8,
-		},
-		{
-			name: "1GigaBit",
-			args: args{
-				bandwidthStr: "1G",
-			},
-			want: 1000000000 / 8,
+			want: 1000000,
 		},
 		{
 			name: "1GigaByte",
 			args: args{
+				bandwidthStr: "1G",
+			},
+			want: 1000000000,
+		},
+		{
+			name: "1GibiByte",
+			args: args{
 				bandwidthStr: "1Gi",
 			},
-			want: 1024 * 1024 * 1024 / 8,
-		},
-		{
-			name: "FractionalMegaBits",
-			args: args{
-				bandwidthStr: "999.123456789123456789M",
-			},
-			want: 999123457 / 8,
-		},
-		{
-			name: "FractionalGigaBits",
-			args: args{
-				bandwidthStr: "10.123456789123456789123456G",
-			},
-			want: 10123456789 / 8,
-		},
-		{
-			name: "FractionalBigGigaBits",
-			args: args{
-				bandwidthStr: "10000.123456789123456789123456G",
-			},
-			want: 10000123456789 / 8,
+			want: 1024 * 1024 * 1024,
 		},
 		{
 			name: "FractionalMegaBytes",
+			args: args{
+				bandwidthStr: "999.123456789123456789M",
+			},
+			want: 999123456,
+		},
+		{
+			name: "FractionalGigaBytes",
+			args: args{
+				bandwidthStr: "10.123456789123456789123456G",
+			},
+			want: 10123456789,
+		},
+		{
+			name: "FractionalBigGigaBytes",
+			args: args{
+				bandwidthStr: "10000.123456789123456789123456G",
+			},
+			want: 10000123456789,
+		},
+		{
+			name: "FractionalMebiBytes",
 			args: args{
 				bandwidthStr: "999.123456789123456789Mi",
 			},
 			want: uint64(f1),
 		},
 		{
-			name: "FractionalGigaBytes",
+			name: "FractionalGibiBytes",
 			args: args{
 				bandwidthStr: "10.123456789123456789123456Gi",
 			},
 			want: uint64(f2),
 		},
 		{
-			name: "FractionalBigGigaBytes",
+			name: "FractionalBigGibiBytes",
 			args: args{
 				bandwidthStr: "10000.123456789123456789123456Gi",
 			},
@@ -116,7 +116,7 @@ func TestGetBandwidthInBytes(t *testing.T) {
 			args: args{
 				bandwidthStr: "1024Ki",
 			},
-			want: 1024 * 1024 / 8,
+			want: 1024 * 1024,
 		},
 	}
 	t.Parallel()

--- a/cmd/admin-replicate-info.go
+++ b/cmd/admin-replicate-info.go
@@ -97,8 +97,8 @@ func (i srInfo) String() string {
 			}
 			limit := "N/A" // N/A means cluster bandwidth is not configured
 			if peer.DefaultBandwidth.Limit > 0 {
-				limit = humanize.Bytes(uint64(peer.DefaultBandwidth.Limit * 8))
-				limit = fmt.Sprintf("%sb/s", limit[:len(limit)-1])
+				limit = humanize.Bytes(uint64(peer.DefaultBandwidth.Limit))
+				limit = fmt.Sprintf("%s/s", limit)
 			}
 			r := console.Colorize("TDetail", newPrettyTable(" | ",
 				Field{"Deployment ID", 36},

--- a/cmd/admin-replicate-update.go
+++ b/cmd/admin-replicate-update.go
@@ -51,7 +51,7 @@ var adminReplicateUpdateFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "bucket-bandwidth",
-		Usage: "Set default bandwidth limit for bucket in bits per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
+		Usage: "Set default bandwidth limit for bucket in bytes per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
 	},
 	cli.BoolFlag{
 		Name:  "disable-ilm-expiry-replication",

--- a/cmd/replicate-add.go
+++ b/cmd/replicate-add.go
@@ -267,7 +267,6 @@ func getBandwidthInBytes(bandwidthStr string) (bandwidth uint64, err error) {
 		if err != nil {
 			return
 		}
-		bandwidth = bandwidth / 8
 	}
 	return
 }

--- a/cmd/replicate-add.go
+++ b/cmd/replicate-add.go
@@ -83,7 +83,7 @@ var replicateAddFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "bandwidth",
-		Usage: "set bandwidth limit in bits per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
+		Usage: "set bandwidth limit in bytes per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
 	},
 	cli.BoolFlag{
 		Name:  "sync",

--- a/cmd/replicate-status.go
+++ b/cmd/replicate-status.go
@@ -244,12 +244,12 @@ func (s replicateStatusMessage) String() string {
 			limit := "N/A"   // N/A means cluster bandwidth is not configured
 			current := "N/A" // N/A means cluster bandwidth is not configured
 			if bwStat.CurrentBandwidthInBytesPerSecond > 0 {
-				current = humanize.Bytes(uint64(bwStat.CurrentBandwidthInBytesPerSecond * 8))
-				current = fmt.Sprintf("%sb/s", current[:len(current)-1])
+				current = humanize.Bytes(uint64(bwStat.CurrentBandwidthInBytesPerSecond))
+				current = fmt.Sprintf("%s/s", current)
 			}
 			if bwStat.BandWidthLimitInBytesPerSecond > 0 {
-				limit = humanize.Bytes(uint64(bwStat.BandWidthLimitInBytesPerSecond * 8))
-				limit = fmt.Sprintf("%sb/s", limit[:len(limit)-1])
+				limit = humanize.Bytes(uint64(bwStat.BandWidthLimitInBytesPerSecond))
+				limit = fmt.Sprintf("%s/s", limit)
 			}
 			addRowF(titleui("Configured Max Bandwidth (Bps): ")+"%s"+titleui("   Current Bandwidth (Bps): ")+"%s", valueui(limit), valueui(current))
 		}

--- a/cmd/replicate-update.go
+++ b/cmd/replicate-update.go
@@ -76,7 +76,7 @@ var replicateUpdateFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "bandwidth",
-		Usage: "Set bandwidth limit in bits per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
+		Usage: "Set bandwidth limit in bytes per second (K,B,G,T for metric and Ki,Bi,Gi,Ti for IEC units)",
 	},
 	cli.UintFlag{
 		Name:  "healthcheck-seconds",


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

the user input will be in bytes, need not convert it again to bytes.

## Motivation and Context

To avoid any confusion while setting the replication bandwidth.

## How to test this PR?

```
./mc replicate update ALIAS/BUCKET --id site-repl-769b7d7a-b0df-4d66-abf1-68516ddb53d4 --bandwidth 1G --remote-bucket REMOTE_ALIAS/BUCKET
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
