### PR TITLE
Fix wrong message shown when upload to SUBNET fails

### DIFF
--- a/cmd/support-inspect.go
+++ b/cmd/support-inspect.go
@@ -90,7 +90,7 @@ type inspectMessage struct {
 // Colorized message for console printing.
 func (t inspectMessage) String() string {
 	var msg string
-	if globalAirgapped {
+	if globalAirgapped || t.File != "" {
 		if t.Key == "" {
 			msg = fmt.Sprintf("File data successfully downloaded as %s", console.Colorize("File", t.File))
 		} else {


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

When upload of the inspect file to SUBNET fails, following wrong message was getting printed:

`Object inspection data for '' uploaded to SUBNET successfully`

Fixed the if condition to ensure that following correct message is printed:

`File data successfully downloaded as <filename>`

## Motivation and Context

Bugfix

## How to test this PR?

- Ensure that there is no connectivity to SUBNET
- Run `mc support inspect </path/to/object>`
- Verify that correct message is printed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
