### PR TITLE
conditionally disallow list() when object does not exist

### DIFF
--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -50,6 +50,7 @@ type url2StatOptions struct {
 	encKeyDB                map[string][]prefixSSEPair
 	timeRef                 time.Time
 	isZip                   bool
+	headOnly                bool
 	ignoreBucketExistsCheck bool
 }
 
@@ -204,7 +205,14 @@ func url2Stat(ctx context.Context, opts url2StatOptions) (client Client, content
 	alias, _ := url2Alias(opts.urlStr)
 	sse := getSSE(opts.urlStr, opts.encKeyDB[alias])
 
-	content, err = client.Stat(ctx, StatOptions{preserve: opts.fileAttr, sse: sse, timeRef: opts.timeRef, versionID: opts.versionID, isZip: opts.isZip, ignoreBucketExists: opts.ignoreBucketExistsCheck})
+	content, err = client.Stat(ctx, StatOptions{
+		preserve:           opts.fileAttr,
+		sse:                sse,
+		timeRef:            opts.timeRef,
+		versionID:          opts.versionID,
+		isZip:              opts.isZip,
+		ignoreBucketExists: opts.ignoreBucketExistsCheck,
+	})
 	if err != nil {
 		return nil, nil, err.Trace(opts.urlStr)
 	}


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
conditionally disallow list() when object does not exist

## Motivation and Context
allow users to avoid list() call when an object does 
not exist when the following flags are used with `mc stat`

```
--no-list (HEAD the latest version)
--version-id <vid>
```

Also, avoid superfluous url2Stat() calls while processing the 
args; there is no real reason to do that.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
