### PR TITLE
Add ability to update tier credentials for Azure service principal ac…

### DIFF
--- a/cmd/ilm-tier-edit.go
+++ b/cmd/ilm-tier-edit.go
@@ -48,6 +48,21 @@ var adminTierEditFlags = []cli.Flag{
 		Usage: "Azure Blob Storage account key",
 	},
 	cli.StringFlag{
+		Name:  "az-sp-tenant-id",
+		Value: "",
+		Usage: "Directory ID for the Azure service principal account",
+	},
+	cli.StringFlag{
+		Name:  "az-sp-client-id",
+		Value: "",
+		Usage: "The client ID of the Azure service principal account",
+	},
+	cli.StringFlag{
+		Name:  "az-sp-client-secret",
+		Value: "",
+		Usage: "The client secret of the Azure service principal account",
+	},
+	cli.StringFlag{
 		Name:  "credentials-file",
 		Value: "",
 		Usage: "path to Google Cloud Storage credentials file",
@@ -114,9 +129,14 @@ func mainAdminTierEdit(ctx *cli.Context) error {
 	var creds madmin.TierCreds
 	accessKey := ctx.String("access-key")
 	secretKey := ctx.String("secret-key")
-	accountKey := ctx.String("account-key")
 	credsPath := ctx.String("credentials-file")
 	useAwsRole := ctx.IsSet("use-aws-role")
+
+	// Azure, either account-key or one of the 3 service principal flags are required
+	accountKey := ctx.String("account-key")
+	azSPTenantID := ctx.String("az-sp-tenant-id")
+	azSPClientID := ctx.String("az-sp-client-id")
+	azSPClientSecret := ctx.String("az-sp-client-secret")
 
 	switch {
 	case accessKey != "" && secretKey != "" && !useAwsRole: // S3 tier
@@ -124,8 +144,14 @@ func mainAdminTierEdit(ctx *cli.Context) error {
 		creds.SecretKey = secretKey
 	case useAwsRole:
 		creds.AWSRole = true
-	case accountKey != "": // Azure tier
+	case accountKey != "": // Azure tier, account key given
 		creds.SecretKey = accountKey
+	case azSPTenantID != "" || azSPClientID != "" || azSPClientSecret != "": // Azure tier, SP creds given
+		creds.AzSP = madmin.ServicePrincipalAuth{
+			TenantID:     azSPTenantID,
+			ClientID:     azSPClientID,
+			ClientSecret: azSPClientSecret,
+		}
 	case credsPath != "": // GCS tier
 		credsBytes, e := os.ReadFile(credsPath)
 		fatalIf(probe.NewError(e), "Unable to read credentials file at %s", credsPath)


### PR DESCRIPTION
…counts

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add the ability to edit (update) the creds of an Azure tier using `mc ilm tier update ALIAS MYTIER --az-sp-client-id ... ` 
 with the 3 `az-sp` credentials

## Motivation and Context

Part of the tiering functionality.

## How to test this PR?

```
❯ ./mc ilm tier update ALIAS MYTIER --az-sp-client-id UUID --az-sp-tenant-id UUID --az-sp-client-secret SECRET
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
