### PR TITLE
Support metrics-v3 api in `admin prometheus generate`

### DIFF
--- a/cmd/admin-prometheus-generate.go
+++ b/cmd/admin-prometheus-generate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2024 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -31,22 +31,15 @@ import (
 )
 
 const (
-	defaultJobName      = "minio-job"
-	nodeJobName         = "minio-job-node"
-	bucketJobName       = "minio-job-bucket"
-	defaultMetricsPath  = "/minio/v2/metrics/cluster"
-	nodeMetricsPath     = "/minio/v2/metrics/node"
-	bucketMetricsPath   = "/minio/v2/metrics/bucket"
-	resourceJobName     = "minio-job-resource"
-	resourceMetricsPath = "/minio/v2/metrics/resource"
+	defaultJobName    = "minio-job"
+	metricsV2BasePath = "/minio/v2/metrics"
 )
 
-var prometheusFlags = []cli.Flag{
+var prometheusFlags = append(metricsFlags,
 	cli.BoolFlag{
 		Name:  "public",
 		Usage: "disable bearer token generation for scrape_configs",
-	},
-}
+	})
 
 var adminPrometheusGenerateCmd = cli.Command{
 	Name:            "generate",
@@ -63,14 +56,56 @@ USAGE:
   {{.HelpName}} TARGET [METRIC-TYPE]
 
 METRIC-TYPE:
-  valid values are ['cluster', 'node', 'bucket']. Defaults to 'cluster' if not specified.
+  valid values are
+    api-version v2 ['cluster', 'node', 'bucket', 'resource']. defaults to 'cluster' if not specified.
+    api-version v3 ["api", "system", "debug", "cluster", "ilm", "audit", "logger", "replication", "notification", "scanner"]. defaults to all if not specified.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
-EXAMPLES:
+EXAMPLES (v3):
   1. Generate a default prometheus config.
-     {{.Prompt}} {{.HelpName}} myminio
+     {{.Prompt}} {{.HelpName}} play --api-version v3
+
+  2. Generate prometheus config for api metrics.
+     {{.Prompt}} {{.HelpName}} play api --api-version v3
+
+  3. Generate prometheus config for api metrics of bucket 'mybucket'.
+     {{.Prompt}} {{.HelpName}} play api --bucket mybucket --api-version v3
+
+  4. Generate prometheus config for system metrics.
+     {{.Prompt}} {{.HelpName}} play system --api-version v3
+
+  5. Generate prometheus config for debug metrics.
+     {{.Prompt}} {{.HelpName}} play debug --api-version v3
+
+  6. Generate prometheus config for cluster metrics.
+     {{.Prompt}} {{.HelpName}} play cluster --api-version v3
+
+  7. Generate prometheus config for ilm metrics.
+     {{.Prompt}} {{.HelpName}} play ilm --api-version v3
+
+  8. Generate prometheus config for audit metrics.
+     {{.Prompt}} {{.HelpName}} play audit --api-version v3
+
+  9. Generate prometheus config for logger metrics.
+     {{.Prompt}} {{.HelpName}} play logger --api-version v3
+
+  10. Generate prometheus config for replication metrics.
+     {{.Prompt}} {{.HelpName}} play replication --api-version v3
+
+  11. Generate prometheus config for replication metrics of bucket 'mybucket'.
+     {{.Prompt}} {{.HelpName}} play replication --bucket mybucket --api-version v3
+
+  12. Generate prometheus config for notification metrics.
+     {{.Prompt}} {{.HelpName}} play notification --api-version v3
+
+  13. Generate prometheus config for scanner metrics.
+     {{.Prompt}} {{.HelpName}} play scanner --api-version v3
+
+EXAMPLES (v2):
+  1. Generate a default prometheus config.
+     {{.Prompt}} {{.HelpName}} play
 
   2. Generate prometheus config for node metrics.
      {{.Prompt}} {{.HelpName}} play node
@@ -80,6 +115,9 @@ EXAMPLES:
 
   4. Generate prometheus config for resource metrics.
      {{.Prompt}} {{.HelpName}} play resource
+
+  5. Generate prometheus config for cluster metrics.
+     {{.Prompt}} {{.HelpName}} play cluster
 `,
 }
 
@@ -164,66 +202,43 @@ func generatePrometheusConfig(ctx *cli.Context) error {
 	}
 
 	metricsSubSystem := args.Get(1)
-	var config PrometheusConfig
-	switch metricsSubSystem {
-	case "node":
-		config = PrometheusConfig{
-			ScrapeConfigs: []ScrapeConfig{
-				{
-					JobName:     nodeJobName,
-					MetricsPath: nodeMetricsPath,
-					StaticConfigs: []StatConfig{
-						{
-							Targets: []string{""},
-						},
-					},
-				},
-			},
+	apiVer := ctx.String("api-version")
+	jobName := defaultJobName
+	metricsPath := ""
+
+	switch apiVer {
+	case "v2":
+		if metricsSubSystem == "" {
+			metricsSubSystem = "cluster"
 		}
-	case "bucket":
-		config = PrometheusConfig{
-			ScrapeConfigs: []ScrapeConfig{
-				{
-					JobName:     bucketJobName,
-					MetricsPath: bucketMetricsPath,
-					StaticConfigs: []StatConfig{
-						{
-							Targets: []string{""},
-						},
-					},
-				},
-			},
+		validateV2Args(ctx, metricsSubSystem)
+		if metricsSubSystem != "cluster" {
+			jobName = defaultJobName + "-" + metricsSubSystem
 		}
-	case "resource":
-		config = PrometheusConfig{
-			ScrapeConfigs: []ScrapeConfig{
-				{
-					JobName:     resourceJobName,
-					MetricsPath: resourceMetricsPath,
-					StaticConfigs: []StatConfig{
-						{
-							Targets: []string{""},
-						},
-					},
-				},
-			},
-		}
-	case "", "cluster":
-		config = PrometheusConfig{
-			ScrapeConfigs: []ScrapeConfig{
-				{
-					JobName:     defaultJobName,
-					MetricsPath: defaultMetricsPath,
-					StaticConfigs: []StatConfig{
-						{
-							Targets: []string{""},
-						},
-					},
-				},
-			},
+		metricsPath = metricsV2BasePath + "/" + metricsSubSystem
+	case "v3":
+		bucket := ctx.String("bucket")
+		validateV3Args(metricsSubSystem, bucket)
+		metricsPath = getMetricsV3Path(metricsSubSystem, bucket)
+		if metricsSubSystem != "" {
+			jobName = defaultJobName + "-" + metricsSubSystem
 		}
 	default:
-		fatalIf(errInvalidArgument().Trace(), "invalid metric type '%v'", metricsSubSystem)
+		fatalIf(errInvalidArgument().Trace(), "Invalid api version `"+apiVer+"`")
+	}
+
+	config := PrometheusConfig{
+		ScrapeConfigs: []ScrapeConfig{
+			{
+				JobName:     jobName,
+				MetricsPath: metricsPath,
+				StaticConfigs: []StatConfig{
+					{
+						Targets: []string{""},
+					},
+				},
+			},
+		},
 	}
 
 	if !ctx.Bool("public") {

--- a/cmd/admin-prometheus-metrics.go
+++ b/cmd/admin-prometheus-metrics.go
@@ -141,7 +141,7 @@ func fetchMetrics(metricsURL string, token string) (*http.Response, error) {
 	return client.Do(req)
 }
 
-func printPrometheusMetricsV2(ctx *cli.Context, req prometheusMetricsReq) error {
+func validateV2Args(ctx *cli.Context, subsys string) {
 	for _, flag := range metricsV3Flags {
 		flagName := flag.GetName()
 		if ctx.IsSet(flagName) {
@@ -149,16 +149,19 @@ func printPrometheusMetricsV2(ctx *cli.Context, req prometheusMetricsReq) error 
 		}
 	}
 
-	subsys := req.subsystem
-	if subsys == "" {
-		subsys = "cluster"
-	}
-
 	if !metricsV2SubSystems.Contains(subsys) {
 		fatalIf(errInvalidArgument().Trace(),
 			"invalid metric type `"+subsys+"`. valid values are `"+
 				strings.Join(metricsV2SubSystems.ToSlice(), ", ")+"`")
 	}
+}
+
+func printPrometheusMetricsV2(ctx *cli.Context, req prometheusMetricsReq) error {
+	subsys := req.subsystem
+	if subsys == "" {
+		subsys = "cluster"
+	}
+	validateV2Args(ctx, subsys)
 
 	resp, e := fetchMetrics(req.aliasURL+metricsEndPointRoot+subsys, req.token)
 	if e != nil {


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add a flag --api-version with possible values of v2 and v3, with default being v2.

So when this flag is not passed, the command will work exactly as it did before.

When using v3, there is a different set of metric types supported. It also supports a new flag:

bucket: the bucket for which the metrics are to be fetched. it is applicable only for the metric types that are available at bucket level, which currently are 'api' and 'replication'

## Motivation and Context

Support newly introduced `metrics-v3` api

## How to test this PR?

- `mc admin prometheus generate ALIAS cluster|node|bucket|resource`
  - should continue to work as before
  - should work in same way when `--api-version v2` is passed
  - should fail with `Flag `bucket` is not supported with v2 metrics.` when `--bucket` is passed to the command

- `mc admin prometheus generate ALIAS api|system|debug|ilm|audit|logger|replication|notification|scanner`
   - should fail with `invalid metric type`

- `mc admin prometheus generate ALIAS node|bucket|resource --api-version v3`
  - should fail with `invalid metric type`
 
- `mc admin prometheus generate ALIAS api|system|debug|cluster|ilm|audit|logger|replication|notification|scanner --api-version v3`
   - should work fine and put the v3 api endpoint in the generated scrape config

- `mc admin prometheus generate ALIAS api|replication --api-version v3 --bucket BUCKET`
  - should put the bucket specific v3 api endpoint in the generated scrape config

- `mc admin prometheus generate ALIAS --api-version v3`
  - should put the base path (`/minio/metrics/v3`) in the generated scrape config

- `mc admin prometheus generate ALIAS --api-version v3 --bucket BUCKET`
  - should fail with `metric type must be passed with --bucket. valid values are 'api, replication'`

- `mc admin prometheus generate ALIAS system|debug|cluster|ilm|audit|logger|notification|scanner --api-version v3 --bucket BUCKET`
  - should fail with `--bucket is applicable only for metric types 'api, replication'`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [x] Create a documentation update request [here](https://github.com/minio/docs/issues/1266)
