### PR TITLE
mc find - allow absolute times

### DIFF
--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -120,6 +120,7 @@ var rewindSupportedFormat = []string{
 	"2006.01.02T15:04",
 	"2006.01.02T15:04:05",
 	time.RFC3339,
+	printDate,
 }
 
 // Parse rewind flag while considering the system local time zone

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -175,7 +175,16 @@ func isOlder(ti time.Time, olderRef string) bool {
 	}
 	objectAge := time.Since(ti)
 	olderThan, e := ParseDuration(olderRef)
-	fatalIf(probe.NewError(e), "Unable to parse olderThan=`"+olderRef+"`.")
+	if e != nil {
+		for _, format := range rewindSupportedFormat {
+			if t, e2 := time.Parse(format, olderRef); e2 == nil {
+				olderThan = Duration(time.Since(t))
+				e = nil
+				break
+			}
+		}
+	}
+	fatalIf(probe.NewError(e), "Unable to parse olderThan=`"+olderRef+"`. Supply relative '7d6h2m' or absolute '"+printDate+"'.")
 	return objectAge < time.Duration(olderThan)
 }
 
@@ -187,7 +196,16 @@ func isNewer(ti time.Time, newerRef string) bool {
 
 	objectAge := time.Since(ti)
 	newerThan, e := ParseDuration(newerRef)
-	fatalIf(probe.NewError(e), "Unable to parse newerThan=`"+newerRef+"`.")
+	if e != nil {
+		for _, format := range rewindSupportedFormat {
+			if t, e2 := time.Parse(format, newerRef); e2 == nil {
+				newerThan = Duration(time.Since(t))
+				e = nil
+				break
+			}
+		}
+	}
+	fatalIf(probe.NewError(e), "Unable to parse newerThan=`"+newerRef+"`. Supply relative '7d6h2m' or absolute '"+printDate+"'.")
 	return objectAge >= time.Duration(newerThan)
 }
 


### PR DESCRIPTION
## Description

For `--newer-than` and `--older-than`, allow using absolute times.

Example:

```
λ mc ls play/testbucket
[2025-01-22 09:57:12 CET] 676KiB STANDARD Daily checks Procedure for Portainer.docx
[2025-01-22 16:40:07 CET]  22KiB STANDARD dovrennost_mobilizaciya_0-2.docx

λ mc find -newer-than="2025-01-22 09:57:00 CET" play/testbucket
play/testbucket/Daily checks Procedure for Portainer.docx
play/testbucket/dovrennost_mobilizaciya_0-2.docx

λ mc find -newer-than="2025-01-22 09:57:13 CET" play/testbucket
play/testbucket/dovrennost_mobilizaciya_0-2.docx
```

We allow the same timestamp types as `--rewind` and add the printed type for easy copy+paste.

## Motivation and Context

Sometimes you just want absolute timestamps.

## How to test this PR?

See above.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
