### PR TITLE
Reject policy with comma in name

### DIFF
--- a/cmd/admin-policy-create.go
+++ b/cmd/admin-policy-create.go
@@ -18,8 +18,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/minio/cli"
@@ -125,6 +127,10 @@ func mainAdminPolicyCreate(ctx *cli.Context) error {
 	// Get the alias parameter from cli
 	args := ctx.Args()
 	aliasedURL := args.Get(0)
+
+	if strings.Contains(args.Get(1), ",") {
+		fatalIf(probe.NewError(errors.New("policy name may not incude comma")), "Only a single policy may be specified here. Policy name may not incude commas.")
+	}
 
 	policy, e := os.ReadFile(args.Get(2))
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to get policy")

--- a/cmd/admin-policy-create.go
+++ b/cmd/admin-policy-create.go
@@ -129,7 +129,7 @@ func mainAdminPolicyCreate(ctx *cli.Context) error {
 	aliasedURL := args.Get(0)
 
 	if strings.Contains(args.Get(1), ",") {
-		fatalIf(probe.NewError(errors.New("policy name may not incude comma")), "Only a single policy may be specified here. Policy name may not incude commas.")
+		fatalIf(probe.NewError(errors.New("policy name may not include comma")), "Only a single policy may be specified here.")
 	}
 
 	policy, e := os.ReadFile(args.Get(2))


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Adds check to throw error if policy name contains comma.

## Motivation and Context
Policy lists are comma delimited, so policy names may not contain commas. Before, mc allowed creation of policy with comma in name.

## How to test this PR?
Attempt to create a policy with a comma in the policy name.

```
/mc admin policy create minio "testPolicy,withcomma" ~/mytestpolicy.json
mc: <ERROR> Only a single policy may be specified here. policy name may not include comma.
```

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
