### PR TITLE
heal: Adapt the status based on a new Finished flag

### DIFF
--- a/cmd/admin-heal.go
+++ b/cmd/admin-heal.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2022 MinIO, Inc.
+// Copyright (c) 2015-2024 MinIO, Inc.
 //
 // This file is part of MinIO Object Storage stack
 //
@@ -398,7 +398,7 @@ func (s verboseBackgroundHealStatusMessage) String() string {
 					stateText = console.Colorize("DiskFailed", d.State)
 				}
 				fmt.Fprintf(&msg, "  +  %s : %s\n", d.DrivePath, stateText)
-				if d.Healing && d.HealInfo != nil {
+				if d.Healing && d.HealInfo != nil && !d.HealInfo.Finished {
 					now := time.Now().UTC()
 					scanSpeed := float64(d.UsedSpace) / float64(now.Sub(d.HealInfo.Started))
 					remainingTime := time.Duration(float64(setsStatus[setIndex{d.PoolIndex, d.SetIndex}].maxUsedSpace-d.UsedSpace) / scanSpeed)
@@ -495,7 +495,7 @@ func (s shortBackgroundHealStatusMessage) String() string {
 				continue
 			}
 
-			if disk.HealInfo != nil {
+			if disk.HealInfo != nil && !disk.HealInfo.Finished {
 				missingInSet++
 
 				diskSet := setIndex{pool: disk.PoolIndex, set: disk.SetIndex}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.8
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v3 v3.0.60
+	github.com/minio/madmin-go/v3 v3.0.63
 	github.com/minio/minio-go/v7 v7.0.75
 	github.com/minio/pkg/v3 v3.0.11
 	github.com/minio/selfupdate v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/minio/colorjson v1.0.8 h1:AS6gEQ1dTRYHmC4xuoodPDRILHP/9Wz5wYUGDQfPLpg
 github.com/minio/colorjson v1.0.8/go.mod h1:wrs39G/4kqNlGjwqHvPlAnXuc2tlPszo6JKdSBCLN8w=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
-github.com/minio/madmin-go/v3 v3.0.60 h1:Vy9t7Mti22EcqqQyYRcvtLJmluaA3VINhBzaDBsT8h8=
-github.com/minio/madmin-go/v3 v3.0.60/go.mod h1:IFAwr0XMrdsLovxAdCcuq/eoL4nRuMVQQv0iubJANQw=
+github.com/minio/madmin-go/v3 v3.0.63 h1:ERJRxEI/FFRh8MDi4Z+3DKe4sONkQ0g+OkNzRpk7qxk=
+github.com/minio/madmin-go/v3 v3.0.63/go.mod h1:IFAwr0XMrdsLovxAdCcuq/eoL4nRuMVQQv0iubJANQw=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.75 h1:0uLrB6u6teY2Jt+cJUVi9cTvDRuBKWSRzSAcznRkwlE=


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
In a new MinIO version, Healing can be set to false while HealInfo is not nil. 
This indicates that the drive was healed and the healing is finished. This commit
 adapts the code with the new concept. This will not break with older MinIO 
versions since those versions will already remove .healing.bin, in that case 
Healing will be false, HealInfo will be nil.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
