### PR TITLE
Improve trace stats

### DIFF
--- a/cmd/admin-scanner-status.go
+++ b/cmd/admin-scanner-status.go
@@ -35,6 +35,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
+	"github.com/klauspost/compress/zstd"
 	"github.com/minio/cli"
 	json "github.com/minio/colorjson"
 	"github.com/minio/madmin-go/v3"
@@ -211,7 +212,15 @@ func mainAdminScannerInfo(ctx *cli.Context) error {
 		}()
 		f, e := os.Open(inFile)
 		fatalIf(probe.NewError(e), "Unable to open input")
-		sc := bufio.NewReader(f)
+		defer f.Close()
+		in := io.Reader(f)
+		if strings.HasSuffix(inFile, ".zst") {
+			zr, e := zstd.NewReader(in)
+			fatalIf(probe.NewError(e), "Unable to open input")
+			defer zr.Close()
+			in = zr
+		}
+		sc := bufio.NewReader(in)
 		var lastTime time.Time
 		for {
 			b, e := sc.ReadBytes('\n')


### PR DESCRIPTION
## Description

Allows traces to be replayed in stats mode from `mc admin trace -json ALIAS >trace.json`, using `mc admin trace -in=trace.json`. Also `.zst` are automatically decompressed.

This is replayed at full speed, since I don't really see any value in keeping original speed.

Add scrolling to stats. Up+Down+Home+End

Add 'r' to reset min/max stats.

## How to test this PR?

See instructions above.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
