### PR TITLE
Show a warning when the server certificate duration is expiring soon

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -512,7 +512,7 @@ func registerApp(name string) *cli.App {
 			host := k.(string)
 			expires := v.(time.Time)
 			fmt.Fprintf(os.Stderr, "\n")
-			fmt.Fprintf(os.Stderr, "== WARN: `%s` certificate will expire in %s. Consider renewing it soon.\n", host, expires)
+			fmt.Fprintf(os.Stderr, "== WARN: `%s` certificate will expire in %s. Renew soon to avoid outage.\n", host, expires)
 			fmt.Fprintf(os.Stderr, "\n")
 			return true
 		})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -507,6 +507,17 @@ func registerApp(name string) *cli.App {
 	app.CustomAppHelpTemplate = mcHelpTemplate
 	app.EnableBashCompletion = true
 	app.OnUsageError = onUsageError
+	app.After = func(*cli.Context) error {
+		globalExpiringCerts.Range(func(k, v interface{}) bool {
+			host := k.(string)
+			expires := v.(time.Time)
+			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "== WARN: `%s` certificate will expire in %s. Consider renewing it soon.\n", host, expires)
+			fmt.Fprintf(os.Stderr, "\n")
+			return true
+		})
+		return nil
+	}
 
 	if isTerminal() && !globalPagerDisabled {
 		app.HelpWriter = globalHelpPager


### PR DESCRIPTION
When 90% of the validity time of a server is elapsed, print a warning remainding the user to change the certificate.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
