### PR TITLE
Allow STANDARD_IA as a AWS tier storage class

### DIFF
--- a/cmd/ilm-tier-add.go
+++ b/cmd/ilm-tier-add.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -169,10 +170,8 @@ func checkAdminTierAddSyntax(ctx *cli.Context) {
 	}
 }
 
-const (
-	s3Standard          = "STANDARD"
-	s3ReducedRedundancy = "REDUCED_REDUNDANCY"
-)
+// The list of AWS S3 storage classes that can be used with MinIO ILM tiering
+var supportedAWSTierSC = []string{"STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA"}
 
 // fetchTierConfig returns a TierConfig given a tierName, a tierType and ctx to
 // lookup command-line flags from. It exits with non-zero error code if any of
@@ -256,7 +255,7 @@ func fetchTierConfig(ctx *cli.Context, tierName string, tierType madmin.TierType
 
 		s3SC := ctx.String("storage-class")
 		if s3SC != "" {
-			if s3SC != s3Standard && s3SC != s3ReducedRedundancy {
+			if !slices.Contains(supportedAWSTierSC, s3SC) {
 				fatalIf(errInvalidArgument().Trace(), fmt.Sprintf("unsupported storage-class type %s", s3SC))
 			}
 			s3Opts = append(s3Opts, madmin.S3StorageClass(s3SC))


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Currently picking STANDARD_IA as a AWS S3 tiering storage class will fail. However it does not seem
there is any valid reason for that especially STANARD_IA has real time PUT and GET operations.


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
