### PR TITLE
Upgrade Go toolchain to 1.24.4 to fix CVE-2025-22874 in crypto/x509

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/minio/mc
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.10
+toolchain go1.24.4
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0


### PR DESCRIPTION
This commit updates the Go toolchain directive in go.mod to use go1.24.4,
which includes a fix for CVE-2025-22874 affecting the crypto/x509 standard library.