### PR TITLE
heal: Simplify bucket healing status

### DIFF
--- a/cmd/admin-heal-ui.go
+++ b/cmd/admin-heal-ui.go
@@ -127,7 +127,9 @@ func (ui *uiData) updateStats(i madmin.HealResultItem) error {
 	var afterCol col
 	h := newHRI(&i)
 	switch h.Type {
-	case madmin.HealItemMetadata, madmin.HealItemBucket:
+	case madmin.HealItemBucket:
+		_, afterCol, err = h.getBucketHCCChange()
+	case madmin.HealItemMetadata, madmin.HealItemBucketMetadata:
 		_, afterCol, err = h.getReplicatedFileHCCChange()
 	default:
 		_, afterCol, err = h.getObjectHCCChange()
@@ -206,7 +208,9 @@ func (ui *uiData) printItemsQuietly(s *madmin.HealTaskStatus) (err error) {
 	for _, item := range s.Items {
 		h := newHRI(&item)
 		switch h.Type {
-		case madmin.HealItemMetadata, madmin.HealItemBucket:
+		case madmin.HealItemBucket:
+			b, a, err = h.getBucketHCCChange()
+		case madmin.HealItemMetadata, madmin.HealItemBucketMetadata:
 			b, a, err = h.getReplicatedFileHCCChange()
 		default:
 			b, a, err = h.getObjectHCCChange()
@@ -267,7 +271,9 @@ func (ui *uiData) printItemsJSON(s *madmin.HealTaskStatus) (err error) {
 		var b, a col
 		var err error
 		switch h.Type {
-		case madmin.HealItemMetadata, madmin.HealItemBucket:
+		case madmin.HealItemBucket:
+			b, a, err = h.getBucketHCCChange()
+		case madmin.HealItemMetadata, madmin.HealItemBucketMetadata:
 			b, a, err = h.getReplicatedFileHCCChange()
 		default:
 			if h.Type == madmin.HealItemObject {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Avoid using drive count concept to pick a color for a bucket healing result. This was straighforward when we were healing a bucket per erasure set but now it becomes more complex to calculate a result.

Pick green if everything is okay, yellow if a bucket is missing in a
drive, red for any other drive state (unformatted, offline, ..) and
grey for any weird situation.

This will also avoid mc admin heal quitting beause of shard/parity error message

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
