### PR TITLE
Support metrics-v3 api in `admin prometheus metrics`

### DIFF
--- a/cmd/admin-prometheus-metrics-v3.go
+++ b/cmd/admin-prometheus-metrics-v3.go
@@ -45,6 +45,9 @@ var (
 		},
 	}
 
+	metricsV3SubSystems = set.CreateStringSet("api", "system", "debug", "cluster",
+		"ilm", "audit", "logger", "replication", "notification", "scanner")
+
 	bucketMetricsSubSystems = set.CreateStringSet("api", "replication")
 )
 
@@ -52,10 +55,10 @@ const metricsV3EndPointRoot = "/minio/metrics/v3"
 
 func printPrometheusMetricsV3(ctx *cli.Context, req prometheusMetricsReq) error {
 	subsys := req.subsystem
-	switch subsys {
-	case "", "api", "system", "debug", "cluster", "ilm", "audit", "logger", "replication", "notification", "scanner":
-	default:
-		fatalIf(errInvalidArgument().Trace(), "invalid metric type `"+subsys+"`")
+	if subsys != "" && !metricsV3SubSystems.Contains(subsys) {
+		fatalIf(errInvalidArgument().Trace(),
+			"invalid metric type `"+subsys+"`. valid values are `"+
+				strings.Join(metricsV3SubSystems.ToSlice(), ", ")+"`")
 	}
 
 	list := ctx.Bool("list")

--- a/cmd/admin-prometheus-metrics-v3.go
+++ b/cmd/admin-prometheus-metrics-v3.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v7/pkg/set"
+	"github.com/minio/pkg/v3/console"
+)
+
+var (
+	metricsV3Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "bucket",
+			Usage: "bucket name to list metrics for. only applicable with api version v3 for metric type 'bucket'",
+		},
+		cli.BoolFlag{
+			Name:  "list",
+			Usage: "list the available metrics. only applicable with api version v3",
+		},
+	}
+
+	bucketMetricsSubSystems = set.CreateStringSet("api", "replication")
+)
+
+const metricsV3EndPointRoot = "/minio/metrics/v3"
+
+func printPrometheusMetricsV3(ctx *cli.Context, req prometheusMetricsReq) error {
+	subsys := req.subsystem
+	switch subsys {
+	case "", "api", "system", "debug", "cluster", "ilm", "audit", "logger", "replication", "notification", "scanner":
+	default:
+		fatalIf(errInvalidArgument().Trace(), "invalid metric type `"+subsys+"`")
+	}
+
+	list := ctx.Bool("list")
+	bucket := ctx.String("bucket")
+	metricsURL := req.aliasURL + metricsV3EndPointRoot
+	params := url.Values{}
+
+	if len(bucket) > 0 {
+		bms := strings.Join(bucketMetricsSubSystems.ToSlice(), ", ")
+		if len(subsys) == 0 {
+			fatalIf(errInvalidArgument().Trace(), fmt.Sprintf("metric type must be passed with --bucket. valid values are `"+bms+"`"))
+		}
+
+		if !bucketMetricsSubSystems.Contains(subsys) {
+			fatalIf(errInvalidArgument().Trace(), fmt.Sprintf("--bucket is applicable only for metric types `"+bms+"`"))
+		}
+
+		metricsURL += "/bucket"
+	}
+
+	if len(subsys) > 0 {
+		metricsURL += "/" + subsys
+	}
+
+	if len(bucket) > 0 {
+		// bucket specific metrics endpoints have '/bucket' prefix and bucket name as suffix.
+		// e.g. bucket api metrics: /bucket/api/mybucket
+		metricsURL += "/" + bucket
+	}
+
+	if list {
+		params.Add("list", "true")
+	}
+
+	qparams := params.Encode()
+	if len(qparams) > 0 {
+		metricsURL += "?" + qparams
+	}
+
+	resp, e := fetchMetrics(metricsURL, req.token)
+	if e != nil {
+		return e
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		printMsg(prometheusMetricsV3Reader{
+			prometheusMetricsReader: prometheusMetricsReader{Reader: resp.Body},
+			isList:                  list,
+		})
+		return nil
+	}
+
+	return errors.New(resp.Status)
+}
+
+// JSON returns jsonified message
+func (pm prometheusMetricsV3Reader) JSON() string {
+	if !pm.isList {
+		return pm.prometheusMetricsReader.JSON()
+	}
+
+	metricInfos := []prometheusMetricInfo{}
+	rows := pm.readMetricsV3List()
+	for idx, row := range rows {
+		if idx == 0 || len(row) != 4 {
+			// first row is the header, skip it.
+			continue
+		}
+		metricInfos = append(metricInfos, prometheusMetricInfo{
+			Name:   strings.TrimSpace(row[0]),
+			Type:   strings.TrimSpace(row[1]),
+			Help:   strings.TrimSpace(row[2]),
+			Labels: strings.TrimSpace(row[3]),
+		})
+	}
+
+	jsonMessageBytes, e := json.MarshalIndent(metricInfos, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal into JSON.")
+	return string(jsonMessageBytes)
+}
+
+func (pm prometheusMetricsV3Reader) readMetricsV3List() [][]string {
+	scanner := bufio.NewScanner(pm.Reader)
+	lineNum := 0
+	rows := [][]string{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		lineNum++
+		if lineNum == 2 {
+			// second line is just a separator, skip it.
+			continue
+		}
+		// remove leading and trailing '|', remove '`' and finally split by '|'
+		// example row: | `minio_bucket_api_total` | `counter` | Total number of requests for a bucket | `bucket,name,type,server` |
+		row := strings.Split(strings.ReplaceAll(strings.Trim(line, "|"), "`", ""), "|")
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func (pm prometheusMetricsV3Reader) printMetricsV3List() error {
+	rows := pm.readMetricsV3List()
+	dspOrder := []col{colGreen}
+	for i := 0; i < len(rows)-1; i++ {
+		dspOrder = append(dspOrder, colGrey)
+	}
+
+	var printColors []*color.Color
+	for _, c := range dspOrder {
+		printColors = append(printColors, getPrintCol(c))
+	}
+
+	// four columns - name, type, help, labels
+	tbl := console.NewTable(printColors, []bool{false, false, false, false}, 0)
+	return tbl.DisplayTable(rows)
+}
+
+// String - returns the string representation of the prometheus metrics
+func (pm prometheusMetricsV3Reader) String() string {
+	if !pm.isList {
+		return pm.prometheusMetricsReader.String()
+	}
+
+	e := pm.printMetricsV3List()
+	fatalIf(probe.NewError(e), "Unable to render table view")
+
+	return ""
+}
+
+// prometheusMetricsV3Reader is used for printing
+// the prometheus metrics returned by the v3 api.
+type prometheusMetricsV3Reader struct {
+	prometheusMetricsReader
+	isList bool
+}
+
+// prometheusMetricInfo contains information about a prometheus metric.
+type prometheusMetricInfo struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Help   string `json:"help"`
+	Labels string `json:"labels"`
+}

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -59,43 +59,43 @@ FLAGS:
   {{end}}
 EXAMPLES (v3):
   1. API metrics
-     {{.Prompt}} {{.HelpName}} play api
+     {{.Prompt}} {{.HelpName}} play api --api-version v3
 
   2. API metrics for the bucket 'mybucket'
-     {{.Prompt}} {{.HelpName}} play api --bucket mybucket
+     {{.Prompt}} {{.HelpName}} play api --bucket mybucket --api-version v3
 
   3. System metrics
-     {{.Prompt}} {{.HelpName}} play system
+     {{.Prompt}} {{.HelpName}} play system --api-version v3
 
   4. Debug metrics
-     {{.Prompt}} {{.HelpName}} play debug
+     {{.Prompt}} {{.HelpName}} play debug --api-version v3
 
   5. Cluster metrics
-     {{.Prompt}} {{.HelpName}} play cluster
+     {{.Prompt}} {{.HelpName}} play cluster --api-version v3
 
   6. ILM metrics
-     {{.Prompt}} {{.HelpName}} play ilm
+     {{.Prompt}} {{.HelpName}} play ilm --api-version v3
 
   7. Audit metrics
-     {{.Prompt}} {{.HelpName}} play audit
+     {{.Prompt}} {{.HelpName}} play audit --api-version v3
 
   8. Logger metrics
-     {{.Prompt}} {{.HelpName}} play logger
+     {{.Prompt}} {{.HelpName}} play logger --api-version v3
 
   9. Replication metrics
-     {{.Prompt}} {{.HelpName}} play replication
+     {{.Prompt}} {{.HelpName}} play replication --api-version v3
 
   10. Replication metrics for the bucket 'mybucket'
-      {{.Prompt}} {{.HelpName}} play replication --bucket mybucket
+      {{.Prompt}} {{.HelpName}} play replication --bucket mybucket --api-version v3
 
   11. Notification metrics
-      {{.Prompt}} {{.HelpName}} play notification
+      {{.Prompt}} {{.HelpName}} play notification --api-version v3
 
   12. Scanner metrics
-      {{.Prompt}} {{.HelpName}} play scanner
+      {{.Prompt}} {{.HelpName}} play scanner --api-version v3
 
   13. List of cluster metrics (without values)
-      {{.Prompt}} {{.HelpName}} play cluster --list
+      {{.Prompt}} {{.HelpName}} play cluster --list --api-version v3
 
 
 EXAMPLES (v2):

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -98,10 +98,6 @@ EXAMPLES (v3):
   12. Scanner metrics
       {{.Prompt}} {{.HelpName}} play scanner --api-version v3
 
-  13. List of cluster metrics (without values)
-      {{.Prompt}} {{.HelpName}} play cluster --list --api-version v3
-
-
 EXAMPLES (v2):
   1. Metrics reported cluster wide.
      {{.Prompt}} {{.HelpName}} play
@@ -240,7 +236,7 @@ func mainSupportMetrics(ctx *cli.Context) error {
 		fatalIf(probe.NewError(err), "Unable to list prometheus metrics with api-version v2.")
 	case "v3":
 		err := printPrometheusMetricsV3(ctx, metricsReq)
-		fatalIf(probe.NewError(err), "Unable to list prometheus metrics with api-version v2.")
+		fatalIf(probe.NewError(err), "Unable to list prometheus metrics with api-version v3.")
 	default:
 		fatalIf(errInvalidArgument().Trace(), "Invalid api version `"+apiVer+"`")
 	}

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2024 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -30,40 +30,96 @@ import (
 	"github.com/minio/mc/pkg/probe"
 )
 
+var metricsFlags = append(metricsV3Flags,
+	cli.StringFlag{
+		Name:  "api-version",
+		Usage: "version of metrics api to use. valid values are ['v2', 'v3']. defaults to 'v2' if not specified.",
+		Value: "v2",
+	})
+
 var adminPrometheusMetricsCmd = cli.Command{
 	Name:         "metrics",
-	Usage:        "print cluster wide prometheus metrics",
+	Usage:        "print prometheus metrics",
 	OnUsageError: onUsageError,
 	Action:       mainSupportMetrics,
 	Before:       setGlobalsFromContext,
-	Flags:        globalFlags,
+	Flags:        append(globalFlags, metricsFlags...),
 	CustomHelpTemplate: `NAME:
   {{.HelpName}} - {{.Usage}}
 USAGE:
   {{.HelpName}} TARGET [METRIC-TYPE]
 
 METRIC-TYPE:
-  valid values are ['cluster', 'node', 'bucket', 'resource']. Defaults to 'cluster' if not specified.
+  valid values are
+    api-version v2 ['cluster', 'node', 'bucket', 'resource']. defaults to 'cluster' if not specified.
+    api-version v3 ["api", "system", "debug", "cluster", "ilm", "audit", "logger", "replication", "notification", "scanner"]. defaults to all if not specified.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
-EXAMPLES:
-  1. List of metrics reported cluster wide.
+EXAMPLES (v3):
+  1. API metrics
+     {{.Prompt}} {{.HelpName}} play api
+
+  2. API metrics for the bucket 'mybucket'
+     {{.Prompt}} {{.HelpName}} play api --bucket mybucket
+
+  3. System metrics
+     {{.Prompt}} {{.HelpName}} play system
+
+  4. Debug metrics
+     {{.Prompt}} {{.HelpName}} play debug
+
+  5. Cluster metrics
+     {{.Prompt}} {{.HelpName}} play cluster
+
+  6. ILM metrics
+     {{.Prompt}} {{.HelpName}} play ilm
+
+  7. Audit metrics
+     {{.Prompt}} {{.HelpName}} play audit
+
+  8. Logger metrics
+     {{.Prompt}} {{.HelpName}} play logger
+
+  9. Replication metrics
+     {{.Prompt}} {{.HelpName}} play replication
+
+  10. Replication metrics for the bucket 'mybucket'
+      {{.Prompt}} {{.HelpName}} play replication --bucket mybucket
+
+  11. Notification metrics
+      {{.Prompt}} {{.HelpName}} play notification
+
+  12. Scanner metrics
+      {{.Prompt}} {{.HelpName}} play scanner
+
+  13. List of cluster metrics (without values)
+      {{.Prompt}} {{.HelpName}} play cluster --list
+
+
+EXAMPLES (v2):
+  1. Metrics reported cluster wide.
      {{.Prompt}} {{.HelpName}} play
 
-  2. List of metrics reported at node level.
+  2. Metrics reported at node level.
      {{.Prompt}} {{.HelpName}} play node
 
-  3. List of metrics reported at bucket level.
+  3. Metrics reported at bucket level.
      {{.Prompt}} {{.HelpName}} play bucket
 
-  4. List of resource metrics.
+  4. Resource metrics.
      {{.Prompt}} {{.HelpName}} play resource
 `,
 }
 
 const metricsEndPointRoot = "/minio/v2/metrics/"
+
+type prometheusMetricsReq struct {
+	aliasURL  string
+	token     string
+	subsystem string
+}
 
 // checkSupportMetricsSyntax - validate arguments passed by a user
 func checkSupportMetricsSyntax(ctx *cli.Context) {
@@ -72,44 +128,37 @@ func checkSupportMetricsSyntax(ctx *cli.Context) {
 	}
 }
 
-func printPrometheusMetrics(ctx *cli.Context) error {
-	// Get the alias parameter from cli
-	args := ctx.Args()
-	alias := cleanAlias(args.Get(0))
-
-	if !isValidAlias(alias) {
-		fatalIf(errInvalidAlias(alias), "Invalid alias.")
-	}
-	hostConfig := mustGetHostConfig(alias)
-	if hostConfig == nil {
-		fatalIf(errInvalidAliasedURL(alias), "No such alias `"+alias+"` found.")
-		return nil
-	}
-
-	token, e := getPrometheusToken(hostConfig)
+func fetchMetrics(metricsURL string, token string) (*http.Response, error) {
+	req, e := http.NewRequest(http.MethodGet, metricsURL, nil)
 	if e != nil {
-		return e
+		return nil, e
 	}
-	metricsSubSystem := args.Get(1)
-	switch metricsSubSystem {
-	case "node", "bucket", "cluster", "resource":
-	case "":
-		metricsSubSystem = "cluster"
-	default:
-		fatalIf(errInvalidArgument().Trace(), "invalid metric type '%v'", metricsSubSystem)
-	}
-
-	req, e := http.NewRequest(http.MethodGet, hostConfig.URL+metricsEndPointRoot+metricsSubSystem, nil)
-	if e != nil {
-		return e
-	}
-
 	if token != "" {
 		req.Header.Add("Authorization", "Bearer "+token)
 	}
 
 	client := httpClient(60 * time.Second)
-	resp, e := client.Do(req)
+	return client.Do(req)
+}
+
+func printPrometheusMetricsV2(ctx *cli.Context, req prometheusMetricsReq) error {
+	for _, flag := range metricsV3Flags {
+		flagName := flag.GetName()
+		if ctx.IsSet(flagName) {
+			fatalIf(errInvalidArgument().Trace(), "Flag `"+flagName+"` is not supported with v2 metrics")
+		}
+	}
+
+	subsys := req.subsystem
+	switch subsys {
+	case "node", "bucket", "cluster", "resource":
+	case "":
+		subsys = "cluster"
+	default:
+		fatalIf(errInvalidArgument().Trace(), "invalid metric type `"+subsys+"`")
+	}
+
+	resp, e := fetchMetrics(req.aliasURL+metricsEndPointRoot+subsys, req.token)
 	if e != nil {
 		return e
 	}
@@ -151,7 +200,44 @@ type prometheusMetricsReader struct {
 func mainSupportMetrics(ctx *cli.Context) error {
 	checkSupportMetricsSyntax(ctx)
 
-	fatalIf(probe.NewError(printPrometheusMetrics(ctx)), "Unable to list prometheus metrics.")
+	// Get the alias parameter from cli
+	args := ctx.Args()
+	alias := cleanAlias(args.Get(0))
+
+	if !isValidAlias(alias) {
+		fatalIf(errInvalidAlias(alias), "Invalid alias.")
+	}
+
+	hostConfig := mustGetHostConfig(alias)
+	if hostConfig == nil {
+		fatalIf(errInvalidAliasedURL(alias), "No such alias `"+alias+"` found.")
+		return nil
+	}
+
+	token, e := getPrometheusToken(hostConfig)
+	if e != nil {
+		return e
+	}
+
+	metricsSubSystem := args.Get(1)
+	apiVer := ctx.String("api-version")
+
+	metricsReq := prometheusMetricsReq{
+		aliasURL:  hostConfig.URL,
+		token:     token,
+		subsystem: metricsSubSystem,
+	}
+
+	switch apiVer {
+	case "v2":
+		err := printPrometheusMetricsV2(ctx, metricsReq)
+		fatalIf(probe.NewError(err), "Unable to list prometheus metrics with api-version v2.")
+	case "v3":
+		err := printPrometheusMetricsV3(ctx, metricsReq)
+		fatalIf(probe.NewError(err), "Unable to list prometheus metrics with api-version v2.")
+	default:
+		fatalIf(errInvalidArgument().Trace(), "Invalid api version `"+apiVer+"`")
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add a flag --api-version with possible values of v2 and v3, with default being v2. So when this flag is not passed, the command will work exactly as it did before.

When using v3, there is a different set of metric types supported. It also supports two additional flags:

bucket: the bucket for which the metrics are to be fetched. it is applicable only for the metric types that are available at bucket level, which currently are 'api' and 'replication'

list: when passed, this will only print the list of all metrics available for the given metrics type (without fetching their values)

## Motivation and Context

Support newly introduced `metrics-v3` api

## How to test this PR?

- `mc admin prometheus metrics ALIAS cluster|node|bucket|resource`
  - should continue to work as before
  - should work in same way when `--api-version v2` is passed
  - should fail with `Flag `bucket|list` is not supported with v2 metrics.` when `--bucket` or `--list` are passed to the command

- `mc admin prometheus metrics ALIAS api|system|debug|ilm|audit|logger|replication|notification|scanner`
   - should fail with `invalid metric type`

- `mc admin prometheus metrics ALIAS node|bucket|resource --api-version v3`
  - should fail with `invalid metric type`
 
- `mc admin prometheus metrics ALIAS api|system|debug|cluster|ilm|audit|logger|replication|notification|scanner --api-version v3`
   - should work fine and return metrics by invoking the v3 api

- `mc admin prometheus metrics ALIAS api|replication --api-version v3 --bucket BUCKET`
  - should return corresponding metrics for the given bucket only

- `mc admin prometheus metrics ALIAS --api-version v3`
  - should return _all_ the metrics

- `mc admin prometheus metrics ALIAS --api-version v3 --bucket BUCKET`
  - should fail with `metric type must be passed with --bucket. valid values are 'api, replication'`

- `mc admin prometheus metrics ALIAS system|debug|cluster|ilm|audit|logger|notification|scanner --api-version v3 --bucket BUCKET`
  - should fail with `--bucket is applicable only for metric types 'api, replication'`
 
- All the valid commands for v3 api should print a table with list of corresponding available metrics when `--list` is also passed e.g.

```
❯ ./mc admin prometheus metrics myminio replication --api-version v3 --list
┌────────────────────────────────────────────────┬─────────┬───────────────────────────────────────────────────────────────────────────────┬──────────┐
│  Name                                          │  Type   │  Help                                                                         │  Labels  │
│  minio_replication_average_active_workers      │  gauge  │  Average number of active replication workers                                 │  server  │
│  minio_replication_average_queued_bytes        │  gauge  │  Average number of bytes queued for replication since server start            │  server  │
│  minio_replication_average_queued_count        │  gauge  │  Average number of objects queued for replication since server start          │  server  │
│  minio_replication_average_data_transfer_rate  │  gauge  │  Average replication data transfer rate in bytes/sec                          │  server  │
│  minio_replication_current_active_workers      │  gauge  │  Total number of active replication workers                                   │  server  │
│  minio_replication_current_data_transfer_rate  │  gauge  │  Current replication data transfer rate in bytes/sec                          │  server  │
│  minio_replication_last_minute_queued_bytes    │  gauge  │  Number of bytes queued for replication in the last full minute               │  server  │
│  minio_replication_last_minute_queued_count    │  gauge  │  Number of objects queued for replication in the last full minute             │  server  │
│  minio_replication_max_active_workers          │  gauge  │  Maximum number of active replication workers seen since server start         │  server  │
│  minio_replication_max_queued_bytes            │  gauge  │  Maximum number of bytes queued for replication since server start            │  server  │
│  minio_replication_max_queued_count            │  gauge  │  Maximum number of objects queued for replication since server start          │  server  │
│  minio_replication_max_data_transfer_rate      │  gauge  │  Maximum replication data transfer rate in bytes/sec seen since server start  │  server  │
└────────────────────────────────────────────────┴─────────┴───────────────────────────────────────────────────────────────────────────────┴──────────┘
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
