### PR TITLE
enable batch expiry option in trace

### DIFF
--- a/cmd/admin-trace.go
+++ b/cmd/admin-trace.go
@@ -169,6 +169,7 @@ var traceCallTypeAliases = map[string]func(o *madmin.ServiceTraceOpts) string{
 	"resync": traceCallTypes["replication-resync"],
 	"brep":   traceCallTypes["batch-replication"],
 	"brot":   traceCallTypes["batch-keyrotation"],
+	"bexp":   traceCallTypes["batch-expiration"],
 }
 
 func traceCallsHelp() string {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
enable batch expiry option in trace

## Motivation and Context
ability to trace batch expiry calls

## How to test this PR?
### Build this PR
`make build`

### Create a sample batch expiry job config yaml

```yaml

# batch-expiry-test.yaml
expire:
  apiVersion: v1
  bucket: test-bucket 
  rules:
    - type: object  
      olderThan: 24h # 10days * 24  
      purge:
          retainVersions: 0
  retry:
    attempts: 10 
    delay: 500ms 

```

### Setup data
```sh
mc mb local22/test-bucket
# Optional 
# mc version enable local22/test-bucket

# temporarily set public for setting up data
mc anonymous set public  local22/test-bucket

#Populate data
 for i in {11..210};  do  day=$((i % 31 + 1)); formatted_day=$(printf "%02d" $day); date_string="2024-03-${formatted_day}T17:19:03.115209866-08:00";   curl -k -X PUT http://0.0.0.0:22000/test-bucket/$i.txt -d "" -H "X-Minio-Source-Mtime: $date_string"
;  done


### Run the job
`./mc batch start local22 ./batch-expiry.yaml`


### Observe the trace result
```
### Trace Result
```sh
#Un versioned bucket

➜ ./mc admin trace local22 --call bexp                       
          
2024-06-20T10:18:32.899 [BATCHEXPIRE] Expire() (job-name=TUK88yqEkpyzCSzMyZLp88:-1,attempts=1st) 127.0.0.1:22000 177.txt (versionID=) 562.891µs
...

# Versioned Bucket

➜ ./mc admin trace local22 --call bexp

2024-06-20T10:19:39.744 [BATCHEXPIRE] Expire() (job-name=nsfatSoHdv8EK8ma3aZFHF:-1,attempts=1st) 127.0.0.1:22000 100.txt (versionID=42b67ad7-8bfe-41ea-922f-1256674ec4ed) 213.185µs
...
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [x] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
