### PR TITLE
Add go runtime profile type

### DIFF
--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -269,6 +269,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		})
 		if e != nil {
 			// Attempt an older API server might be old
+			//lint:ignore SA1019 We explicitly want old API.
 			e = client.ServiceRestart(ctxt)
 		}
 		fatalIf(probe.NewError(e), "Unable to restart the server.")

--- a/cmd/admin-service-restart.go
+++ b/cmd/admin-service-restart.go
@@ -269,7 +269,7 @@ func mainAdminServiceRestart(ctx *cli.Context) error {
 		})
 		if e != nil {
 			// Attempt an older API server might be old
-			//lint:ignore SA1019 We explicitly want old API.
+			//nolint:staticcheck
 			e = client.ServiceRestart(ctxt)
 		}
 		fatalIf(probe.NewError(e), "Unable to restart the server.")

--- a/cmd/admin-service-unfreeze.go
+++ b/cmd/admin-service-unfreeze.go
@@ -74,7 +74,7 @@ func checkAdminServiceUnfreezeSyntax(ctx *cli.Context) {
 }
 
 func mainAdminServiceUnfreeze(ctx *cli.Context) error {
-	// Validate serivce unfreeze syntax.
+	// Validate service unfreeze syntax.
 	checkAdminServiceUnfreezeSyntax(ctx)
 
 	// Set color.
@@ -89,7 +89,7 @@ func mainAdminServiceUnfreeze(ctx *cli.Context) error {
 	fatalIf(err, "Unable to initialize admin connection.")
 
 	// Unfreeze the specified MinIO server
-	fatalIf(probe.NewError(client.ServiceUnfreeze(globalContext)), "Unable to unfreeze the server.")
+	fatalIf(probe.NewError(client.ServiceUnfreezeV2(globalContext)), "Unable to unfreeze the server.")
 
 	// Success..
 	printMsg(serviceUnfreezeCommand{Status: "success", ServerURL: aliasedURL})

--- a/cmd/client-fs_windows.go
+++ b/cmd/client-fs_windows.go
@@ -56,6 +56,6 @@ func IsDeleteEvent(event notify.Event) bool {
 
 // getAllXattrs returns the extended attributes for a file if supported
 // by the OS
-func getAllXattrs(path string) (map[string]string, error) {
+func getAllXattrs(_ string) (map[string]string, error) {
 	return nil, nil
 }

--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -119,7 +119,9 @@ func checkAdminProfileSyntax(ctx *cli.Context) {
 		string(madmin.ProfilerTrace),
 		string(madmin.ProfilerThreads),
 		string(madmin.ProfilerGoroutines),
-		string(madmin.ProfilerCPUIO))
+		string(madmin.ProfilerCPUIO),
+		string(madmin.ProfilerRuntime),
+	)
 	// Check if the provided profiler type is known and supported
 	profilers := strings.Split(strings.ToLower(ctx.String("type")), ",")
 	for _, profiler := range profilers {
@@ -134,8 +136,8 @@ func checkAdminProfileSyntax(ctx *cli.Context) {
 		showCommandHelpAndExit(ctx, 1) // last argument is exit code
 	}
 
-	if ctx.Int("duration") < 10 {
-		fatal(errDummy().Trace(), "for any useful profiling one must run it for atleast 10 seconds")
+	if ctx.Int("duration") < 1 {
+		fatal(errDummy().Trace(), "for any useful profiling one must run it for at least 1 second")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.8
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v3 v3.0.78
+	github.com/minio/madmin-go/v3 v3.0.79
 	github.com/minio/minio-go/v7 v7.0.82
 	github.com/minio/pkg/v3 v3.0.23
 	github.com/minio/selfupdate v0.6.0
@@ -118,3 +118,5 @@ require (
 	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/minio/madmin-go/v3 v3.0.79 => github.com/klauspost/madmin-go/v3 v3.0.0-20241218165029-d0467cf8d00a

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/minio/cli v1.24.2
 	github.com/minio/colorjson v1.0.8
 	github.com/minio/filepath v1.0.0
-	github.com/minio/madmin-go/v3 v3.0.79
+	github.com/minio/madmin-go/v3 v3.0.82-0.20241219154017-7a6a137d7ed6
 	github.com/minio/minio-go/v7 v7.0.82
 	github.com/minio/pkg/v3 v3.0.23
 	github.com/minio/selfupdate v0.6.0
@@ -118,5 +118,3 @@ require (
 	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/minio/madmin-go/v3 v3.0.79 => github.com/klauspost/madmin-go/v3 v3.0.0-20241218165029-d0467cf8d00a

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
+github.com/klauspost/madmin-go/v3 v3.0.0-20241218165029-d0467cf8d00a h1:6M46Xowm4oJIr7BcL9WyFHKEaJ5iv4D0/5YmWMXC56I=
+github.com/klauspost/madmin-go/v3 v3.0.0-20241218165029-d0467cf8d00a/go.mod h1:QAZPX3xx4gdZbZ8t85SieFSwXMOQhFx7bVjldhyc6Bk=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -141,8 +143,6 @@ github.com/minio/colorjson v1.0.8 h1:AS6gEQ1dTRYHmC4xuoodPDRILHP/9Wz5wYUGDQfPLpg
 github.com/minio/colorjson v1.0.8/go.mod h1:wrs39G/4kqNlGjwqHvPlAnXuc2tlPszo6JKdSBCLN8w=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
-github.com/minio/madmin-go/v3 v3.0.78 h1:JHUZU8akWSu8UF+mIBpsOSLtOG9b4ZTZVz3TShLbYn4=
-github.com/minio/madmin-go/v3 v3.0.78/go.mod h1:IZOL4lEMiJ4QN2iWQjkOIIthcVuNYU7ENF7RkyxlzKY=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.82 h1:tWfICLhmp2aFPXL8Tli0XDTHj2VB/fNf0PC1f/i1gRo=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
-github.com/klauspost/madmin-go/v3 v3.0.0-20241218165029-d0467cf8d00a h1:6M46Xowm4oJIr7BcL9WyFHKEaJ5iv4D0/5YmWMXC56I=
-github.com/klauspost/madmin-go/v3 v3.0.0-20241218165029-d0467cf8d00a/go.mod h1:QAZPX3xx4gdZbZ8t85SieFSwXMOQhFx7bVjldhyc6Bk=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -143,6 +141,8 @@ github.com/minio/colorjson v1.0.8 h1:AS6gEQ1dTRYHmC4xuoodPDRILHP/9Wz5wYUGDQfPLpg
 github.com/minio/colorjson v1.0.8/go.mod h1:wrs39G/4kqNlGjwqHvPlAnXuc2tlPszo6JKdSBCLN8w=
 github.com/minio/filepath v1.0.0 h1:fvkJu1+6X+ECRA6G3+JJETj4QeAYO9sV43I79H8ubDY=
 github.com/minio/filepath v1.0.0/go.mod h1:/nRZA2ldl5z6jT9/KQuvZcQlxZIMQoFFQPvEXx9T/Bw=
+github.com/minio/madmin-go/v3 v3.0.82-0.20241219154017-7a6a137d7ed6 h1:ftB3HcXyqxWWN+WoqSSy5K+4muzvq+aMtdtu9zMLyCg=
+github.com/minio/madmin-go/v3 v3.0.82-0.20241219154017-7a6a137d7ed6/go.mod h1:QAZPX3xx4gdZbZ8t85SieFSwXMOQhFx7bVjldhyc6Bk=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.82 h1:tWfICLhmp2aFPXL8Tli0XDTHj2VB/fNf0PC1f/i1gRo=

--- a/pkg/disk/stat_windows.go
+++ b/pkg/disk/stat_windows.go
@@ -22,6 +22,6 @@ package disk
 
 // GetFileSystemAttrs return the file system attribute as string; containing mode,
 // uid, gid, uname, Gname, atime, mtime, ctime and md5
-func GetFileSystemAttrs(file string) (string, error) {
+func GetFileSystemAttrs(_ string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## Description

Available on AIStor.

~Requires https://github.com/minio/madmin-go/pull/322~ (merged)

Lower minimum duration to 1 second. Useful (pretty much required) for traces.

## How to test this PR?

Test against AIStor PR 262

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
