### PR TITLE
fix: remove check if lock config exists before set

### DIFF
--- a/cmd/retention-set.go
+++ b/cmd/retention-set.go
@@ -148,11 +148,10 @@ func mainRetentionSet(cliCtx *cli.Context) error {
 
 	target, versionID, recursive, rewind, withVersions, mode, validity, unit, bypass, bucketMode := parseSetRetentionArgs(cliCtx)
 
-	fatalIfBucketLockNotSupported(ctx, target)
-
 	if bucketMode {
 		return setBucketLock(target, mode, validity, unit)
 	}
+	fatalIfBucketLockNotSupported(ctx, target)
 
 	if withVersions && rewind.IsZero() {
 		rewind = time.Now().UTC()


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

check this doc https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-s3-enabling-object-lock-buckets/
We should not check the objectLockObject status before set.
And `PutBucketObjectLockConfigHandler` will check the config if exists.

## Motivation and Context


## How to test this PR?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
