### PR TITLE
docs: don't call the bucket quota a "hard quota"

### DIFF
--- a/cmd/quota-set.go
+++ b/cmd/quota-set.go
@@ -32,7 +32,7 @@ import (
 var quotaSetFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "size",
-		Usage: "set a hard quota, disallowing writes after quota is reached",
+		Usage: "set a quota, disallowing writes after quota is reached",
 	},
 }
 
@@ -60,7 +60,7 @@ FLAGS:
   {{range .VisibleFlags}}{{.}}
   {{end}}
 EXAMPLES:
-  1. Set hard quota of 1gb for a bucket "mybucket" on MinIO.
+  1. Set quota of 1gb for a bucket "mybucket" on MinIO.
      {{.Prompt}} {{.HelpName}} myminio/mybucket --size 1GB
 `,
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Follow up to https://github.com/minio/mc/pull/5011, already merged.

Calling the `mc quota set` quota value a "hard quota" is misleading. It is indeed possible to go over quota while waiting for the next scanner pass to notice. Remove `hard` from the command help and example.

Note: there is also a reference in the code itself, which could be confusing to future maintainers. (Maybe used in an error message on failure to set quota?)  Someone more familiar with the code should determine what to do about that. 
```
qType := madmin.HardQuota
```

## Motivation and Context


## How to test this PR?
Docs only

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
