### PR TITLE
add global `--resolve HOST[:PORT]=IP` flag

### DIFF
--- a/cmd/client-admin.go
+++ b/cmd/client-admin.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -149,29 +148,19 @@ func newAnonymousClient(aliasedURL string) (*madmin.AnonymousClient, *probe.Erro
 		return nil, probe.NewError(e)
 	}
 
-	// Keep TLS config.
-	tlsConfig := &tls.Config{
-		RootCAs: globalRootCAs,
-		// Can't use SSLv3 because of POODLE and BEAST
-		// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
-		// Can't use TLSv1.1 because of RC4 cipher usage
-		MinVersion: tls.VersionTLS12,
-	}
-	if globalInsecure {
-		tlsConfig.InsecureSkipVerify = true
-	}
 	// Set custom transport
 	var transport http.RoundTripper = &http.Transport{
-		Proxy: ieproxy.GetProxyFunc(),
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 15 * time.Second,
-		}).DialContext,
+		Proxy:       ieproxy.GetProxyFunc(),
+		DialContext: newCustomDialContext(&Config{}),
+		DialTLSContext: newCustomDialTLSContext(&tls.Config{
+			RootCAs:            globalRootCAs,
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: globalInsecure,
+		}),
 		MaxIdleConnsPerHost:   256,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 10 * time.Second,
-		TLSClientConfig:       tlsConfig,
 		// Set this value so that the underlying transport round-tripper
 		// doesn't try to auto decode the body of objects with
 		// content-encoding set to `gzip`.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -59,6 +59,11 @@ var globalFlags = []cli.Flag{
 		Usage:  "enable debug output",
 		EnvVar: envPrefix + "DEBUG",
 	},
+	cli.StringSliceFlag{
+		Name:   "resolve",
+		Usage:  "resolves HOST[:PORT] to an IP address. Example: minio.local:9000=10.10.75.1",
+		EnvVar: envPrefix + "RESOLVE",
+	},
 	cli.BoolFlag{
 		Name:   "insecure",
 		Usage:  "disable SSL certificate verification",

--- a/cmd/tofu.go
+++ b/cmd/tofu.go
@@ -93,9 +93,9 @@ func promptTrustSelfSignedCert(ctx context.Context, endpoint, alias string) (*x5
 	client := http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
+			DialTLSContext: newCustomDialTLSContext(&tls.Config{
 				RootCAs: globalRootCAs, // make sure to use loaded certs before probing
-			},
+			}),
 		},
 	}
 
@@ -167,9 +167,9 @@ func fetchPeerCertificate(ctx context.Context, endpoint string) (*x509.Certifica
 	}
 	client := http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
+			DialTLSContext: newCustomDialTLSContext(&tls.Config{
 				InsecureSkipVerify: true,
-			},
+			}),
 		},
 	}
 	resp, e := client.Do(req)


### PR DESCRIPTION
## Description
This commit adds support for custom DNS overwrites via one or multiple `--resolve` flags. It allows `mc` users to define custom DNS mappings from a HOST (and optional port) to an IP address.

For example:
```
mc --resolve foo.com:9000:10.1.2.3 ls myminio/mybucket
```
The `--resolve` syntax is taken from cURL. Ref. `curl --help dns`

Use cases:

  1. DNS overwrites. If there are no DNS resolvers available, e.g. due to a temp. outage, this allows `mc` to connect to a defined alias as long as the IP of the one or multiple cluster nodes are known. It also allows `mc` to overwrite the current DNS responses. This is useful for various tests in dev and staging environments.
  2. TLS certificate verification. Often TLS certificates are issued for some DNS names (via SAN) but not for IP addresses. IP addresses are usually not static and might change anytime. Accessing a MinIO cluster that serves a certificate containing only DNS SANs via an IP address results in a TLS certificate verification error - even if the certificate is issued by a trusted CA. The current workaround is the `--insecure` flag which disables TLS certification completely.

Example for TLS verification:

```
$ mc alias set 'myminio' 'https://192.168.188.118:9000' 'minioadmin' 'minioadmin'
mc: <ERROR> Unable to initialize new alias from the provided credentials.
Get "https://192.168.188.118:9000": tls: failed to verify certificate:
x509: cannot validate certificate for 192.168.188.118 because it doesn't contain any IP SANs.
```

```
mc alias set --resolve foo.com:9000:192.168.188.118 'myminio' 'https://foo.com:9000' 'minioadmin' 'minioadmin'
Added `myminio` successfully.
```

## Motivation and Context
TLS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
