### PR TITLE
mirror:Check the source object exists before remove

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -367,7 +367,17 @@ func (mj *mirrorJob) doRemove(ctx context.Context, sURLs URLs, event EventInfo) 
 	if mj.opts.isFake {
 		return sURLs.WithError(nil)
 	}
-
+	if sURLs.SourceContent != nil {
+		// Construct proper path with alias.
+		sourceWithAlias := filepath.Join(sURLs.SourceAlias, sURLs.SourceContent.URL.Path)
+		sourceCient, pErr := newClient(sourceWithAlias)
+		if pErr != nil {
+			return sURLs.WithError(pErr)
+		}
+		if _, err := sourceCient.Stat(ctx, StatOptions{headOnly: true}); err == nil {
+			return sURLs.WithError(nil)
+		}
+	}
 	// Construct proper path with alias.
 	targetWithAlias := filepath.Join(sURLs.TargetAlias, sURLs.TargetContent.URL.Path)
 	clnt, pErr := newClient(targetWithAlias)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Check whether objects of other versions exist before remove.


## Motivation and Context
fix #5147 


## How to test this PR?
1.Creating a Bucket and Enabling Versioning Control
```
mc mb myminio/bucket --with-versioning
```
2.Start the mirror process.
```
mc mirror --overwrite --remove --watch myminio/bucket /local/
```
3.Upload the object to the bucket twice.
```
mc cp test.txt myminio/bucket/
mc cp test.txt myminio/bucket/
```
4.Delete an object based on the version number.
```
mc rm myminio/bucket/test.txt --version-id xxxxxx
```
Check whether local files are deleted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
