### PR TITLE
Change support profile defaults

### DIFF
--- a/cmd/support-profile.go
+++ b/cmd/support-profile.go
@@ -37,12 +37,12 @@ var (
 		cli.IntFlag{
 			Name:  "duration",
 			Usage: "profile for the specified duration in seconds",
-			Value: 10,
+			Value: 15,
 		},
 		cli.StringFlag{
 			Name:  "type",
-			Usage: "profiler type, possible values are 'cpu', 'cpuio', 'mem', 'block', 'mutex', 'trace', 'threads' and 'goroutines'",
-			Value: "cpu,mem,block,mutex,goroutines",
+			Usage: "profiler type, possible values are 'cpu', 'cpuio', 'mem', 'block', 'mutex', 'trace', 'threads', 'goroutines' and 'runtime'",
+			Value: "cpu,mem,goroutines,runtime",
 		},
 	}, subnetCommonFlags...)
 )


### PR DESCRIPTION
## Description

* Remove block and mutex as they are rather intensive and provide little information.
* Add 'runtime'. Small, not intensive and possibly useful. Ignored by non-AIStor.
* Do 15 seconds for better data.

## Motivation and Context

Better defaults...

## How to test this PR?

`mc support profile ALIAS`

## Types of changes
- [x] Optimization (provides speedup with no functional changes)
