### PR TITLE
Fix transition days calculation

### DIFF
--- a/cmd/ilm/utils.go
+++ b/cmd/ilm/utils.go
@@ -75,7 +75,7 @@ func getExpirationDays(rule lifecycle.Rule) int {
 // time.Now().UTC() for the given rule.
 func getTransitionDays(rule lifecycle.Rule) int {
 	if !rule.Transition.Date.IsZero() {
-		return int(time.Now().UTC().Sub(rule.Transition.Date.Time).Hours() / 24)
+		return int(time.Until(rule.Transition.Date.Time).Hours() / 24)
 	}
 
 	return int(rule.Transition.Days)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Fixes transition days calculation for date based ILM rules.

## Motivation and Context
Calculation of transition days for date based ILM rules was inverted, giving incorrect value.

## How to test this PR?
Create a date based ILM rule e.x. :
`mc ilm rule add   --transition-date "2025-03-20"   --transition-tier "PLAY" TARGET`

View the rule using
`./mc ilm rule ls TARGET`

Before

![Screenshot 2025-03-05 at 11 07 21 AM](https://github.com/user-attachments/assets/45571ca5-3bc6-468b-85b3-7d953b9db028)


After

![Screenshot 2025-03-05 at 11 07 38 AM](https://github.com/user-attachments/assets/696fae81-de97-411a-bfb6-51a11c68908e)
## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
