### PR TITLE
Wait for object to upload properly

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -1028,6 +1028,7 @@ function test_bucket_replication() {
 			break
 		fi
 		assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd cp "$FILE_0_B" "${SERVER_ALIAS}/${bkt1}/${object_name}"
+		sleep 5s # to make sure objects reflects
 		assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd rm "${SERVER_ALIAS}/${bkt1}/${object_name}"
 		assert_failure "$start_time" "${FUNCNAME[0]}" mc_cmd stat "${SERVER_ALIAS}/${bkt1}/${object_name}"
 		loop_count=$((loop_count + 1))


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Sometimes while mint tests, removal of object immediately after upload command fails with object not found. As the object may not be uploaded and reflected yet to the cluster, this can fail. Added a small sleep after upload to make sure object is available before any remove call.

## Motivation and Context


## How to test this PR?
mint tests would take care

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
