### PR TITLE
enable get credentials from environment

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -304,7 +304,14 @@ func expandAliasFromEnv(envURL string) (*aliasConfigV10, *probe.Error) {
 	if err != nil {
 		return nil, err.Trace(envURL)
 	}
-
+	if globalCredsEnv {
+		if accessKeyVal := os.Getenv(accessKey); accessKeyVal != "" {
+			accessKey = accessKeyVal
+		}
+		if secretKeyVal := os.Getenv(secretKey); secretKeyVal != "" {
+			secretKey = secretKeyVal
+		}
+	}
 	return &aliasConfigV10{
 		URL:          u.String(),
 		API:          "S3v4",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -96,6 +96,11 @@ var globalFlags = []cli.Flag{
 		Hidden: true,
 		Value:  10 * time.Minute,
 	},
+	cli.BoolFlag{
+		Name:   "creds-env",
+		Usage:  "enable get credentials from environment",
+		EnvVar: envPrefix + "CREDS_ENV",
+	},
 }
 
 // bundled encryption flags

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -73,6 +73,7 @@ var (
 	globalDebug        = false               // Debug flag set via command line
 	globalNoColor      = false               // No Color flag set via command line
 	globalInsecure     = false               // Insecure flag set via command line
+	globalCredsEnv     = false               // Get credentials from environment flag set via command line
 	globalResolvers    map[string]netip.Addr // Custom mappings from HOST[:PORT] to IP
 	globalAirgapped    = false               // Airgapped flag set via command line
 	globalSubnetConfig []madmin.SubsysConfig // Subnet config
@@ -124,6 +125,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	insecure := ctx.Bool("insecure") || ctx.GlobalBool("insecure")
 	devMode := ctx.Bool("dev") || ctx.GlobalBool("dev")
 	airgapped := ctx.Bool("airgap") || ctx.GlobalBool("airgap")
+	credsEnv := ctx.Bool("creds-env") || ctx.GlobalBool("creds-env")
 
 	globalQuiet = globalQuiet || quiet
 	globalDebug = globalDebug || debug
@@ -133,6 +135,7 @@ func setGlobalsFromContext(ctx *cli.Context) error {
 	globalInsecure = globalInsecure || insecure
 	GlobalDevMode = GlobalDevMode || devMode
 	globalAirgapped = globalAirgapped || airgapped
+	globalCredsEnv = globalCredsEnv || credsEnv
 
 	// Disable colorified messages if requested.
 	if globalNoColor || globalQuiet {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
If the AK or SK contains special characters, using the environment variable prefixed with MC_HOST_ to preset aliases fails.


## Motivation and Context
Presetting aliases using environment variables no need to worry about special characters.


## How to test this PR?
before:
```
export MC_HOST_test=https://test1:a:b:c:@ASDASDSAD@play.min.io
mc ls test
```
![image](https://github.com/user-attachments/assets/aca9c6f4-f947-48ce-90dc-06ae97dad205)
afrer:
```
export access_key=test1
export secret_key=a:b:c:@ASDASDSAD
export MC_HOST_test=https://access_key:secret_key@play.min.io
mc ls test --creds-env
```
![image](https://github.com/user-attachments/assets/f57196f8-6095-4455-966e-831fe79c4677)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
