### PR TITLE
Improve the error message when trying to add multiple expiry options …

### DIFF
--- a/cmd/ilm/options.go
+++ b/cmd/ilm/options.go
@@ -272,6 +272,8 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 		}
 	}
 
+	expiryRulesCount := 0
+
 	if ctx.IsSet("size-lt") {
 		szStr := ctx.String("size-lt")
 		szLt, err := humanize.ParseBytes(szStr)
@@ -321,9 +323,11 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 		tags = strPtr(ctx.String("tags"))
 	}
 	if ctx.IsSet("expiry-date") {
+		expiryRulesCount++
 		expiryDate = strPtr(ctx.String("expiry-date"))
 	}
 	if ctx.IsSet("expiry-days") {
+		expiryRulesCount++
 		expiryDays = strPtr(ctx.String("expiry-days"))
 	}
 	if f := "expire-days"; ctx.IsSet(f) {
@@ -339,6 +343,7 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 		expiredObjectDeleteMarker = boolPtr(ctx.Bool("expired-object-delete-marker"))
 	}
 	if f := "expire-delete-marker"; ctx.IsSet(f) {
+		expiryRulesCount++
 		expiredObjectDeleteMarker = boolPtr(ctx.Bool(f))
 	}
 	if ctx.IsSet("noncurrentversion-expiration-days") {
@@ -372,6 +377,10 @@ func GetLifecycleOptions(ctx *cli.Context) (LifecycleOptions, *probe.Error) {
 	}
 	if ctx.IsSet("expire-all-object-versions") {
 		expiredObjectAllversions = boolPtr(ctx.Bool("expire-all-object-versions"))
+	}
+
+	if expiryRulesCount > 1 {
+		return LifecycleOptions{}, probe.NewError(errors.New("only one of expiry-date, expiry-days and expire-delete-marker can be used in a single rule. Try adding multiple rules to achieve the desired effect"))
 	}
 
 	return LifecycleOptions{


### PR DESCRIPTION
…in a single rule

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Make an error message more descriptive about what the user can do to fix the problem.

## Motivation and Context

Currently this ilm rule adding error is hard to understand:

```
mc ilm add play/locked-bucket-abc --expiry-date 2026-01-01 --noncurrent-expire-days 3 --expire-delete-marker --prefix /adgf
mc: <ERROR> Unable to generate new lifecycle rules for the input: only one parameter under Expiration can be specified.
```

- There are many `mc` flags but it's not clear which ones are "under Expiration" (which is a reference to an internal Go struct, not something a user can see).
- For example, `--noncurrent-expire-days` is NOT  "under Expiration" even though it looks like it might be, as it contains the word "expire" in it. 
- --expire-days, --expire-date and --expire-all-object-versions are "under Expiration" but this is not clear. 

The new error simply informs the user where they have made a mistake, and suggests that they can achieve what they want by adding a multiple rules:

```
 ❯ ./mc ilm add play/locked-bucket-abc --expiry-date 2026-01-01 --expire-delete-marker --prefix /adgf
mc: <ERROR> Unable to generate new lifecycle rules for the input: only one of expiry-date, expiry-days 
and expire-delete-marker can be used in a single rule. Try adding multiple rules to achieve the desired effect.
```

## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
