### PR TITLE
fix: urls equals nil deref

### DIFF
--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -50,7 +50,7 @@ func (m URLs) Equal(n URLs) bool {
 		return false
 	} else if m.SourceContent == nil && n.SourceContent != nil {
 		return false
-	} else if m.SourceContent.URL != n.SourceContent.URL {
+	} else if m.SourceContent != nil && n.SourceContent != nil && m.SourceContent.URL != n.SourceContent.URL {
 		return false
 	}
 
@@ -58,7 +58,7 @@ func (m URLs) Equal(n URLs) bool {
 		return false
 	} else if m.TargetContent == nil && n.TargetContent != nil {
 		return false
-	} else if m.TargetContent.URL != n.TargetContent.URL {
+	} else if m.TargetContent != nil && n.TargetContent != nil && m.TargetContent.URL != n.TargetContent.URL {
 		return false
 	}
 


### PR DESCRIPTION
Now in checks we can get nil dereference while both struct has Content field of nil. But in code we cheching for nil, and I believe that testcase can be real:
```go
urls1 := URLs{};
urls2 := URLs{};
urls1.Equal(urls2);
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
