### PR TITLE
Exit mc mirror when errors occur if retry is disabled and it's a watch operation

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -45,6 +45,14 @@ type errorMessage struct {
 	SysInfo   map[string]string  `json:"sysinfo,omitempty"`
 }
 
+// errorOrFatal wrapper function to call errorIf or fatalIf based on the boolean value
+func errorOrFatal(useFatal bool, err *probe.Error, msg string, data ...interface{}) {
+	if useFatal {
+		fatalIf(err, msg, data...)
+	}
+	errorIf(err, msg, data...)
+}
+
 // fatalIf wrapper function which takes error and selectively prints stack frames if available on debug
 func fatalIf(err *probe.Error, msg string, data ...interface{}) {
 	if err == nil {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

When running `mc mirror --watch` the cli exits with a non-zero exit code instead of just printing the error.

## Motivation and Context

I'm running `mc mirror --watch` in a **systemd** unit to constantly mirror my minio buckets to AWS S3. In the current state, it's not possible to monitor **mc** effectively since the process will just continue running.

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
