### PR TITLE
Reject add ILM rule with both day and date parameters

### DIFF
--- a/cmd/ilm/parse.go
+++ b/cmd/ilm/parse.go
@@ -114,14 +114,7 @@ func validateExpiration(rule lifecycle.Rule) error {
 }
 
 func validateTransition(rule lifecycle.Rule) error {
-	var i int
-	if !rule.Transition.IsDaysNull() {
-		i++
-	}
-	if !rule.Transition.IsDateNull() {
-		i++
-	}
-	if i > 1 {
+	if !rule.Transition.IsDaysNull() && !rule.Transition.IsDateNull() {
 		return errors.New("only one parameter under Transition can be specified")
 	}
 	return nil


### PR DESCRIPTION

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Rejects attempt to add an ILM rule with both transition-date and transition-days parameters set with an appropriate error message.

## Motivation and Context
Attempting to add an ILM rule with both transition-date and transition-days parameters set would report success, despite the days portion being lost in rule creation.

## How to test this PR?
Attempt to create an ILM rule with both transition-date and transition-days parameters set e.g.
`./mc ilm rule add   --transition-date "2025-03-20"  --transition-days "2" --transition-tier "PLAY" TARGET`

Should fail with error message `Unable to generate new lifecycle rules for the input: only one parameter under Transition can be specified.`

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
