### PR TITLE
Add support rpc JSON replay.

### DIFF
--- a/cmd/admin-scanner-status.go
+++ b/cmd/admin-scanner-status.go
@@ -33,7 +33,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
@@ -64,9 +64,8 @@ var adminScannerInfoFlags = []cli.Flag{
 		Value: -1,
 	},
 	cli.StringFlag{
-		Name:   "in",
-		Hidden: true,
-		Usage:  "read previously saved json from file and replay",
+		Name:  "in",
+		Usage: "read previously saved json from file and replay",
 	},
 	cli.StringFlag{
 		Name:  "bucket",
@@ -198,19 +197,6 @@ func mainAdminScannerInfo(ctx *cli.Context) error {
 
 	checkAdminScannerInfoSyntax(ctx)
 
-	aliasedURL := ctx.Args().Get(0)
-
-	// Create a new MinIO Admin Client
-	client, err := newAdminClient(aliasedURL)
-	fatalIf(err.Trace(aliasedURL), "Unable to initialize admin client.")
-
-	if bucket := ctx.String("bucket"); bucket != "" {
-		bucketStats, err := client.BucketScanInfo(globalContext, bucket)
-		fatalIf(probe.NewError(err).Trace(aliasedURL), "Unable to get bucket stats.")
-		printMsg(bucketScanMsg{Stats: bucketStats})
-		return nil
-	}
-
 	ui := tea.NewProgram(initScannerMetricsUI(ctx.Int("max-paths")))
 	ctxt, cancel := context.WithCancel(globalContext)
 	defer cancel()
@@ -220,11 +206,11 @@ func mainAdminScannerInfo(ctx *cli.Context) error {
 		go func() {
 			if _, e := ui.Run(); e != nil {
 				cancel()
-				fatalIf(probe.NewError(e).Trace(aliasedURL), "Unable to fetch scanner metrics")
+				fatalIf(probe.NewError(e), "Unable to fetch scanner metrics")
 			}
 		}()
 		f, e := os.Open(inFile)
-		fatalIf(probe.NewError(e).Trace(aliasedURL), "Unable to open input")
+		fatalIf(probe.NewError(e), "Unable to open input")
 		sc := bufio.NewReader(f)
 		var lastTime time.Time
 		for {
@@ -248,6 +234,18 @@ func mainAdminScannerInfo(ctx *cli.Context) error {
 			lastTime = metrics.Aggregated.Scanner.CollectedAt
 		}
 		os.Exit(0)
+	}
+
+	// Create a new MinIO Admin Client
+	aliasedURL := ctx.Args().Get(0)
+	client, err := newAdminClient(aliasedURL)
+	fatalIf(err.Trace(aliasedURL), "Unable to initialize admin client.")
+
+	if bucket := ctx.String("bucket"); bucket != "" {
+		bucketStats, err := client.BucketScanInfo(globalContext, bucket)
+		fatalIf(probe.NewError(err).Trace(aliasedURL), "Unable to get bucket stats.")
+		printMsg(bucketScanMsg{Stats: bucketStats})
+		return nil
 	}
 
 	opts := madmin.MetricsOptions{


### PR DESCRIPTION
## Description

Add realtime replay of captured JSON data.

Example:
```
λ mc support top rpc --json myminio >rpc.json

λ mc support top rpc -in=rpc.json
```

Sample file: [rpc.json.gz](https://github.com/user-attachments/files/17440415/rpc.json.gz)


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
