### PR TITLE
feat: allow to list objects sorted by size

### DIFF
--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -60,6 +60,10 @@ var (
 			Name:  "zip",
 			Usage: "list files inside zip archive (MinIO servers only)",
 		},
+		cli.StringFlag{
+			Name:  "sort",
+			Usage: "sort by field. Only possible value for now: size",
+		},
 	}
 )
 
@@ -177,6 +181,11 @@ func checkListSyntax(cliCtx *cli.Context) ([]string, doListOptions) {
 
 	timeRef := parseRewindFlag(cliCtx.String("rewind"))
 
+	sortBy := cliCtx.String("sort")
+	if sortBy != "" && sortBy != "size" {
+		fatalIf(errInvalidArgument().Trace(args...), "Unsupported sort option '"+sortBy+"'. Only 'size' is supported.")
+	}
+
 	if listZip && (withVersions || !timeRef.IsZero()) {
 		fatalIf(errInvalidArgument().Trace(args...), "Zip file listing can only be performed on the latest version")
 	}
@@ -189,6 +198,7 @@ func checkListSyntax(cliCtx *cli.Context) ([]string, doListOptions) {
 		withVersions: withVersions,
 		listZip:      listZip,
 		filter:       storageClasss,
+		sortBy:       sortBy,
 	}
 	return args, opts
 }

--- a/cmd/ls-main.go
+++ b/cmd/ls-main.go
@@ -182,7 +182,10 @@ func checkListSyntax(cliCtx *cli.Context) ([]string, doListOptions) {
 	timeRef := parseRewindFlag(cliCtx.String("rewind"))
 
 	sortBy := cliCtx.String("sort")
-	if sortBy != "" && sortBy != "size" {
+	switch sortBy {
+	case "":
+	case "size":
+	default:
 		fatalIf(errInvalidArgument().Trace(args...), "Unsupported sort option '"+sortBy+"'. Only 'size' is supported.")
 	}
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -264,7 +264,12 @@ func doList(ctx context.Context, clnt Client, o doListOptions) error {
 	// Sort by size if requested
 	if o.sortBy == "size" {
 		slices.SortFunc(objects, func(a, b contentMessage) int {
-			return int(a.Size - b.Size)
+			if a.Size < b.Size {
+				return -1
+			} else if a.Size > b.Size {
+				return 1
+			}
+			return 0
 		})
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description & context
Add a `--sort=size` option to `mcli ls` to be able to sort files by size

Usually, you would do that by piping to `sort`, or using the `--sort` flag of ls


## How to test this PR?
Compare `go run . ls <path>` and `go run . ls <path> --sort=size`


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated (??)
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
