### PR TITLE
add min-len and max-len parameters to mc share upload

### DIFF
--- a/cmd/client-fs.go
+++ b/cmd/client-fs.go
@@ -565,7 +565,7 @@ func (f *fsClient) ShareDownload(_ context.Context, _ string, _ time.Duration) (
 }
 
 // ShareUpload - share upload not implemented for filesystem.
-func (f *fsClient) ShareUpload(_ context.Context, _ bool, _ time.Duration, _ string) (string, map[string]string, *probe.Error) {
+func (f *fsClient) ShareUpload(_ context.Context, _ bool, _ time.Duration, _ string, _ int64, _ int64) (string, map[string]string, *probe.Error) {
 	return "", nil, probe.NewError(APINotImplemented{
 		API:     "ShareUpload",
 		APIType: "filesystem",

--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -2445,7 +2445,7 @@ func (c *S3Client) ShareDownload(ctx context.Context, versionID string, expires 
 }
 
 // ShareUpload - get data for presigned post http form upload.
-func (c *S3Client) ShareUpload(ctx context.Context, isRecursive bool, expires time.Duration, contentType string) (string, map[string]string, *probe.Error) {
+func (c *S3Client) ShareUpload(ctx context.Context, isRecursive bool, expires time.Duration, contentType string, minLen int64, maxLen int64) (string, map[string]string, *probe.Error) {
 	bucket, object := c.url2BucketAndObject()
 	p := minio.NewPostPolicy()
 	if e := p.SetExpires(UTCNow().Add(expires)); e != nil {
@@ -2466,6 +2466,9 @@ func (c *S3Client) ShareUpload(ctx context.Context, isRecursive bool, expires ti
 		if e := p.SetKey(object); e != nil {
 			return "", nil, probe.NewError(e)
 		}
+	}
+	if minLen != 0 || maxLen != 0 {
+		p.SetContentLengthRange(minLen, maxLen)
 	}
 	u, m, e := c.api.PresignedPostPolicy(ctx, p)
 	if e != nil {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -159,7 +159,7 @@ type Client interface {
 
 	// I/O operations with expiration
 	ShareDownload(ctx context.Context, versionID string, expires time.Duration) (string, *probe.Error)
-	ShareUpload(context.Context, bool, time.Duration, string) (string, map[string]string, *probe.Error)
+	ShareUpload(context.Context, bool, time.Duration, string, int64, int64) (string, map[string]string, *probe.Error)
 
 	// Watch events
 	Watch(ctx context.Context, options WatchOptions) (*WatchObject, *probe.Error)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Allow to specify content length range with `mc share upload` command.

## Motivation and Context

This is usefull to share upload link with length restriction.

This feature is already present in [minio java client](https://github.com/minio/minio-java/blob/master/examples/GetPresignedPostFormData.java#L61).

## How to test this PR?

Create a test bucket on [play](https://play.min.io) server and share an upload using --max-len parameter then upload a file larger than expected:

```
mc mb play/mytest
mc share upload --max-len 2 play/mytest/info.txt
curl (...) -Ffile=@afilebiggerthantwobytes.txt

```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Unit tests added/updated => I'm dont know how to do this for this kind feature :-(
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN) => I've updated the cli help. I will create the documentation update if this pull request is accepted. 
