### PR TITLE
Adding support for Hex keys

### DIFF
--- a/cmd/encryption-methods.go
+++ b/cmd/encryption-methods.go
@@ -198,19 +198,19 @@ func parseSSEKey(sseKey string, keyType sseKeyType) (
 ) {
 	sseKeyBytes := []byte(sseKey)
 
-	seperatorIndex := bytes.LastIndex(sseKeyBytes, []byte("="))
-	if seperatorIndex < 0 {
+	separatorIndex := bytes.LastIndex(sseKeyBytes, []byte("="))
+	if separatorIndex < 0 {
 		err = errSSEKeyMissing().Trace(sseKey)
 		return
 	}
 
-	encodedKey := string(sseKeyBytes[seperatorIndex+1:])
-	if seperatorIndex == len(sseKeyBytes)-1 {
+	encodedKey := string(sseKeyBytes[separatorIndex+1:])
+	if separatorIndex == len(sseKeyBytes)-1 {
 		err = errSSEKeyMissing().Trace(sseKey)
 		return
 	}
 
-	alias, prefix = splitKey(string(sseKeyBytes[:seperatorIndex]))
+	alias, prefix = splitKey(string(sseKeyBytes[:separatorIndex]))
 
 	if keyType == sseS3 {
 		return

--- a/cmd/encryption-methods.go
+++ b/cmd/encryption-methods.go
@@ -18,9 +18,11 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/hex"
+	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/minio/cli"
@@ -194,41 +196,46 @@ func parseSSEKey(sseKey string, keyType sseKeyType) (
 	key string,
 	err *probe.Error,
 ) {
-	if keyType == sseS3 {
-		alias, prefix = splitKey(sseKey)
-		return
-	}
+	sseKeyBytes := []byte(sseKey)
 
-	var path string
-	alias, path = splitKey(sseKey)
-	splitPath := strings.Split(path, "=")
-	if len(splitPath) == 0 {
+	seperatorIndex := bytes.LastIndex(sseKeyBytes, []byte("="))
+	if seperatorIndex < 0 {
 		err = errSSEKeyMissing().Trace(sseKey)
 		return
 	}
 
-	aliasPlusPrefix := strings.Join(splitPath[:len(splitPath)-1], "=")
-	prefix = strings.Replace(aliasPlusPrefix, alias+"/", "", 1)
-	key = splitPath[len(splitPath)-1]
+	encodedKey := string(sseKeyBytes[seperatorIndex+1:])
+	if seperatorIndex == len(sseKeyBytes)-1 {
+		err = errSSEKeyMissing().Trace(sseKey)
+		return
+	}
 
-	if keyType == sseC {
-		keyB, de := base64.RawStdEncoding.DecodeString(key)
-		if de != nil {
-			err = errSSEClientKeyFormat("One of the inserted keys was " + strconv.Itoa(len(key)) + " bytes and did not have valid base64 raw encoding.").Trace(sseKey)
-			return
+	alias, prefix = splitKey(string(sseKeyBytes[:seperatorIndex]))
+
+	if keyType == sseS3 {
+		return
+	}
+
+	if keyType == sseKMS {
+		if !validKMSKeyName(encodedKey) {
+			err = errSSEKMSKeyFormat(fmt.Sprintf("Key (%s) is badly formatted.", encodedKey)).Trace(sseKey)
 		}
-		key = string(keyB)
-		if len(key) != 32 {
-			err = errSSEClientKeyFormat("The plain text key was " + strconv.Itoa(len(key)) + " bytes but should be 32 bytes long").Trace(sseKey)
+		return
+	}
+
+	keyB, de := hex.DecodeString(encodedKey)
+	if de != nil {
+		keyB, de = base64.RawStdEncoding.DecodeString(encodedKey)
+		if de != nil {
+			err = errSSEClientKeyFormat(fmt.Sprintf("Key (%s) was neither base64 raw encoded nor hex encoded.", encodedKey)).Trace(sseKey)
 			return
 		}
 	}
 
-	if keyType == sseKMS {
-		if !validKMSKeyName(key) {
-			err = errSSEKMSKeyFormat("One of the inserted keys was " + strconv.Itoa(len(key)) + " bytes and did not have a valid KMS key name.").Trace(sseKey)
-			return
-		}
+	key = string(keyB)
+	if len(key) != 32 {
+		err = errSSEClientKeyFormat(fmt.Sprintf("Plain text from key (%s) is only %d bytes, but should be 32 bytes.", encodedKey, len(key))).Trace(sseKey)
+		return
 	}
 
 	return

--- a/cmd/encryption-methods.go
+++ b/cmd/encryption-methods.go
@@ -223,13 +223,16 @@ func parseSSEKey(sseKey string, keyType sseKeyType) (
 		return
 	}
 
-	keyB, de := hex.DecodeString(encodedKey)
-	if de != nil {
-		keyB, de = base64.RawStdEncoding.DecodeString(encodedKey)
-		if de != nil {
-			err = errSSEClientKeyFormat(fmt.Sprintf("Key (%s) was neither base64 raw encoded nor hex encoded.", encodedKey)).Trace(sseKey)
-			return
-		}
+	var keyB []byte
+	var decodeError error
+	if len(encodedKey) == 64 {
+		keyB, decodeError = hex.DecodeString(encodedKey)
+	} else {
+		keyB, decodeError = base64.RawStdEncoding.DecodeString(encodedKey)
+	}
+
+	if decodeError != nil {
+		err = errSSEClientKeyFormat(fmt.Sprintf("Key (%s) was neither base64 raw encoded nor hex encoded.", encodedKey)).Trace(sseKey)
 	}
 
 	key = string(keyB)

--- a/cmd/encryption-methods_test.go
+++ b/cmd/encryption-methods_test.go
@@ -28,6 +28,7 @@ func TestParseEncryptionKeys(t *testing.T) {
 	baseObject := "object_name"
 	sseKey := "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDA"
 	sseKeyPlain := "01234567890123456789012345678900"
+	sseHexKey := "3031323334353637383930313233343536373839303132333435363738393030"
 
 	// INVALID KEYS
 	sseKeyInvalidShort := "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2"
@@ -45,6 +46,14 @@ func TestParseEncryptionKeys(t *testing.T) {
 		sseType       sseKeyType
 		success       bool
 	}{
+		{
+			encryptionKey: fmt.Sprintf("%s/%s/%s=%s", baseAlias, basePrefix, baseObject, sseHexKey),
+			keyPlain:      sseKeyPlain,
+			alias:         baseAlias,
+			prefix:        basePrefix,
+			object:        baseObject,
+			success:       true,
+		},
 		{
 			encryptionKey: fmt.Sprintf("%s/%s/%s=%s", baseAlias, basePrefix, baseObject, sseKey),
 			keyPlain:      sseKeyPlain,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -97,7 +97,7 @@ var encFlags = []cli.Flag{
 
 var encCFlag = cli.StringSliceFlag{
 	Name:  "enc-c",
-	Usage: "encrypt/decrypt objects using client provided keys. (multiple keys can be provided) Format: Raw base64 encoding.",
+	Usage: "encrypt/decrypt objects using client provided keys. (multiple keys can be provided) Formats: RawBase64 or Hex.",
 }
 
 var encKSMFlag = cli.StringSliceFlag{

--- a/cmd/typed-errors.go
+++ b/cmd/typed-errors.go
@@ -187,7 +187,7 @@ var errSSEKMSKeyFormat = func(msg string) *probe.Error {
 type sseClientKeyFormatErr error
 
 var errSSEClientKeyFormat = func(msg string) *probe.Error {
-	m := "Encryption key should be 44 bytes raw base64 encoded key."
+	m := "Encryption key should be either raw base64 encoded or hex encoded. "
 	m += msg
 	return probe.NewError(sseClientKeyFormatErr(errors.New(m))).Untrace()
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Due to the nature of S3 APIs and the way we declare encryption keys, we can not support encryption keys with the symbol = in them. This makes support for base64 encoding, which includes padding, impossible. 

To provide an additional option to the RawBase64Encoding option, this PR adds support for Hex Encoding.

## Motivation and Context
Most tools (openssl for example) generate base64 encoded keys with padding, so when they are used in scripts along with mc, they tend to fail. An alternative is to offer support for Hex encoding. 

## How to test this PR?
The functional test suite includes two tests for hex support.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [x] Internal documentation updated
- [x] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
