### PR TITLE
fix for chained mirror #4558

### DIFF
--- a/cmd/mirror-main.go
+++ b/cmd/mirror-main.go
@@ -747,7 +747,7 @@ func (mj *mirrorJob) watchMirrorEvents(ctx context.Context, events []EventInfo) 
 			}
 			mirrorURL.TotalCount = mj.status.GetCounts()
 			mirrorURL.TotalSize = mj.status.Get()
-			if mirrorURL.TargetContent != nil && (mj.opts.isRemove || mj.opts.activeActive) {
+			if mirrorURL.TargetContent != nil && (mj.opts.isRemove || mj.opts.activeActive || mj.opts.isWatch) {
 				mj.parallel.queueTask(func() URLs {
 					return mj.doRemove(ctx, mirrorURL, event)
 				}, 0)
@@ -995,7 +995,8 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 		isOverwrite = cli.Bool("overwrite")
 	}
 
-	isWatch := cli.Bool("watch") || cli.Bool("multi-master") || cli.Bool("active-active")
+	isWatch := cli.Bool("watch") || cli.Bool("multi-master")
+	isActiveActive := cli.Bool("active-active")
 	isRemove := cli.Bool("remove")
 	md5, checksum := parseChecksum(cli)
 
@@ -1023,7 +1024,7 @@ func runMirror(ctx context.Context, srcURL, dstURL string, cli *cli.Context, enc
 		storageClass:          cli.String("storage-class"),
 		userMetadata:          userMetadata,
 		encKeyDB:              encKeyDB,
-		activeActive:          isWatch,
+		activeActive:          isActiveActive,
 	}
 
 	// If we are not using active/active and we are not removing


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
Issue #4558 describes how the chained mirror command avoided copy and put requests when the request originated from server to server, but still performed the delete/remove operation. The problem was that the same isWatch variable was being used for both the isWatch and isActiveActive fields in the mirrorOptions struct. I have now separated the isActiveActive field into a different variable and updated the condition that queues the doRemove operation accordingly.


## How to test this PR?
1. create three servers A, B, C
2. start mirror commands
 mc mirror -w A B
 mc mirror -w B C
 3. perform put and delete requests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
