### PR TITLE
fix: rm command with `--newer-than` not working

### DIFF
--- a/cmd/rm-main.go
+++ b/cmd/rm-main.go
@@ -329,7 +329,7 @@ func removeSingle(url, versionID string, opts removeOpts) error {
 		}
 
 		// We should not proceed
-		if ignoreStatError && opts.olderThan != "" || opts.newerThan != "" {
+		if ignoreStatError && (opts.olderThan != "" || opts.newerThan != "") {
 			errorIf(pErr.Trace(url), "Unable to stat `"+url+"`.")
 			return exitStatus(globalErrorExitStatus)
 		}


### PR DESCRIPTION
## Description

`mc rm` with `--newer-than` doesn't work, to reproduce:

```bash
minio server /tmp/data &

mc mb local/foo
touch bar.txt
mc cp bar.txt local/foo
mc rm --newer-than 1d local/foo/

echo $?                           # gives 1, which should be 0
mc ls local/foo                   # bar.txt still exists, which is unexpected
```

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
