### PR TITLE
fix empty ilm tier list output

### DIFF
--- a/cmd/ilm-tier-list.go
+++ b/cmd/ilm-tier-list.go
@@ -28,6 +28,7 @@ import (
 	json "github.com/minio/colorjson"
 	madmin "github.com/minio/madmin-go/v3"
 	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/pkg/v3/console"
 )
 
 var adminTierListCmd = cli.Command{
@@ -108,6 +109,11 @@ func mainAdminTierList(ctx *cli.Context) error {
 
 	tiers, e := client.ListTiers(globalContext)
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to list configured remote tier targets")
+
+	if len(tiers) == 0 {
+		console.Info("No remote tier targets found for alias '" + aliasedURL + "'. Use `mc ilm tier add` to configure one.\n")
+		return nil
+	}
 
 	if globalJSON {
 		printMsg(&tierListMessage{

--- a/cmd/ilm-tier-list.go
+++ b/cmd/ilm-tier-list.go
@@ -111,7 +111,7 @@ func mainAdminTierList(ctx *cli.Context) error {
 	fatalIf(probe.NewError(e).Trace(args...), "Unable to list configured remote tier targets")
 
 	if len(tiers) == 0 {
-		console.Info("No remote tier targets found for alias '" + aliasedURL + "'. Use `mc ilm tier add` to configure one.\n")
+		console.Infoln("No remote tier targets found for alias '" + aliasedURL + "'. Use `mc ilm tier add` to configure one.")
 		return nil
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This PR fixes the output of mc ilm tier list when there are no tiers registered to the target

## How to test this PR?
Verify that we get an info message instead of empty table when we run mc ilm tier list to a target with No Tiers Registered

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
