### PR TITLE
fix ilm rule edit for --expire-all-object-versions

### DIFF
--- a/cmd/ilm/options.go
+++ b/cmd/ilm/options.go
@@ -435,7 +435,8 @@ func ApplyRuleFields(dest *lifecycle.Rule, opts LifecycleOptions) *probe.Error {
 		dest.Expiration.DeleteMarker = lifecycle.ExpireDeleteMarker(*opts.ExpiredObjectDeleteMarker)
 		dest.Expiration.Days = 0
 		dest.Expiration.Date = lifecycle.ExpirationDate{}
-	} else if opts.ExpiredObjectAllversions != nil {
+	}
+	if opts.ExpiredObjectAllversions != nil {
 		dest.Expiration.DeleteAll = lifecycle.ExpirationBoolean(*opts.ExpiredObjectAllversions)
 	}
 


### PR DESCRIPTION
Editing a rule with --expire-all-object-versions should be applied to existing rule properly

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


## Motivation and Context


## How to test this PR?
```
mc ilm rule add --expire-days "365"  sitea/bucket2
mc ilm rule edit --id ctpdqf3b61a9d2elqqv0 --expire-days "365" --expire-all-object-versions sitea/bucket2
```

ExpiredObjectAllVersions: true should be set in the policy after the edit
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
