### PR TITLE
mirror: skip status message from excluded buckets

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -1086,11 +1086,6 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 					}
 				}
 
-				mj.status.PrintMsg(mirrorMessage{
-					Source: newSrcURL,
-					Target: newTgtURL,
-				})
-
 				if mj.opts.isFake {
 					continue
 				}
@@ -1099,6 +1094,11 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 				if matchExcludeBucketOptions(mopts.excludeBuckets, sourceSuffix) {
 					continue
 				}
+
+				mj.status.PrintMsg(mirrorMessage{
+					Source: newSrcURL,
+					Target: newTgtURL,
+				})
 
 				// Bucket only exists in the source, create the same bucket in the destination
 				if err := newDstClt.MakeBucket(ctx, cli.String("region"), false, withLock); err != nil {


### PR DESCRIPTION
## Description
Make mc mirror log easier to read when `--exclude-bucket` switch is used by skipping status messages from those buckets.

## Motivation and Context
In complex environments it is common to have multiple mc mirrors running and syncing different buckets so it is critical to be able to track what which of them gets mirrored by which process.

## How to test this PR?
Mirror from one env to another with `--exclude-bucket` flag make sure that you don't see excluded buckets in list.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
