### PR TITLE
mirror: let user decide whether to skip errors if client runs in watch / active-active mode

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -581,8 +581,8 @@ func (mj *mirrorJob) monitorMirrorStatus(cancel context.CancelFunc) (errDuringMi
 			if !ignoreErr {
 				mirrorFailedOps.Inc()
 				errDuringMirror = true
-				// Quit mirroring if --watch and --active-active are not passed
-				if !mj.opts.skipErrors && !mj.opts.activeActive && !mj.opts.isWatch {
+				// Quit mirroring if --skip-errors is not passed
+				if !mj.opts.skipErrors {
 					cancel()
 					cancelInProgress = true
 				}


### PR DESCRIPTION
## Description

Fix #4883

## Motivation and Context

When client has run with `--watch` and minio servers are down (or encounter a network error), `watch` request and mirroring progress will not recover forever after serveral retries.

In version [2022-04-01](https://github.com/minio/mc/blob/RELEASE.2022-04-01T23-44-48Z/cmd/mirror-main.go#L513-L517), mirroring progress will be cancelled and [restarted](https://github.com/minio/mc/blob/RELEASE.2024-07-11T18-01-28Z/cmd/mirror-main.go#L1124-L1129) when `statusCh` returns a `no-ignored` error.

After PR [4032](https://github.com/minio/mc/pull/4032), mirroring progress will not be restarted forever when client runs with `--watch` and/or `--active-active`.

This patch restores the "restart" policy in version `2022-04-01` and users can also pass `--skip-errors` to keep same behavior of current implementation.

## How to test this PR?
 - `mc mirror --watch --remove --overwrite --debug --summary [alias]/[bucket]/path/ ./`
 - use iptables to drop packages from minio servers
 - restore iptables after some minutes
 - client resumes to work

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
