### PR TITLE
pre-emptively disable sha256 payload if checksum is set

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1086,6 +1086,8 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, progre
 		}
 	}
 
+	disableSha256 := putOpts.checksum.IsSet() // pre-emptively disable sha256 payload, if checksum is set.
+
 	opts := minio.PutObjectOptions{
 		UserMetadata:          metadata,
 		UserTags:              tagsMap,
@@ -1100,6 +1102,7 @@ func (c *S3Client) Put(ctx context.Context, reader io.Reader, size int64, progre
 		SendContentMd5:        putOpts.md5,
 		Checksum:              putOpts.checksum,
 		DisableMultipart:      putOpts.disableMultipart,
+		DisableContentSha256:  disableSha256,
 		PartSize:              putOpts.multipartSize,
 		NumThreads:            putOpts.multipartThreads,
 		ConcurrentStreamParts: putOpts.concurrentStream, // if enabled honors NumThreads for piped() uploads


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
pre-emptively disable sha256 payload if checksum is set

## Motivation and Context
just making sure we do not compute sha256 payload
along with x-amz-checksum

## How to test this PR?
Observe that `mc put` doesn't compute any sha256 payload
non TLS connections when --checksum is selected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
