### PR TITLE
Some paths like url2Stat will send resource with backslashes on windows

### DIFF
--- a/cmd/encryption-methods.go
+++ b/cmd/encryption-methods.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -60,6 +61,7 @@ func (p byPrefixLength) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 
 // get SSE Key if object prefix matches with given resource.
 func getSSE(resource string, encKeys []prefixSSEPair) encrypt.ServerSide {
+	resource = filepath.ToSlash(resource)
 	for _, k := range encKeys {
 		if strings.HasPrefix(resource, k.Prefix) {
 			return k.SSE


### PR DESCRIPTION
## Description

This will cause key paths to mismatch and not be sent.

Example (after fix, Windows):

```
λ mc stat -enc-c="play/testbucket/=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDA" play/testbucket/mc
Name      : mc
Date      : 2025-07-02 17:52:42 CEST
Size      : 43 MiB
ETag      : 398345f23dc2ad4dd277e437e6ca7a1d-3
Type      : file
Encryption: SSE-C
Metadata  :
  Content-Type: application/x-msdownload
```

## How to test this PR?

See above

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
