### PR TITLE
Don't show Bucket created confirmation message if bucket creation failed

### DIFF
--- a/cmd/mb-main.go
+++ b/cmd/mb-main.go
@@ -153,7 +153,7 @@ func mainMakeBucket(cliCtx *cli.Context) error {
 				errorIf(err.Trace(targetURL), "Unable to make bucket `%s`.", targetURL)
 			}
 			cErr = exitStatus(globalErrorExitStatus)
-			continue
+			break
 		}
 
 		if cliCtx.Bool("with-versioning") {


### PR DESCRIPTION


## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Skips displaying "Bucket created successfully" confirmation if bucket creation fails.

## Motivation and Context

Before, UI displayed "Bucket created successfully" confirmation despite failure of bucket creation. Confirmation no longer displayed if bucket creation fails. 

Before
<img width="754" alt="Screenshot 2025-01-13 at 3 04 25 PM" src="https://github.com/user-attachments/assets/9df04ab8-96eb-4d7e-8740-fefcf43ba039" />


<img width="754" alt="Screenshot 2025-01-13 at 3 02 09 PM" src="https://github.com/user-attachments/assets/e2687391-defa-4bd2-8b53-bb91a6aff279" />
## How to test this PR?
Attempt to create a bucket in an incorrect way (ex - "mc mb ALIAS BUCKETNAME" vs  "mc mb ALIAS/BUCKETNAME"). No bucket should be created (can verify with mc ls), and only error message should show.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
