### PR TITLE
stat: print information about all buckets when only alias are set

### DIFF
--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -72,20 +72,23 @@ EXAMPLES:
   1. Stat all contents of mybucket on Amazon S3 cloud storage.
      {{.Prompt}} {{.HelpName}} s3/mybucket/
 
-  2. Stat all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.
+  2. Stat all contents of all bucket on Amazon S3 cloud storage.
+     {{.Prompt}} {{.HelpName}} s3
+
+  3. Stat all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.
      {{.Prompt}} {{.HelpName}} s3\mybucket\
 
-  3. Stat files recursively on a local filesystem on Microsoft Windows.
+  4. Stat files recursively on a local filesystem on Microsoft Windows.
      {{.Prompt}} {{.HelpName}} --recursive C:\Users\mydocuments\
 
-  4. Stat encrypted files on Amazon S3 cloud storage. In case the encryption key contains non-printable character like tab, pass the
+  5. Stat encrypted files on Amazon S3 cloud storage. In case the encryption key contains non-printable character like tab, pass the
      base64 encoded string as key.
      {{.Prompt}} {{.HelpName}} --enc-c "s3/personal-document/=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDA" s3/personal-document/2019-account_report.docx
 
-  5. Stat a specific object version.
+  6. Stat a specific object version.
      {{.Prompt}} {{.HelpName}} --version-id "CL3sWgdSN2pNntSf6UnZAuh2kcu8E8si" s3/personal-docs/2018-account_report.docx
 
-  6. Stat all objects versions recursively created before 1st January 2020.
+  7. Stat all objects versions recursively created before 1st January 2020.
      {{.Prompt}} {{.HelpName}} --versions --rewind 2020.01.01T00:00 s3/personal-docs/
 `,
 }

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -72,7 +72,7 @@ EXAMPLES:
   1. Stat all contents of mybucket on Amazon S3 cloud storage.
      {{.Prompt}} {{.HelpName}} s3/mybucket/
 
-  2. Stat all contents of all bucket on Amazon S3 cloud storage.
+  2. Stat all contents of all buckets on Amazon S3 cloud storage.
      {{.Prompt}} {{.HelpName}} s3
 
   3. Stat all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.

--- a/cmd/stat-main.go
+++ b/cmd/stat-main.go
@@ -47,6 +47,10 @@ var (
 			Name:  "recursive, r",
 			Usage: "stat all objects recursively",
 		},
+		cli.BoolFlag{
+			Name:  "verbose, v",
+			Usage: "show verbose buckets information",
+		},
 	}
 )
 
@@ -73,7 +77,7 @@ EXAMPLES:
      {{.Prompt}} {{.HelpName}} s3/mybucket/
 
   2. Stat all contents of all buckets on Amazon S3 cloud storage.
-     {{.Prompt}} {{.HelpName}} s3
+     {{.Prompt}} {{.HelpName}} s3 --verbose
 
   3. Stat all contents of mybucket on Amazon S3 cloud storage on Microsoft Windows.
      {{.Prompt}} {{.HelpName}} s3\mybucket\
@@ -128,7 +132,7 @@ func parseAndCheckStatSyntax(ctx context.Context, cliCtx *cli.Context, encKeyDB 
 			fatalIf(err.Trace(url), "Unable to stat `"+url+"`.")
 		}
 		_, path := url2Alias(url)
-		if path != "" {
+		if path != "" || !cliCtx.Bool("verbose") {
 			targetUrls = append(targetUrls, url)
 			continue
 		}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -88,7 +88,7 @@ func (stat statMessage) String() (msg string) {
 	}
 	if stat.Restore != nil {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s:", "Restore") + "\n")
-		if stat.Restore.ExpiryTime.IsZero() && !stat.Restore.ExpiryTime.Equal(timeSentinel) {
+		if !stat.Restore.ExpiryTime.IsZero() && !stat.Restore.ExpiryTime.Equal(timeSentinel) {
 			msgBuilder.WriteString(fmt.Sprintf("  %-10s: %s", "ExpiryTime",
 				stat.Restore.ExpiryTime.Local().Format(printDate)) + "\n")
 		}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -79,10 +79,10 @@ func (stat statMessage) String() (msg string) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "VersionID", versionIDField) + "\n")
 	}
 	msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Type", stat.Type) + "\n")
-	if stat.Expires != nil && !stat.Expires.Equal(timeSentinel) {
+	if stat.Expires != nil && !stat.Expires.IsZero() && !stat.Expires.Equal(timeSentinel) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Expires", stat.Expires.Format(printDate)) + "\n")
 	}
-	if stat.Expiration != nil && !stat.Expiration.Equal(timeSentinel) {
+	if stat.Expiration != nil && !stat.Expiration.IsZero() && !stat.Expiration.Equal(timeSentinel) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s (lifecycle-rule-id: %s) ", "Expiration",
 			stat.Expiration.Local().Format(printDate), stat.ExpirationRuleID) + "\n")
 	}

--- a/cmd/stat.go
+++ b/cmd/stat.go
@@ -61,7 +61,7 @@ func (stat statMessage) String() (msg string) {
 	// Format properly for alignment based on maxKey leng
 	stat.Key = fmt.Sprintf("%-10s: %s", "Name", stat.Key)
 	msgBuilder.WriteString(console.Colorize("Name", stat.Key) + "\n")
-	if !stat.Date.IsZero() {
+	if !stat.Date.IsZero() && !stat.Date.Equal(timeSentinel) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Date", stat.Date.Format(printDate)) + "\n")
 	}
 	if stat.Type != "folder" {
@@ -79,17 +79,19 @@ func (stat statMessage) String() (msg string) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "VersionID", versionIDField) + "\n")
 	}
 	msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Type", stat.Type) + "\n")
-	if stat.Expires != nil {
+	if stat.Expires != nil && !stat.Expires.Equal(timeSentinel) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s ", "Expires", stat.Expires.Format(printDate)) + "\n")
 	}
-	if stat.Expiration != nil {
+	if stat.Expiration != nil && !stat.Expiration.Equal(timeSentinel) {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s: %s (lifecycle-rule-id: %s) ", "Expiration",
 			stat.Expiration.Local().Format(printDate), stat.ExpirationRuleID) + "\n")
 	}
 	if stat.Restore != nil {
 		msgBuilder.WriteString(fmt.Sprintf("%-10s:", "Restore") + "\n")
-		msgBuilder.WriteString(fmt.Sprintf("  %-10s: %s", "ExpiryTime",
-			stat.Restore.ExpiryTime.Local().Format(printDate)) + "\n")
+		if stat.Restore.ExpiryTime.IsZero() && !stat.Restore.ExpiryTime.Equal(timeSentinel) {
+			msgBuilder.WriteString(fmt.Sprintf("  %-10s: %s", "ExpiryTime",
+				stat.Restore.ExpiryTime.Local().Format(printDate)) + "\n")
+		}
 		msgBuilder.WriteString(fmt.Sprintf("  %-10s: %t", "Ongoing",
 			stat.Restore.OngoingRestore) + "\n")
 	}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context
When view information about all buckets at a time, details such as the bucket usage cannot be printed.
![image](https://github.com/user-attachments/assets/c74a4665-cb1e-484a-bfe0-ea4f583b7f30)
Buckets should be treated as special directories because we have metrics for bucket.


## How to test this PR?
mc stat myminio --verbose
![image](https://github.com/user-attachments/assets/28f6f079-8920-4473-8657-546b3366508a)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
