### PR TITLE
Simplify go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,51 +3,47 @@ module github.com/minio/mc
 go 1.21
 
 require (
+	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0
+	github.com/charmbracelet/lipgloss v0.10.0
 	github.com/cheggaaa/pb v1.0.29
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.16.0
-	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/inconshreveable/mousetrap v1.1.0
+	github.com/jedib0t/go-pretty/v6 v6.5.8
+	github.com/juju/ratelimit v1.0.2
 	github.com/klauspost/compress v1.17.8
 	github.com/mattn/go-ieproxy v0.0.11
 	github.com/mattn/go-isatty v0.0.20
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.7
 	github.com/minio/filepath v1.0.0
-	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/minio/madmin-go/v3 v3.0.58-0.20240701162942-671010069ecb
 	github.com/minio/minio-go/v7 v7.0.72-0.20240618070918-0b004e328e1e
+	github.com/minio/pkg/v3 v3.0.0
+	github.com/minio/selfupdate v0.6.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/muesli/reflow v0.3.0
+	github.com/muesli/termenv v0.15.2
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/xattr v0.4.9
 	github.com/posener/complete v1.2.3
 	github.com/prometheus/client_golang v1.19.0
-	github.com/prometheus/prom2json v1.3.3 // indirect
+	github.com/prometheus/procfs v0.14.0
 	github.com/rjeczalik/notify v0.9.3
 	github.com/rs/xid v1.5.0
 	github.com/shirou/gopsutil/v3 v3.24.4
 	github.com/tidwall/gjson v1.17.1
-	golang.org/x/crypto v0.23.0 // indirect
+	github.com/vbauerster/mpb/v8 v8.7.3
 	golang.org/x/net v0.25.0
+	golang.org/x/sys v0.20.0
+	golang.org/x/term v0.20.0
 	golang.org/x/text v0.15.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0
-)
-
-require (
-	github.com/charmbracelet/bubbles v0.18.0
-	github.com/charmbracelet/lipgloss v0.10.0
-	github.com/golang-jwt/jwt/v4 v4.5.0
-	github.com/juju/ratelimit v1.0.2
-	github.com/minio/madmin-go/v3 v3.0.58-0.20240701162942-671010069ecb
-	github.com/minio/pkg/v3 v3.0.0
-	github.com/minio/selfupdate v0.6.0
-	github.com/muesli/reflow v0.3.0
-	github.com/olekukonko/tablewriter v0.0.5
-	github.com/vbauerster/mpb/v8 v8.7.3
-	golang.org/x/term v0.20.0
 )
 
 require (
@@ -55,18 +51,6 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/lestrrat-go/jwx v1.2.29 // indirect
-	github.com/minio/mux v1.9.0 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	github.com/safchain/ethtool v0.3.0 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240509183442-62759503f434 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240509183442-62759503f434 // indirect
-)
-
-require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/console v1.0.4 // indirect
@@ -74,17 +58,20 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/jedib0t/go-pretty/v6 v6.5.8
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
+	github.com/lestrrat-go/jwx v1.2.29 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240408141607-282e7b5d6b74 // indirect
@@ -92,16 +79,21 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/minio/mux v1.9.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.15.2
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.53.0 // indirect
-	github.com/prometheus/procfs v0.14.0
+	github.com/prometheus/prom2json v1.3.3 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
+	github.com/safchain/ethtool v0.3.0 // indirect
 	github.com/secure-io/sio-go v0.3.1 // indirect
+	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tinylib/msgp v1.1.9 // indirect
@@ -113,8 +105,10 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.13 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.20.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20240509183442-62759503f434 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240509183442-62759503f434 // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect


### PR DESCRIPTION
Combine into direct and indirect sections. See https://github.com/golang/go/issues/67948 for why this is a mess.

Enables running `go mod tidy` without blowing up things.

## Types of changes

- [x] Simplify