### PR TITLE
Add commands for managing Bucket CORS

### DIFF
--- a/cmd/auto-complete.go
+++ b/cmd/auto-complete.go
@@ -511,6 +511,10 @@ var completeCmds = map[string]complete.Predictor{
 	"/quota/clear": aliasCompleter,
 	"/put":         complete.PredictOr(s3Completer, fsCompleter),
 	"/get":         complete.PredictOr(s3Completer, fsCompleter),
+
+	"/cors/set":    s3Complete{deepLevel: 2},
+	"/cors/get":    s3Complete{deepLevel: 2},
+	"/cors/remove": s3Complete{deepLevel: 2},
 }
 
 // flagsToCompleteFlags transforms a cli.Flag to complete.Flags

--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -40,6 +40,7 @@ import (
 	"github.com/minio/mc/pkg/hookreader"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/cors"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
 	"github.com/minio/minio-go/v7/pkg/notification"
@@ -1504,6 +1505,30 @@ func (f *fsClient) Restore(_ context.Context, _ string, _ int) *probe.Error {
 func (f *fsClient) GetPart(_ context.Context, _ int) (io.ReadCloser, *probe.Error) {
 	return nil, probe.NewError(APINotImplemented{
 		API:     "GetPart",
+		APIType: "filesystem",
+	})
+}
+
+// GetBucketCors - not implemented
+func (f *fsClient) GetBucketCors(_ context.Context) (*cors.Config, *probe.Error) {
+	return nil, probe.NewError(APINotImplemented{
+		API:     "GetBucketCors",
+		APIType: "filesystem",
+	})
+}
+
+// SetBucketCors - not implemented
+func (f *fsClient) SetBucketCors(_ context.Context, _ []byte) *probe.Error {
+	return probe.NewError(APINotImplemented{
+		API:     "SetBucketCors",
+		APIType: "filesystem",
+	})
+}
+
+// DeleteBucketCors - not implemented
+func (f *fsClient) DeleteBucketCors(_ context.Context) *probe.Error {
+	return probe.NewError(APINotImplemented{
+		API:     "DeleteBucketCors",
 		APIType: "filesystem",
 	})
 }

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -38,6 +38,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/minio/minio-go/v7/pkg/cors"
 	"github.com/minio/pkg/v3/env"
 
 	"github.com/minio/minio-go/v7"
@@ -3000,4 +3001,53 @@ func (c *S3Client) GetPart(ctx context.Context, part int) (io.ReadCloser, *probe
 		return nil, probe.NewError(e)
 	}
 	return reader, nil
+}
+
+// SetBucketCors - Set bucket cors configuration.
+func (c *S3Client) SetBucketCors(ctx context.Context, corsXML []byte) *probe.Error {
+	bucketName, _ := c.url2BucketAndObject()
+	if bucketName == "" {
+		return probe.NewError(BucketNameEmpty{})
+	}
+
+	corsCfg, err := cors.ParseBucketCorsConfig(bytes.NewReader(corsXML))
+	if err != nil {
+		return probe.NewError(err)
+	}
+
+	err = c.api.SetBucketCors(ctx, bucketName, corsCfg)
+	if err != nil {
+		return probe.NewError(err)
+	}
+	return nil
+}
+
+// GetBucketCors - Get bucket cors configuration.
+func (c *S3Client) GetBucketCors(ctx context.Context) (*cors.Config, *probe.Error) {
+	bucketName, _ := c.url2BucketAndObject()
+	if bucketName == "" {
+		return nil, probe.NewError(BucketNameEmpty{})
+	}
+
+	corsCfg, err := c.api.GetBucketCors(ctx, bucketName)
+	if err != nil {
+		return nil, probe.NewError(err)
+	}
+
+	return corsCfg, nil
+}
+
+// DeleteBucketCors - Delete bucket cors configuration.
+func (c *S3Client) DeleteBucketCors(ctx context.Context) *probe.Error {
+	bucketName, _ := c.url2BucketAndObject()
+	if bucketName == "" {
+		return probe.NewError(BucketNameEmpty{})
+	}
+
+	err := c.api.SetBucketCors(ctx, bucketName, nil)
+	if err != nil {
+		return probe.NewError(err)
+	}
+
+	return nil
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/minio/mc/pkg/limiter"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/cors"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 	"github.com/minio/minio-go/v7/pkg/lifecycle"
@@ -199,6 +200,11 @@ type Client interface {
 	// OD operations
 	GetPart(ctx context.Context, part int) (io.ReadCloser, *probe.Error)
 	PutPart(ctx context.Context, reader io.Reader, size int64, progress io.Reader, opts PutOptions) (n int64, err *probe.Error)
+
+	// Cors operations
+	GetBucketCors(ctx context.Context) (*cors.Config, *probe.Error)
+	SetBucketCors(ctx context.Context, corsXML []byte) *probe.Error
+	DeleteBucketCors(ctx context.Context) *probe.Error
 }
 
 // ClientContent - Content container for content metadata

--- a/cmd/cors-get.go
+++ b/cmd/cors-get.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/pkg/v3/console"
+)
+
+var corsGetCmd = cli.Command{
+	Name:         "get",
+	Usage:        "get a bucket CORS configuration",
+	Action:       mainCorsGet,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} ALIAS/BUCKET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Get the CORS configuration for the bucket 'mybucket':
+     {{.Prompt}} {{.HelpName}} myminio/mybucket
+ `,
+}
+
+// checkCorsGetSyntax - validate all the passed arguments
+func checkCorsGetSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		showCommandHelpAndExit(ctx, 1) // last argument is exit code
+	}
+}
+
+// mainCorsGet is the handle for "mc cors get" command.
+func mainCorsGet(ctx *cli.Context) error {
+	checkCorsGetSyntax(ctx)
+
+	console.SetColor("CorsMessage", color.New(color.FgGreen))
+	console.SetColor("CorsNotFound", color.New(color.FgYellow))
+
+	// args[0] is the ALIAS/BUCKET argument.
+	args := ctx.Args()
+	urlStr := args.Get(0)
+
+	client, err := newClient(urlStr)
+	fatalIf(err.Trace(urlStr), "Unable to initialize client for "+urlStr)
+
+	corsCfg, err := client.GetBucketCors(globalContext)
+	fatalIf(err.Trace(urlStr), "Unable to get bucket CORS configuration for "+urlStr)
+
+	status := "success"
+	if corsCfg == nil {
+		status = "not found"
+	}
+
+	printMsg(corsMessage{
+		op:      "get",
+		Status:  status,
+		CorsCfg: corsCfg,
+	})
+
+	return nil
+}

--- a/cmd/cors-main.go
+++ b/cmd/cors-main.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import "github.com/minio/cli"
+
+var corsSubcommands = []cli.Command{
+	corsSetCmd,
+	corsGetCmd,
+	corsRemoveCmd,
+}
+
+var corsCmd = cli.Command{
+	Name:        "cors",
+	Usage:       "manage bucket CORS configuration",
+	Action:      mainCors,
+	Before:      setGlobalsFromContext,
+	Flags:       globalFlags,
+	Subcommands: corsSubcommands,
+}
+
+func mainCors(ctx *cli.Context) error {
+	commandNotFound(ctx, corsSubcommands)
+	return nil
+}

--- a/cmd/cors-remove.go
+++ b/cmd/cors-remove.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	"github.com/minio/pkg/v3/console"
+)
+
+var corsRemoveCmd = cli.Command{
+	Name:         "remove",
+	Usage:        "remove a bucket CORS configuration",
+	Action:       mainCorsRemove,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} ALIAS/BUCKET
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Remove the CORS configuration for the bucket 'mybucket':
+     {{.Prompt}} {{.HelpName}} myminio/mybucket
+ `,
+}
+
+// checkCorsRemoveSyntax - validate all the passed arguments
+func checkCorsRemoveSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		showCommandHelpAndExit(ctx, 1) // last argument is exit code
+	}
+}
+
+// mainCorsRemove is the handle for "mc cors remove" command.
+func mainCorsRemove(ctx *cli.Context) error {
+	checkCorsRemoveSyntax(ctx)
+
+	console.SetColor("CorsMessage", color.New(color.FgGreen))
+
+	// args[0] is the ALIAS/BUCKET argument.
+	args := ctx.Args()
+	urlStr := args.Get(0)
+
+	client, err := newClient(urlStr)
+	fatalIf(err.Trace(urlStr), "Unable to initialize client for "+urlStr)
+
+	err = client.DeleteBucketCors(globalContext)
+	fatalIf(err.Trace(urlStr), "Unable to remove bucket CORS configuration for "+urlStr)
+
+	printMsg(corsMessage{
+		op:     "remove",
+		Status: "success",
+	})
+
+	return nil
+}

--- a/cmd/cors-set.go
+++ b/cmd/cors-set.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2015-2024 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/minio/cli"
+	json "github.com/minio/colorjson"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v7/pkg/cors"
+	"github.com/minio/pkg/v3/console"
+)
+
+var corsSetCmd = cli.Command{
+	Name:         "set",
+	Usage:        "set a bucket CORS configuration",
+	Action:       mainCorsSet,
+	OnUsageError: onUsageError,
+	Before:       setGlobalsFromContext,
+	Flags:        globalFlags,
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} ALIAS/BUCKET CORSFILE
+
+CORSFILE:
+  Path to the XML file containing the CORS configuration.
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+EXAMPLES:
+  1. Set the CORS configuration for the bucket 'mybucket':
+     {{.Prompt}} {{.HelpName}} myminio/mybucket /path/to/cors.xml
+
+  2. Set the CORS configuration for the bucket 'mybucket' using stdin:
+     {{.Prompt}} {{.HelpName}} myminio/mybucket -
+ `,
+}
+
+// corsMessage container for output message.
+type corsMessage struct {
+	op      string
+	Status  string       `json:"status"`
+	Message string       `json:"message,omitempty"`
+	CorsCfg *cors.Config `json:"cors,omitempty"`
+}
+
+func (c corsMessage) String() string {
+	switch c.op {
+	case "get":
+		if c.CorsCfg == nil {
+			return console.Colorize("CorsNotFound", "No bucket CORS configuration found.")
+		}
+		corsXML, e := c.CorsCfg.ToXML()
+		fatalIf(probe.NewError(e), "Unable to marshal to XML.")
+		return string(corsXML)
+	case "set":
+		return console.Colorize("CorsMessage", "Set bucket CORS config successfully.")
+	case "remove":
+		return console.Colorize("CorsMessage", "Removed bucket CORS config successfully.")
+	}
+	return ""
+}
+
+func (c corsMessage) JSON() string {
+	jsonBytes, e := json.MarshalIndent(&c, "", " ")
+	fatalIf(probe.NewError(e), "Unable to marshal to JSON.")
+
+	return string(jsonBytes)
+}
+
+// checkCorsSetSyntax - validate all the passed arguments
+func checkCorsSetSyntax(ctx *cli.Context) {
+	if len(ctx.Args()) != 2 {
+		showCommandHelpAndExit(ctx, 1) // last argument is exit code
+	}
+}
+
+// mainCorsSet is the handle for "mc cors set" command.
+func mainCorsSet(ctx *cli.Context) error {
+	checkCorsSetSyntax(ctx)
+
+	console.SetColor("CorsMessage", color.New(color.FgGreen))
+
+	// args[0] is the ALIAS/BUCKET argument.
+	args := ctx.Args()
+	urlStr := args.Get(0)
+
+	// args[1] is the CORSFILE which is a local file, or in the case of "-", stdin.
+	var e error
+	in := os.Stdin
+	if f := args.Get(1); f != "-" {
+		in, e = os.Open(f)
+		fatalIf(probe.NewError(e).Trace(args...), "Unable to open bucket CORS configuration file.")
+		defer in.Close()
+	}
+	corsXML, e := io.ReadAll(in)
+	fatalIf(probe.NewError(e).Trace(args...), "Unable to read bucket CORS configuration file.")
+
+	client, err := newClient(urlStr)
+	fatalIf(err.Trace(urlStr), "Unable to initialize client for "+urlStr)
+
+	fatalIf(client.SetBucketCors(globalContext, corsXML), "Unable to set bucket CORS configuration for "+urlStr)
+
+	printMsg(corsMessage{
+		op:     "set",
+		Status: "success",
+	})
+
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -421,6 +421,7 @@ var appCmds = []cli.Command{
 	cpCmd,
 	catCmd,
 	configCmd,
+	corsCmd,
 	diffCmd,
 	duCmd,
 	encryptCmd,


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add the following commands:

- `mc cors set`
- `mc cors remove`
- `mc cors get`

## Motivation and Context

These will work with S3 and MinEOS

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
