### PR TITLE
Do not fail mc-admin-policy-attach if policy already attached/detached

### DIFF
--- a/cmd/admin-policy-attach.go
+++ b/cmd/admin-policy-attach.go
@@ -23,6 +23,10 @@ import (
 	"github.com/minio/mc/pkg/probe"
 )
 
+const (
+    errCodeChangeAlreadyApplied = "XMinioAdminPolicyChangeAlreadyApplied"
+)
+
 var adminAttachPolicyFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "user, u",
@@ -68,6 +72,17 @@ func mainAdminPolicyAttach(ctx *cli.Context) error {
 	return userAttachOrDetachPolicy(ctx, true)
 }
 
+func isCodeChangeAlreadyAppliedError(e error) bool {
+    switch v := e.(type) {
+    case madmin.ErrorResponse:
+        if v.Code == errCodeChangeAlreadyApplied {
+            return true
+        }
+    }
+
+    return false
+}
+
 func userAttachOrDetachPolicy(ctx *cli.Context, attach bool) error {
 	if len(ctx.Args()) < 2 {
 		showCommandHelpAndExit(ctx, 1) // last argument is exit code
@@ -97,7 +112,10 @@ func userAttachOrDetachPolicy(ctx *cli.Context, attach bool) error {
 	} else {
 		res, e = client.DetachPolicy(globalContext, req)
 	}
-	fatalIf(probe.NewError(e), "Unable to make user/group policy association")
+
+    if e != nil && !isCodeChangeAlreadyAppliedError(e) {
+            fatalIf(probe.NewError(e), "Unable to make user/group policy association")
+    }
 
 	var emptyResp madmin.PolicyAssociationResp
 	if res.UpdatedAt == emptyResp.UpdatedAt {

--- a/cmd/admin-policy-attach.go
+++ b/cmd/admin-policy-attach.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-    errCodeChangeAlreadyApplied = "XMinioAdminPolicyChangeAlreadyApplied"
+	errCodeChangeAlreadyApplied = "XMinioAdminPolicyChangeAlreadyApplied"
 )
 
 var adminAttachPolicyFlags = []cli.Flag{
@@ -73,14 +73,13 @@ func mainAdminPolicyAttach(ctx *cli.Context) error {
 }
 
 func isCodeChangeAlreadyAppliedError(e error) bool {
-    switch v := e.(type) {
-    case madmin.ErrorResponse:
-        if v.Code == errCodeChangeAlreadyApplied {
-            return true
-        }
-    }
-
-    return false
+	switch v := e.(type) {
+	case madmin.ErrorResponse:
+		if v.Code == errCodeChangeAlreadyApplied {
+			return true
+		}
+	}
+	return false
 }
 
 func userAttachOrDetachPolicy(ctx *cli.Context, attach bool) error {
@@ -113,9 +112,9 @@ func userAttachOrDetachPolicy(ctx *cli.Context, attach bool) error {
 		res, e = client.DetachPolicy(globalContext, req)
 	}
 
-    if e != nil && !isCodeChangeAlreadyAppliedError(e) {
-            fatalIf(probe.NewError(e), "Unable to make user/group policy association")
-    }
+	if e != nil && !isCodeChangeAlreadyAppliedError(e) {
+		fatalIf(probe.NewError(e), "Unable to make user/group policy association")
+	}
 
 	var emptyResp madmin.PolicyAssociationResp
 	if res.UpdatedAt == emptyResp.UpdatedAt {

--- a/cmd/admin-policy-attach.go
+++ b/cmd/admin-policy-attach.go
@@ -72,16 +72,6 @@ func mainAdminPolicyAttach(ctx *cli.Context) error {
 	return userAttachOrDetachPolicy(ctx, true)
 }
 
-func isCodeChangeAlreadyAppliedError(e error) bool {
-	switch v := e.(type) {
-	case madmin.ErrorResponse:
-		if v.Code == errCodeChangeAlreadyApplied {
-			return true
-		}
-	}
-	return false
-}
-
 func userAttachOrDetachPolicy(ctx *cli.Context, attach bool) error {
 	if len(ctx.Args()) < 2 {
 		showCommandHelpAndExit(ctx, 1) // last argument is exit code
@@ -112,7 +102,7 @@ func userAttachOrDetachPolicy(ctx *cli.Context, attach bool) error {
 		res, e = client.DetachPolicy(globalContext, req)
 	}
 
-	if e != nil && !isCodeChangeAlreadyAppliedError(e) {
+	if e != nil && madmin.ToErrorResponse(e).Code != errCodeChangeAlreadyApplied {
 		fatalIf(probe.NewError(e), "Unable to make user/group policy association")
 	}
 

--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -967,6 +967,9 @@ function test_admin_users() {
 	# check that the user can write objects with readwrite policy
 	assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin policy attach "$SERVER_ALIAS" readwrite --user="${username}"
 
+	# verify that re-attaching an already attached policy to a user does not result in a failure.
+	assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd admin policy attach "$SERVER_ALIAS" readwrite --user="${username}"
+
 	# Validate that the correct policy has been added to the user
 	"${MC_CMD[@]}" --json admin user list "${SERVER_ALIAS}" | jq -r '.policyName' | grep --quiet "^readwrite$"
 	rv=$?


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
`mc admin policy attach` of a policy that has been already assigned to a user should succeed.
Same with detach.

## Motivation and Context
Currently, attempts to attach a policy to a user who already has the policy attached to them results in a 400.

This change is to handle cases where policy attach/detach operations are automated using scripts/jobs. A re-run of the attach/detach step should not result in the failure of the entire job.

## How to test this PR?
Attach a policy to a user using `mc admin policy attach ...`
Attach the same policy again. The command should succeed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
