### PR TITLE
fix for chained mirror (#4558)

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -717,6 +717,7 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 			}
 			if mj.opts.activeActive &&
 				event.Type != notification.ObjectCreatedCopy &&
+				event.Type != notification.ObjectCreatedPut &&
 				event.Type != notification.ObjectCreatedCompleteMultipartUpload &&
 				(getSourceModTimeKey(mirrorURL.SourceContent.Metadata) != "" ||
 					getSourceModTimeKey(mirrorURL.SourceContent.UserMetadata) != "") {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Changing the condition to allow PUT request from server  to server. Basically added a check for event.Type to be not equal to notification.ObjectCreatedPut, with this change, mirror can now process PUT requests between two server.

## How to test this PR?
1. create three servers
2. start two mirrors
mc mirror --watch A B
mc mirror --watch B C
3. perform put operations on A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
