### PR TITLE
 Fix undo command to work with DELETE actions on non-minio s3

### DIFF
--- a/cmd/undo-main.go
+++ b/cmd/undo-main.go
@@ -247,8 +247,10 @@ func undoURL(ctx context.Context, aliasedURL string, last int, recursive, dryRun
 			remove = false
 			continue
 		}
-		perObjectVersions = append(perObjectVersions, content)
-		atLeastOneUndoApplied = true
+		if (action == actionDelete && content.IsDeleteMarker) || (action == actionPut && !content.IsDeleteMarker) || action == "" {
+			perObjectVersions = append(perObjectVersions, content)
+			atLeastOneUndoApplied = true
+		}
 	}
 
 	// Undo the remaining versions found if any


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This pull request includes a change to the `undoURL` function in the `cmd/undo-main.go` file. The change adds a conditional check to determine whether to append `content` to `perObjectVersions` based on the `action`.

## Motivation and Context

My goal with this PR is to resolve the error in issue #5152 (in which mc ignored the DELETE --actions).

## How to test this PR?

- Build the code
- Create a versioned bucket S3 on Scaleway 
- Upload multiple files, then delete them 
- run `mc undo scw/my-bucket/ -r --dry-run --force --action DELETE`
- You should only see files concerned by -DELETE` actions (on master branch, we also see PUT actions)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
