### PR TITLE
feat: add `--bfs` option to `mc mirror` for layer-by-layer traversal …

### DIFF
--- a/cmd/client-s3.go
+++ b/cmd/client-s3.go
@@ -1839,6 +1839,10 @@ func (c *S3Client) listVersionsRoutine(ctx context.Context, b, o string, opts Li
 		buckets = append(buckets, b)
 	}
 
+	if opts.Prefix != "" {
+		o = opts.Prefix
+	}
+
 	for _, b := range buckets {
 		var skipKey string
 		for objectVersion := range c.api.ListObjects(ctx, b, minio.ListObjectsOptions{
@@ -2104,6 +2108,10 @@ func (c *S3Client) listIncompleteInRoutine(ctx context.Context, contentCh chan *
 func (c *S3Client) listIncompleteRecursiveInRoutine(ctx context.Context, contentCh chan *ClientContent, opts ListOptions) {
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
+	if opts.Prefix != "" {
+		o = opts.Prefix
+	}
+
 	switch {
 	case b == "" && o == "":
 		buckets, err := c.api.ListBuckets(ctx)
@@ -2243,6 +2251,7 @@ func (c *S3Client) objectInfo2ClientContent(bucket string, entry minio.ObjectInf
 	}
 	url.Path = c.buildAbsPath(bucket, entry.Key)
 	content.URL = url
+	content.ObjectKey = entry.Key
 	content.BucketName = bucket
 	content.Size = entry.Size
 	content.ETag = entry.ETag
@@ -2321,6 +2330,10 @@ func (c *S3Client) bucketStat(ctx context.Context, opts BucketStatOptions) (*Cli
 func (c *S3Client) listInRoutine(ctx context.Context, contentCh chan *ClientContent, opts ListOptions) {
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
+	if opts.Prefix != "" {
+		o = opts.Prefix
+	}
+
 	if opts.ListZip && (b == "" || o == "") {
 		contentCh <- &ClientContent{
 			Err: probe.NewError(errors.New("listing zip files must provide bucket and object")),
@@ -2385,6 +2398,10 @@ func sortBucketsNameWithSlash(bucketsInfo []minio.BucketInfo) {
 func (c *S3Client) listRecursiveInRoutine(ctx context.Context, contentCh chan *ClientContent, opts ListOptions) {
 	// get bucket and object from URL.
 	b, o := c.url2BucketAndObject()
+	if opts.Prefix != "" {
+		o = opts.Prefix
+	}
+
 	switch {
 	case b == "" && o == "":
 		buckets, err := c.api.ListBuckets(ctx)

--- a/cmd/client-url.go
+++ b/cmd/client-url.go
@@ -190,10 +190,14 @@ func (u ClientURL) String() string {
 }
 
 // urlJoinPath Join a path to existing URL.
-func urlJoinPath(url1, url2 string) string {
-	u1 := newClientURL(url1)
-	u2 := newClientURL(url2)
-	return joinURLs(u1, u2).String()
+func urlJoinPath(base, element string) string {
+	if strings.HasSuffix(base, "/") && strings.HasPrefix(element, "/") {
+		return base + element[1:]
+	}
+	if !strings.HasSuffix(base, "/") && !strings.HasPrefix(element, "/") {
+		return base + "/" + element
+	}
+	return base + element
 }
 
 // url2Stat returns stat info for URL - supports bucket, object and a prefixe with or without a trailing slash

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -108,6 +108,7 @@ type ListOptions struct {
 	TimeRef           time.Time
 	ShowDir           DirOpt
 	Count             int
+	Prefix            string // Add prefix support
 }
 
 // CopyOptions holds options for copying operation
@@ -213,6 +214,7 @@ type Client interface {
 // ClientContent - Content container for content metadata
 type ClientContent struct {
 	URL          ClientURL
+	ObjectKey    string
 	BucketName   string // only valid and set for client-type objectStorage
 	Time         time.Time
 	Size         int64

--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -144,6 +144,10 @@ var (
 			Name:  "skip-errors",
 			Usage: "skip any errors when mirroring",
 		},
+		cli.BoolFlag{
+			Name:  "bfs",
+			Usage: "using BFS for layer-by-layer traversal of files, suitable for large number of files",
+		},
 		checksumFlag,
 	}
 )
@@ -212,7 +216,7 @@ EXAMPLES:
       {{.Prompt}} {{.HelpName}} --older-than 30d s3/test ~/test
 
   13. Mirror server encrypted objects from Amazon S3 cloud storage to a bucket on Amazon S3 cloud storage
-      {{.Prompt}} {{.HelpName}} --enc-c "minio/archive=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDA" --enc-c "s3/archive=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5BBB" s3/archive/ minio/archive/ 
+      {{.Prompt}} {{.HelpName}} --enc-c "minio/archive=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDA" --enc-c "s3/archive=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5BBB" s3/archive/ minio/archive/
 
   14. Update 'Cache-Control' header on all existing objects recursively.
       {{.Prompt}} {{.HelpName}} --attr "Cache-Control=max-age=90000,min-fresh=9000" myminio/video-files myminio/video-files
@@ -1024,6 +1028,7 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 		userMetadata:          userMetadata,
 		encKeyDB:              encKeyDB,
 		activeActive:          isWatch,
+		bfs:                   cli.Bool("bfs"),
 	}
 
 	// If we are not using active/active and we are not removing

--- a/cmd/mirror-url.go
+++ b/cmd/mirror-url.go
@@ -278,6 +278,7 @@ type mirrorOptions struct {
 	userMetadata                                          map[string]string
 	checksum                                              minio.ChecksumType
 	sourceListingOnly                                     bool
+	bfs                                                   bool
 }
 
 // Prepares urls that need to be copied or removed based on requested options.


### PR DESCRIPTION
## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

In some cases, a Minio bucket can contain so many files that the server struggles to perform the `list objects recursively` operation, resulting in a complete freeze of `mc mirror`. This pull request introduces the `--bfs` parameter, enabling mc mirror to traverse folders layer by layer, thus avoiding overwhelming the server by listing all files at once.

closes #4873

## Motivation and Context

discuss in https://github.com/minio/mc/issues/4873#issuecomment-2788096406

## How to test this PR?

`mc mirror source target --bfs --dry`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
