### PR TITLE
Remove logs feature from 'mc support callhome'

### DIFF
--- a/cmd/subnet-utils.go
+++ b/cmd/subnet-utils.go
@@ -65,10 +65,6 @@ func subnetIssueURL(issueNum int) string {
 	return fmt.Sprintf("%s/issues/%d", SubnetBaseURL(), issueNum)
 }
 
-func subnetLogWebhookURL() string {
-	return SubnetBaseURL() + "/api/logs"
-}
-
 // SubnetUploadURL - returns the upload URL for the given upload type
 func SubnetUploadURL(uploadType string) string {
 	return fmt.Sprintf("%s/api/%s/upload", SubnetBaseURL(), uploadType)


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Both the flags --logs and --diag are removed, and the command supports only diagnostics callhome.

## Motivation and Context

https://github.com/minio/mc/issues/5111

## How to test this PR?

Test all the usages of the command:

```
mc support callhome status <alias>
mc support callhome enable <alias>
mc support callhome disable <alias>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
