### PR TITLE
docs: explain scanner bucket quota check process

### DIFF
--- a/cmd/quota-set.go
+++ b/cmd/quota-set.go
@@ -50,11 +50,16 @@ USAGE:
   {{.HelpName}} TARGET [--size QUOTA]
 
 QUOTA
-  quota accepts human-readable case-insensitive number
-  suffixes such as "k", "m", "g" and "t" referring to the metric units KB,
+  Quota accepts human-readable case-insensitive number.
+  Suffixes such as "k", "m", "g" and "t" referring to the metric units KB,
   MB, GB and TB respectively. Adding an "i" to these prefixes, uses the IEC
   units, so that "gi" refers to "gibibyte" or "GiB". A "b" at the end is
   also accepted. Without suffixes the unit is bytes.
+
+  The MinIO object scanner checks a bucket's quota each time it is scanned.
+  If the scanner determines a bucket has met or exceeded its quota, MinIO
+  rejects subsequent object write requests until the scanner determines the
+  bucket no longer exceeds its quota.
 
 FLAGS:
   {{range .VisibleFlags}}{{.}}


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Proposed addition to `mc quota set` help to clarify that bucket quotas are only checked at the time of a scanner pass. Discussion on what exactly this text should say is very welcome.

## Motivation and Context

The current docs (mc help, web) don't describe the role of the scanner in determining the quota status. Since the scanner only runs periodically, a bucket can exceed its quota until the next scanner pass notices.

In my opinion we should also _not_ describe this as a "hard quota." That suggests MinIO will _never_ allow writes beyond the configured quota, which is incorrect. 

## How to test this PR?

Docs only change (mc quota set help text)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
